### PR TITLE
feat(#208): Re-implemented how Census errors are handled by the PS2 scanner

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,7 +6,7 @@ import { GeneralModule } from './general/general.module';
 import { AlbionModule } from './albion/albion.module';
 import { ConfigModule } from './config/config.module';
 import { DatabaseModule } from './database/database.module';
-// import { Ps2Module } from './ps2/ps2.module';
+import { Ps2Module } from './ps2/ps2.module';
 import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
@@ -39,7 +39,7 @@ import { ScheduleModule } from '@nestjs/schedule';
     }),
     GeneralModule,
     AlbionModule,
-    // Ps2Module,
+    Ps2Module,
     ScheduleModule.forRoot(),
     DiscordModule,
   ],

--- a/src/ps2/interfaces/CensusNotFoundResponse.ts
+++ b/src/ps2/interfaces/CensusNotFoundResponse.ts
@@ -1,1 +1,6 @@
-export declare class CensusNotFoundResponse extends Error {}
+export class CensusNotFoundResponse extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CensusNotFoundResponse';
+  }
+}

--- a/src/ps2/interfaces/CensusNotFoundResponse.ts
+++ b/src/ps2/interfaces/CensusNotFoundResponse.ts
@@ -1,0 +1,1 @@
+export declare class CensusNotFoundResponse extends Error {}

--- a/src/ps2/interfaces/CensusRetriesError.ts
+++ b/src/ps2/interfaces/CensusRetriesError.ts
@@ -1,0 +1,1 @@
+export declare class CensusRetriesError extends Error {}

--- a/src/ps2/interfaces/CensusRetriesError.ts
+++ b/src/ps2/interfaces/CensusRetriesError.ts
@@ -1,1 +1,6 @@
-export declare class CensusRetriesError extends Error {}
+export class CensusRetriesError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CensusRetriesError';
+  }
+}

--- a/src/ps2/interfaces/CensusServerError.ts
+++ b/src/ps2/interfaces/CensusServerError.ts
@@ -1,1 +1,6 @@
-export declare class CensusServerError extends Error {}
+export class CensusServerError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CensusServerError';
+  }
+}

--- a/src/ps2/interfaces/CensusServerError.ts
+++ b/src/ps2/interfaces/CensusServerError.ts
@@ -1,0 +1,1 @@
+export declare class CensusServerError extends Error {}

--- a/src/ps2/service/census.api.service.spec.ts
+++ b/src/ps2/service/census.api.service.spec.ts
@@ -4,17 +4,28 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ReflectMetadataProvider } from '@discord-nestjs/core';
 import { ConfigService } from '@nestjs/config';
 import { TestBootstrapper } from '../../test.bootstrapper';
+import { CensusRetriesError } from '../interfaces/CensusRetriesError';
+import { CensusServerError } from '../interfaces/CensusServerError';
+import { AxiosInstance } from 'axios';
 
 describe('CensusApiService', () => {
   let service: CensusApiService;
   let moduleRef: TestingModule;
+  let mockCensusAxiosFactory: CensusAxiosFactory;
+  let mockClient: AxiosInstance;
+  const mockUrl = 'http://mock.url';
 
   beforeEach(async () => {
     moduleRef = await Test.createTestingModule({
       providers: [
         CensusApiService,
         ReflectMetadataProvider,
-        CensusAxiosFactory,
+        {
+          provide: CensusAxiosFactory,
+          useValue: {
+            createClient: jest.fn(),
+          },
+        },
         {
           provide: ConfigService,
           useValue: {
@@ -25,66 +36,166 @@ describe('CensusApiService', () => {
     }).compile();
     TestBootstrapper.setupConfig(moduleRef);
     service = moduleRef.get<CensusApiService>(CensusApiService);
+    mockCensusAxiosFactory = moduleRef.get(CensusAxiosFactory);
+
+    // Provide a mocked client
+    const axios = {
+      get: jest.fn(),
+    } as never;
+    mockCensusAxiosFactory.createClient = jest.fn().mockReturnValue(axios);
+    mockClient = mockCensusAxiosFactory.createClient();
   });
 
-  test('should be defined', () => {
+  it('should be defined', () => {
     expect(service).toBeDefined();
   });
 
-  test('init should crash upon missing service ID', async () => {
-    TestBootstrapper.setupConfig(moduleRef, {
-      ps2: {
-        censusServiceId: '',
-      },
+  describe('onModuleInit', () => {
+    it('should crash upon missing service ID', async () => {
+      TestBootstrapper.setupConfig(moduleRef, {
+        ps2: {
+          censusServiceId: '',
+        },
+      });
+      await expect(service.onModuleInit()).rejects.toThrowError('PS2_CENSUS_SERVICE_ID is not defined.');
     });
-    await expect(service.onModuleInit()).rejects.toThrowError('PS2_CENSUS_SERVICE_ID is not defined.');
+
+    it('should throw upon census being unavailable or errors', async () => {
+      const error = 'Census responded with an error: "Service Unavailable"';
+      service.getCharacter = jest.fn().mockRejectedValue(new Error(error));
+
+      await expect(service.onModuleInit()).rejects.toThrow(error);
+    });
   });
 
-  test('init should throw upon census being unavailable or errors', async () => {
-    jest.spyOn(service, 'getCharacter').mockRejectedValue(new Error('Census responded with an error: Service Unavailable'));
+  describe('sendRequest', () => {
+    it('should return a successful request', async () => {
+      const mockResponse = { data: 'mock data' };
+      mockClient.get = jest.fn().mockResolvedValue(mockResponse);
 
-    await expect(service.onModuleInit()).rejects.toThrow('Census responded with an error: Service Unavailable');
+      const response = await service.sendRequest(mockUrl);
+
+      // Test that the data key is stripped
+      expect(response).toBe('mock data');
+      expect(mockClient.get).toHaveBeenCalledWith(mockUrl);
+    });
+
+    it('should throw when no response data was returned', async () => {
+      mockClient.get = jest.fn().mockResolvedValue({});
+
+      await expect(service.sendRequest(mockUrl)).rejects.toThrowError('No data was received from Census!');
+
+      expect(mockClient.get).toHaveBeenCalledWith(mockUrl);
+    });
+
+    it('should retry upon a Census error but successfully return', async () => {
+      const mockResponse = { data: 'mock data' };
+      mockClient.get = jest.fn().mockResolvedValueOnce({ data: { error: 'Service Unavailable' } }).mockResolvedValue(mockResponse);
+
+      const response = await service.sendRequest(mockUrl);
+
+      expect(response).toBe('mock data');
+      expect(mockClient.get).toHaveBeenCalledWith(mockUrl);
+      expect(mockClient.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('should retry upon a Census error, and throw an error when retries are exceeded', async () => {
+      const lastError = 'Service Unavailable';
+      mockClient.get = jest.fn().mockResolvedValue({ data: { error: lastError } });
+
+      await expect(service.sendRequest(mockUrl)).rejects.toThrow(`Failed to perform request to Census after 3 retries. Final error: "Census responded with an error: "${lastError}""`);
+
+      expect(mockClient.get).toHaveBeenCalledWith(mockUrl);
+      expect(mockClient.get).toHaveBeenCalledTimes(3);
+    });
   });
 
-  // @TODO: Re-enable once Census is unfucked
-  // NOTE: these actually make the request to the Census API, so they're slow / flaky
-  // test('should return a character, and also returns outfit details', async () => {
-  //   const character = await service.getCharacter('Maelstrome26');
-  //
-  //   expect(character).toBeDefined();
-  //   expect(character.outfit_info).toBeDefined();
-  //   expect(character.outfit_info.outfit_id).toBe('37509488620604883');
-  // }, 30000);
-  // test('should throw an error if a character doesn\'t exist', async () => {
-  //   const name = 'IDoNotExist101010101010101';
-  //   await expect(service.getCharacter(name)).rejects.toThrowError(`Character \`${name}\` does not exist. Please ensure you have spelt it correctly.`);
-  // }, 30000);
-  // test('should return a character, and also returns outfit details (by ID)', async () => {
-  //   const character = await service.getCharacterById('5428010618035323201');
-  //
-  //   expect(character).toBeDefined();
-  //   expect(character.outfit_info).toBeDefined();
-  //   expect(character.outfit_info.outfit_id).toBe('37509488620604883');
-  // }, 30000);
-  // test('should throw an error if a character doesn\'t exist (by ID)', async () => {
-  //   const id = '12343435465464646454';
-  //   await expect(service.getCharacterById(id)).rejects.toThrowError(`Character with ID **${id}** does not exist.`);
-  // }, 30000);
+  describe('getCharacter', () => {
+    it('should return a character, and also returns outfit details', async () => {
+      const mockCharacterId = '542576768678787801';
+      const mockOutfitId = '454544545769833';
+      const mockCharacter = TestBootstrapper.getMockPS2Character(mockCharacterId, mockOutfitId);
+      service.sendRequest = jest.fn().mockResolvedValue({ character_list: [mockCharacter] });
 
-  // Shits hard man
-  // test('census requests should be retried', async () => {
-  //   // Mock Axios client to reject every request.
-  //   let axiosMock = {
-  //     get: jest.fn().mockRejectedValue(new Error('Network error')),
-  //   };
-  //
-  //   // Mock the factory, so we can inject the mocked Axios client.
-  //   const censusAxiosFactory = new CensusAxiosFactory(config);
-  //   jest.spyOn(censusAxiosFactory, 'createClient').mockReturnValue(axiosMock);
-  //
-  //
-  //   service = new CensusApiService(censusAxiosFactory, config);
-  //
-  //   await expect(service.getCharacter('character?name.first_lower=iegehje46454')).resolves.toBeCalledTimes(3);
-  // });
+      const character = await service.getCharacter('Maelstrome26');
+
+      expect(character).toBeDefined();
+      expect(character.character_id).toBe(mockCharacterId);
+      expect(character.outfit_info).toBeDefined();
+      expect(character.outfit_info.outfit_id).toBe(mockOutfitId);
+    });
+
+    it('should throw an error if a character doesn\'t exist', async () => {
+      const name = 'IDoNotExist101010101010101';
+      service.sendRequest = jest.fn().mockResolvedValue({ character_list: [] });
+
+      await expect(service.getCharacter(name)).rejects.toThrowError(`Character \`${name}\` does not exist. Please ensure you have spelt it correctly.`);
+    });
+
+    it('should throw an error if a character search exhausts its retries', async () => {
+      const name = 'IDoNotExist101010101010101';
+      service.sendRequest = jest.fn().mockImplementation(() => {
+        throw new CensusRetriesError('Census Retries exhausted.');
+      });
+
+      await expect(service.getCharacter(name)).rejects.toThrowError('Census Retries exhausted.');
+    });
+  });
+  describe('getCharacterById', () => {
+    it('should return a character with the same ID', async () => {
+      const mockCharacterId = '5428010618035323201';
+      const mockOutfitId = '454544545769833';
+      const mockCharacter = TestBootstrapper.getMockPS2Character(mockCharacterId, mockOutfitId);
+      service.sendRequest = jest.fn().mockResolvedValue({ character_list: [mockCharacter] });
+
+      const character = await service.getCharacterById(mockCharacterId);
+
+      expect(character).toBeDefined();
+      expect(character.character_id).toBe(mockCharacterId);
+      expect(character.outfit_info.outfit_id).toBe(mockOutfitId);
+    });
+
+    it('should throw an error if a character doesn\'t exist (by ID)', async () => {
+      const id = '12343435465464646454';
+
+      service.sendRequest = jest.fn().mockResolvedValue({ character_list: [] });
+      await expect(service.getCharacterById(id)).rejects.toThrowError(`Character with ID **${id}** does not exist.`);
+    });
+
+    it('should throw an error when Census falls on its arse', async () => {
+      service.sendRequest = jest.fn().mockImplementation(() => {
+        throw new CensusServerError('Census errored.');
+      });
+
+      await expect(service.getCharacterById('123456')).rejects.toThrowError('Census Errored when fetching character with ID **123456**. Err: Census errored.');
+    });
+  });
+
+  describe('getOutfit', () => {
+    it('should return an outfit', async () => {
+      const mockOutfitId = '454544545769833';
+      const mockOutfit = TestBootstrapper.getMockPS2Outfit(mockOutfitId);
+      service.sendRequest = jest.fn().mockResolvedValue({ outfit_list: [mockOutfit] });
+
+      const outfit = await service.getOutfit(mockOutfitId);
+
+      expect(outfit).toBeDefined();
+      expect(outfit.outfit_id).toBe(mockOutfitId);
+    });
+
+    it('should throw an error when the outfit does not exist', async () => {
+      const outfitId = '123434354654';
+      service.sendRequest = jest.fn().mockResolvedValue({ outfit_list: [] });
+
+      await expect(service.getOutfit(outfitId)).rejects.toThrowError(`Outfit with ID **${outfitId}** does not exist.`);
+    });
+
+    it('should throw an error when Census falls on its arse', async () => {
+      service.sendRequest = jest.fn().mockImplementation(() => {
+        throw new CensusServerError('Census errored.');
+      });
+
+      await expect(service.getOutfit('123456')).rejects.toThrowError('Census Errored when fetching outfit with ID **123456**. Err: Census errored.');
+    });
+  });
 });

--- a/src/ps2/service/census.api.service.ts
+++ b/src/ps2/service/census.api.service.ts
@@ -6,6 +6,9 @@ import {
 } from '../interfaces/CensusCharacterResponseInterface';
 import { ConfigService } from '@nestjs/config';
 import { CensusOutfitInterface, CensusOutfitResponseInterface } from '../interfaces/CensusOutfitResponseInterface';
+import { CensusNotFoundResponse } from '../interfaces/CensusNotFoundResponse';
+import { CensusRetriesError } from '../interfaces/CensusRetriesError';
+import { CensusServerError } from '../interfaces/CensusServerError';
 
 @Injectable()
 export class CensusApiService implements OnModuleInit {
@@ -37,17 +40,28 @@ export class CensusApiService implements OnModuleInit {
     try {
       const response = await request.get(url);
 
+      if (response.data) {
+        // noinspection ExceptionCaughtLocallyJS
+        throw new Error('No data was received from Census!');
+      }
+
       if (response.data.error) {
         // noinspection ExceptionCaughtLocallyJS
-        throw new Error(`Census responded with an error: ${response.data.error}`);
+        throw new CensusServerError(`Census responded with an error: ${response.data.error}`);
+      }
+
+      if (response.data.errorMessage) {
+        // noinspection ExceptionCaughtLocallyJS
+        throw new CensusServerError(`Census responded with an error: ${response.data.errorMessage}`);
       }
 
       return response.data;
     }
     catch (err) {
       if (tries === CensusApiService.RETRY_ATTEMPTS) {
-        this.logger.error(`Failed to perform request to Census after ${CensusApiService.RETRY_ATTEMPTS} retries. Final error: ${err.message}`);
-        throw new Error(`Failed to perform request to Census after ${CensusApiService.RETRY_ATTEMPTS} retries. Final error: ${err.message}`);
+        const error = `Failed to perform request to Census after ${CensusApiService.RETRY_ATTEMPTS} retries. Final error: ${err.message}`;
+        this.logger.error(error);
+        throw new CensusRetriesError(error);
       }
 
       this.logger.warn(`Request failed (attempt ${tries}/${CensusApiService.RETRY_ATTEMPTS}). Retrying in ${CensusApiService.RETRY_DELAY_MS} ms...`);
@@ -62,7 +76,7 @@ export class CensusApiService implements OnModuleInit {
     const response: CensusCharacterResponseInterface = await this.requestWithRetries(url);
 
     if (response.returned === 0 || !response.character_list || response.character_list.length === 0) {
-      throw new Error(`Character \`${characterName}\` does not exist. Please ensure you have spelt it correctly.`);
+      throw new CensusNotFoundResponse(`Character \`${characterName}\` does not exist. Please ensure you have spelt it correctly.`);
     }
 
     return response.character_list[0];
@@ -70,10 +84,18 @@ export class CensusApiService implements OnModuleInit {
 
   async getCharacterById(characterId: string): Promise<CensusCharacterWithOutfitInterface | null> {
     const url = `character?character_id=${characterId}&c:join=outfit_member^inject_at:outfit_info`;
-    const response: CensusCharacterResponseInterface = await this.requestWithRetries(url);
+
+    let response: CensusCharacterResponseInterface;
+
+    try {
+      response = await this.requestWithRetries(url);
+    }
+    catch (err) {
+      throw new CensusServerError(`Census Errored when fetching character with ID **${characterId}**. Err: ${err.message}`);
+    }
 
     if (response.returned === 0 || !response.character_list || response.character_list.length === 0) {
-      throw new Error(`Character with ID **${characterId}** does not exist.`);
+      throw new CensusNotFoundResponse(`Character with ID **${characterId}** does not exist.`);
     }
 
     return response.character_list[0];
@@ -82,10 +104,17 @@ export class CensusApiService implements OnModuleInit {
   async getOutfit(outfitId: string): Promise<CensusOutfitInterface | null> {
     const url = `outfit/${this.config.get('ps2.outfitId')}?c:resolve=rank`;
 
-    const response: CensusOutfitResponseInterface = await this.requestWithRetries(url);
+    let response: CensusOutfitResponseInterface;
+
+    try {
+      response = await this.requestWithRetries(url);
+    }
+    catch (err) {
+      throw new CensusServerError(`Census Errored when fetching outfit with ID **${outfitId}**. Err: ${err.message}`);
+    }
 
     if (response.returned === 0 || !response.outfit_list || response.outfit_list.length === 0) {
-      throw new Error(`Outfit with ID **${outfitId}** does not exist.`);
+      throw new CensusNotFoundResponse(`Outfit with ID **${outfitId}** does not exist.`);
     }
 
     return response.outfit_list[0];

--- a/src/ps2/service/ps2.game.scanning.service.spec.ts
+++ b/src/ps2/service/ps2.game.scanning.service.spec.ts
@@ -480,6 +480,10 @@ describe('PS2GameScanningService', () => {
     });
   });
 
+  describe('checkForSuggestions', () => {
+    // Yeahhhh no that is madness to test
+  });
+
   describe('reset', () => {
     beforeEach(() => {
       jest.spyOn(service['charactersMap'], 'clear');

--- a/src/ps2/service/ps2.game.scanning.service.spec.ts
+++ b/src/ps2/service/ps2.game.scanning.service.spec.ts
@@ -14,6 +14,7 @@ import { CensusServerError } from '../interfaces/CensusServerError';
 
 const mockCharacterId = '5428010618035323201';
 const mockOutfitId = TestBootstrapper.mockConfig.ps2.outfitId;
+const mockDevUserId = TestBootstrapper.mockConfig.discord.devUserId;
 
 describe('PS2GameScanningService', () => {
   let service: PS2GameScanningService;
@@ -87,47 +88,67 @@ describe('PS2GameScanningService', () => {
 
       const result = await service.gatherCharacters(outfitMembers, mockDiscordMessage);
 
-      expect(mockDiscordMessage.edit).toHaveBeenCalledWith('Gathering 2 characters from Census... (attempt #1)');
-      // I don't know why this is broken... it's not thinking it's being called but it is??? Probably something to do with the promises.
-      // expect(mockCensusService.getCharacterById).toHaveBeenCalledWith(mockCharacterId);
-      // expect(mockCensusService.getCharacterById).toHaveBeenCalledWith(`${mockCharacterId}2`);
-      // expect(mockCensusService.getCharacterById).toHaveBeenCalledTimes(2);
+      expect(mockDiscordMessage.edit).toHaveBeenCalledWith('Gathering 2 characters from Census...');
       expect(result).toEqual([outfitMembers[0], outfitMembers[1]]);
     });
 
-    it('should handle Census outages', async () => {
-      const outfitMembers = [TestBootstrapper.getMockPS2Character(mockCharacterId, mockOutfitId)];
-      const error = new CensusServerError('Census timeout');
-      mockCensusService.getCharacterById = jest.fn().mockRejectedValue(error);
+    it('should handle Census being on its arse, filtering out bad data', async () => {
+      const outfitMembers = [
+        TestBootstrapper.getMockPS2Character(mockCharacterId, mockOutfitId),
+        TestBootstrapper.getMockPS2Character(`${mockCharacterId}2`, mockOutfitId),
+      ];
+
+      mockCensusService.getCharacterById = jest.fn()
+        .mockResolvedValueOnce(outfitMembers[0])
+        .mockImplementationOnce(() => { throw new CensusServerError('Census is dead m9'); });
 
       const result = await service.gatherCharacters(outfitMembers, mockDiscordMessage);
 
-      expect(mockDiscordMessage.edit).toHaveBeenCalledWith('Gathering 1 characters from Census... (attempt #1)');
-      expect(mockDiscordMessage.edit).toHaveBeenCalledWith('## ⚠️ Couldn\'t gather 1 characters from Census, likely due to Census timeout issues. Retrying in 10s (attempt #1)...');
-      // Couldn't check the other 3 times, tests in promise loops is weird as shit man
-      expect(mockDiscordMessage.edit).toHaveBeenCalledWith('## ❌ An error occurred while gathering 1 characters! Giving up after 3 tries.');
-      expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith(`Error: ${error.message}`);
-      expect(result).toBeNull();
+      expect(mockDiscordMessage.edit).toHaveBeenCalledWith('Gathering 2 characters from Census...');
+      expect(result).toEqual([outfitMembers[0]]);
     });
 
     it('should handle characters that don\'t exist', async () => {
-      const error = new CensusNotFoundResponse('Character with ID **12345** does not exist');
-      mockCensusService.getCharacterById = jest.fn().mockRejectedValue(error);
+      const error = ('Character with ID **12345** does not exist.');
+      mockCensusService.getCharacterById = jest.fn().mockImplementation(() => { throw new CensusNotFoundResponse(error); });
 
-      const result = await service.gatherCharacters([TestBootstrapper.getMockPS2Character(mockCharacterId, mockOutfitId)], mockDiscordMessage);
+      const mockPS2Entity = TestBootstrapper.getMockPS2MemberEntity();
 
-      expect(mockDiscordMessage.channel.send).toBeCalledWith(`❌ An error occurred while gathering characters from Census! The character does not exist. ${error}`);
-      expect(result).toBeNull();
+      const result = await service.gatherCharacters(
+        [mockPS2Entity],
+        mockDiscordMessage
+      );
+
+      expect(mockDiscordMessage.channel.send).toBeCalledWith(`❌ ${error}`);
+      expect(result).toEqual([]);
     });
 
-    it('should handle Census being on it\'s arse', async () => {
-      const error = new CensusServerError('Census is dead m9');
-      mockCensusService.getCharacterById = jest.fn().mockRejectedValue(error);
+    it('should handle Census being on its arse', async () => {
+      const error = 'Census is dead m9';
+      mockCensusService.getCharacterById = jest.fn().mockImplementation(() => { throw new CensusServerError(error); });
 
       const result = await service.gatherCharacters([TestBootstrapper.getMockPS2Character(mockCharacterId, mockOutfitId)], mockDiscordMessage);
 
-      expect(mockDiscordMessage.channel.send).toBeCalledWith(`❌ An error occurred while gathering characters from Census! The character does not exist. ${error}`);
-      expect(result).toBeNull();
+      expect(mockDiscordMessage.channel.send).toBeCalledWith(`❌ ${error}`);
+      expect(result).toEqual([]);
+    });
+
+    it('should handle partial character returns', async () => {
+      const error = ('Character with ID **12345** does not exist.');
+      const mockCharacter = TestBootstrapper.getMockPS2Character(mockCharacterId, mockOutfitId);
+      mockCensusService.getCharacterById = jest.fn()
+        .mockImplementationOnce(() => { throw new CensusNotFoundResponse(error); })
+        .mockResolvedValueOnce(mockCharacter);
+
+      const mockPS2Entity = TestBootstrapper.getMockPS2MemberEntity();
+
+      const result = await service.gatherCharacters(
+        [mockPS2Entity, mockPS2Entity],
+        mockDiscordMessage
+      );
+
+      expect(mockDiscordMessage.channel.send).toBeCalledWith(`❌ ${error}`);
+      expect(result).toEqual([mockCharacter]);
     });
   });
 
@@ -144,7 +165,7 @@ describe('PS2GameScanningService', () => {
         false
       );
 
-      expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith(`❌ Character data **${mockPS2MemberEntity.characterId}** did not exist when attempting to verify their membership. Skipping. Pinging <@474839309484>!`);
+      expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith(`❌ Character data for ID **${mockPS2MemberEntity.characterId}** did not exist when attempting to verify their membership. Skipping. Pinging <@474839309484>!`);
       expect(service.removeDiscordLeaver).not.toHaveBeenCalled();
       expect(service.removeOutfitLeaver).not.toHaveBeenCalled();
     });
@@ -159,6 +180,30 @@ describe('PS2GameScanningService', () => {
 
       expect(service.removeDiscordLeaver).not.toHaveBeenCalled();
       expect(service.removeOutfitLeaver).not.toHaveBeenCalled();
+    });
+
+    it('should still take action when a character is missing and notify the dev', async () => {
+      const mockPS2MemberEntity2 = TestBootstrapper.getMockPS2MemberEntity(`${mockCharacterId}2`);
+      const mockPS2Character2 = TestBootstrapper.getMockPS2Character(`${mockCharacterId}2`, '676879886756');
+      const mockDiscordMember = TestBootstrapper.getMockDiscordUser();
+      mockDiscordMessage.guild.members.fetch = jest.fn().mockResolvedValue(mockDiscordMember);
+
+      await service.verifyMembership(
+        [mockPS2Character2],
+        [mockPS2MemberEntity, mockPS2MemberEntity2],
+        mockDiscordMessage,
+        false
+      );
+
+      expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith(`❌ Character data for ID **${mockPS2MemberEntity.characterId}** did not exist when attempting to verify their membership. Skipping. Pinging <@${mockDevUserId}>!`);
+      expect(service.removeDiscordLeaver).not.toHaveBeenCalled();
+      expect(service.removeOutfitLeaver).toHaveBeenCalledWith(
+        mockPS2MemberEntity2,
+        mockPS2Character2,
+        mockDiscordMember,
+        mockDiscordMessage,
+        false
+      );
     });
 
     it('should call the removeOutfitLeaver function if the member has left the outfit', async () => {

--- a/src/ps2/service/ps2.game.scanning.service.spec.ts
+++ b/src/ps2/service/ps2.game.scanning.service.spec.ts
@@ -9,6 +9,8 @@ import { getRepositoryToken } from '@mikro-orm/nestjs';
 import { TestBootstrapper } from '../../test.bootstrapper';
 import { PS2GameScanningService } from './ps2.game.scanning.service';
 import { CensusApiService } from './census.api.service';
+import { CensusNotFoundResponse } from '../interfaces/CensusNotFoundResponse';
+import { CensusServerError } from '../interfaces/CensusServerError';
 
 const mockCharacterId = '5428010618035323201';
 const mockOutfitId = TestBootstrapper.mockConfig.ps2.outfitId;
@@ -19,11 +21,18 @@ describe('PS2GameScanningService', () => {
   let mockDiscordMessage: any;
 
   let mockEntityManager: jest.Mocked<EntityManager>;
+  let mockPS2MembersRepository: jest.Mocked<EntityManager>;
+  let mockPS2MemberEntity: PS2MembersEntity;
+  let mockPS2Character: any;
 
   beforeEach(async () => {
     TestBootstrapper.mockORM();
 
-    const mockPS2MembersRepository = TestBootstrapper.getMockRepositoryInjected({});
+    mockPS2MembersRepository = TestBootstrapper.getMockRepositoryInjected({});
+    mockPS2MemberEntity = TestBootstrapper.getMockPS2MemberEntity(
+      mockCharacterId
+    );
+    mockPS2Character = TestBootstrapper.getMockPS2Character(mockCharacterId, mockOutfitId);
 
     const moduleRef: TestingModule = await Test.createTestingModule({
       providers: [
@@ -63,10 +72,6 @@ describe('PS2GameScanningService', () => {
     // service['messagesMap'] = new Map();
     // service['messagesMap'].set(mockPS2Character.character_id, mockDiscordMessage);
 
-    // Filled spies
-    jest.spyOn(service['logger'], 'error');
-    jest.spyOn(service['logger'], 'warn');
-    jest.spyOn(service['logger'], 'log');
   });
 
   describe('gatherCharacters', () => {
@@ -90,12 +95,12 @@ describe('PS2GameScanningService', () => {
       expect(result).toEqual([outfitMembers[0], outfitMembers[1]]);
     });
 
-    it('should handle errors / outages and retry up to 3 times', async () => {
+    it('should handle Census outages', async () => {
       const outfitMembers = [TestBootstrapper.getMockPS2Character(mockCharacterId, mockOutfitId)];
-      const error = new Error('Census timeout');
+      const error = new CensusServerError('Census timeout');
       mockCensusService.getCharacterById = jest.fn().mockRejectedValue(error);
 
-      const result = await service.gatherCharacters(outfitMembers, mockDiscordMessage, 0, 500);
+      const result = await service.gatherCharacters(outfitMembers, mockDiscordMessage);
 
       expect(mockDiscordMessage.edit).toHaveBeenCalledWith('Gathering 1 characters from Census... (attempt #1)');
       expect(mockDiscordMessage.edit).toHaveBeenCalledWith('## ⚠️ Couldn\'t gather 1 characters from Census, likely due to Census timeout issues. Retrying in 10s (attempt #1)...');
@@ -106,13 +111,95 @@ describe('PS2GameScanningService', () => {
     });
 
     it('should handle characters that don\'t exist', async () => {
-      const error = new Error('Character with ID **12345** does not exist');
+      const error = new CensusNotFoundResponse('Character with ID **12345** does not exist');
       mockCensusService.getCharacterById = jest.fn().mockRejectedValue(error);
 
-      const result = await service.gatherCharacters([TestBootstrapper.getMockPS2Character(mockCharacterId, mockOutfitId)], mockDiscordMessage, 0, 500);
+      const result = await service.gatherCharacters([TestBootstrapper.getMockPS2Character(mockCharacterId, mockOutfitId)], mockDiscordMessage);
 
       expect(mockDiscordMessage.channel.send).toBeCalledWith(`❌ An error occurred while gathering characters from Census! The character does not exist. ${error}`);
       expect(result).toBeNull();
+    });
+
+    it('should handle Census being on it\'s arse', async () => {
+      const error = new CensusServerError('Census is dead m9');
+      mockCensusService.getCharacterById = jest.fn().mockRejectedValue(error);
+
+      const result = await service.gatherCharacters([TestBootstrapper.getMockPS2Character(mockCharacterId, mockOutfitId)], mockDiscordMessage);
+
+      expect(mockDiscordMessage.channel.send).toBeCalledWith(`❌ An error occurred while gathering characters from Census! The character does not exist. ${error}`);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('validateMembership', () => {
+    beforeEach(() => {
+      service.removeDiscordLeaver = jest.fn();
+      service.removeOutfitLeaver = jest.fn();
+    });
+    it('should not take any action when the character data is empty', async () => {
+      await service.verifyMembership(
+        [],
+        [mockPS2MemberEntity],
+        mockDiscordMessage,
+        false
+      );
+
+      expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith(`❌ Character data **${mockPS2MemberEntity.characterId}** did not exist when attempting to verify their membership. Skipping. Pinging <@474839309484>!`);
+      expect(service.removeDiscordLeaver).not.toHaveBeenCalled();
+      expect(service.removeOutfitLeaver).not.toHaveBeenCalled();
+    });
+
+    it('should not take any action when the character is valid', async () => {
+      await service.verifyMembership(
+        [mockPS2Character],
+        [mockPS2MemberEntity],
+        mockDiscordMessage,
+        false
+      );
+
+      expect(service.removeDiscordLeaver).not.toHaveBeenCalled();
+      expect(service.removeOutfitLeaver).not.toHaveBeenCalled();
+    });
+
+    it('should call the removeOutfitLeaver function if the member has left the outfit', async () => {
+      mockPS2Character = TestBootstrapper.getMockPS2Character(mockCharacterId, '3445576868678');
+      const mockDiscordMember = TestBootstrapper.getMockDiscordUser();
+
+      mockDiscordMessage.guild.members.fetch = jest.fn().mockResolvedValue(mockDiscordMember);
+
+      await service.verifyMembership(
+        [mockPS2Character],
+        [mockPS2MemberEntity],
+        mockDiscordMessage,
+        false
+      );
+
+      expect(service.removeDiscordLeaver).not.toHaveBeenCalled();
+      expect(service.removeOutfitLeaver).toHaveBeenCalledWith(
+        mockPS2MemberEntity,
+        mockPS2Character,
+        mockDiscordMember,
+        mockDiscordMessage,
+        false
+      );
+    });
+
+    it('should call the removeDiscordLeaver function if the member has left the server', async () => {
+      mockDiscordMessage.guild.members.fetch = jest.fn().mockImplementation(() => {throw new Error('Who dis?');});
+
+      await service.verifyMembership(
+        [mockPS2Character],
+        [mockPS2MemberEntity],
+        mockDiscordMessage,
+        false
+      );
+
+      expect(service.removeDiscordLeaver).toHaveBeenCalledWith(
+        mockPS2MemberEntity,
+        mockPS2Character,
+        false
+      );
+      expect(service.removeOutfitLeaver).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/ps2/service/ps2.game.scanning.service.ts
+++ b/src/ps2/service/ps2.game.scanning.service.ts
@@ -7,6 +7,7 @@ import { GuildMember, Message } from 'discord.js';
 import { CensusCharacterWithOutfitInterface } from '../interfaces/CensusCharacterResponseInterface';
 import { ConfigService } from '@nestjs/config';
 import { PS2RankMapInterface } from '../../config/ps2.app.config';
+import { CensusServerError } from '../interfaces/CensusServerError';
 
 interface ChangesInterface {
   character: CensusCharacterWithOutfitInterface,
@@ -37,37 +38,38 @@ export class PS2GameScanningService {
     this.suggestionsCount = 0;
   }
 
-  async gatherCharacters(outfitMembers: PS2MembersEntity[], statusMessage: Message, tries = 0, waitTime = 10000) {
+  async gatherCharacters(outfitMembers: PS2MembersEntity[], statusMessage: Message) {
     const characterPromises = [];
-    tries++;
     const length = outfitMembers.length;
 
-    await statusMessage.edit(`Gathering ${length} characters from Census... (attempt #${tries})`);
+    await statusMessage.edit(`Gathering ${length} characters from Census...`);
 
     for (const member of outfitMembers) {
-      characterPromises.push(() => this.censusService.getCharacterById(member.characterId));
+      characterPromises.push(async () => {
+        try {
+          await this.censusService.getCharacterById(member.characterId);
+        }
+        catch (err) {
+          // If a CensusServerError is thrown, stop the process as Census is unstable.
+          if (err instanceof CensusServerError) {
+            throw err;
+          }
+
+          // If an error was thrown, return null for the character. Report the error though to the channel.
+          // The null is then filtered out at the promise.all stage.
+          // Later, the validateMembership function will check if the character data is absent and skip it if it doesn't exist.
+          await statusMessage.channel.send(`❌ ${err.message}`);
+          return null;
+        }
+      });
     }
 
-    try {
-      return await Promise.all(characterPromises.map(promiseFunc => promiseFunc()));
-    }
-    catch (err) {
-      // If error message says does not exist, return null
-      if (err.message.includes('does not exist')) {
-        await statusMessage.channel.send(`❌ An error occurred while gathering characters from Census! The character does not exist. Error: ${err.message}`);
-        return null;
-      }
+    // Get all the characters at the same time.
+    const characters = await Promise.all(characterPromises.map(promiseFunc => promiseFunc()));
 
-      if (tries === 3) {
-        await statusMessage.edit(`## ❌ An error occurred while gathering ${length} characters! Giving up after 3 tries.`);
-        await statusMessage.channel.send(`Error: ${err.message}`);
-        return null;
-      }
-
-      await statusMessage.edit(`## ⚠️ Couldn't gather ${length} characters from Census, likely due to Census timeout issues. Retrying in 10s (attempt #${tries})...`);
-      await new Promise(resolve => setTimeout(resolve, waitTime));
-      return this.gatherCharacters(outfitMembers, statusMessage, tries, waitTime);
-    }
+    // Filter out any null characters, as they errored during the process.
+    // validateMembership will handle these cases.
+    return characters.filter((character) => character !== null);
   }
 
   // Main execution
@@ -97,7 +99,7 @@ export class PS2GameScanningService {
 
     try {
       await message.edit(`Checking ${length} characters for membership status...`);
-      await this.removeLeavers(characters, outfitMembers, message, dryRun);
+      await this.verifyMembership(characters, outfitMembers, message, dryRun);
 
       await message.edit(`Checking ${length} characters for role inconsistencies...`);
       await this.checkForSuggestions(outfitMembers, message);
@@ -148,57 +150,81 @@ export class PS2GameScanningService {
     return this.reset();
   }
 
-  async removeLeavers(characters: CensusCharacterWithOutfitInterface[], outfitMembers: PS2MembersEntity[], message: Message, dryRun = false) {
-    // Save all the characters to a map we can easily pick out later
-    for (const character of characters) {
-      this.charactersMap.set(character.character_id, character);
-    }
-
-    // Get the info required to do the check
-    for (const member of outfitMembers) {
-      const character = this.charactersMap.get(member.characterId);
-
+  async verifyMembership(
+    characters: CensusCharacterWithOutfitInterface[],
+    ps2Members: PS2MembersEntity[],
+    message: Message,
+    dryRun = false
+  ) {
+    for (const member of ps2Members) {
+      const character = characters.find((char) => char.character_id === member.characterId);
       let discordMember: GuildMember | null = null;
 
+      // The character for some reason doesn't exist. This may be because of Census Server Errors, therefore we need to skip them this time.
+      // This is to prevent a rather nasty bug / scenario where we remove literally everyone because Census is on its arse.
+      // Dev needs to be notified though in case of repeated failures which may need manual rectification.
+      // @ref #208
+      if (!character) {
+        this.logger.error(`Character data for ID **${member.characterId}** did not exist when attempting to verify their membership. Skipping.`);
+        await message.channel.send(`❌ Character data **${member.characterId}** did not exist when attempting to verify their membership. Skipping. Pinging <@${this.config.get('discord.devUserId')}>!`);
+        continue;
+      }
+
+      // If they've left the Discord, don't even bother checking their outfit status, we need to de-register them.
       try {
         discordMember = await message.guild.members.fetch({ user: member.discordId, force: true });
       }
       catch (err) {
-        // No discord member means they've left the server
-        this.logger.log(`User ${character.name.first} has left the server`);
+        this.logger.log(`User ${character.name.first} has left the server!`);
+        await this.removeDiscordLeaver(member, character, dryRun);
+        continue;
       }
 
-      await this.processLeaverRemoval(member, character, discordMember, message, dryRun);
+      // Now check if the character's outfit ID still matches.
+      if (character.outfit_info?.outfit_id !== this.config.get('ps2.outfitId')) {
+        this.logger.log(`User ${member.characterId} has left the outfit, but remains on the server!`);
+        await this.removeOutfitLeaver(member, character, discordMember, message, dryRun);
+      }
     }
+
+    // They remain in the outfit and Discord, so they are still valid.
   }
 
-  async processLeaverRemoval(
+  async removeDiscordLeaver(
     member: PS2MembersEntity,
     character: CensusCharacterWithOutfitInterface,
-    discordMember: GuildMember | null,
-    message: Message,
     dryRun = false
   ): Promise<void> {
     if (!dryRun) {
       await this.ps2MembersRepository.getEntityManager().removeAndFlush(member);
     }
 
-    if (!discordMember) {
+    this.changesMap.set(member.characterId, {
+      character,
+      discordMember: null,
+      change: `- 🫥️ Discord member for Character **${character.name.first}** has left the DIG Discord server.`,
+    });
+    return;
+  }
+
+  async removeOutfitLeaver(
+    member: PS2MembersEntity,
+    character: CensusCharacterWithOutfitInterface,
+    discordMember: GuildMember,
+    message: Message,
+    dryRun = false
+  ): Promise<void> {
+    // If a dry run, there is nothing else to do beyond reporting the "change".
+    if (dryRun) {
       this.changesMap.set(member.characterId, {
         character,
-        discordMember: null,
-        change: `- 🫥️ Discord member for Character **${character.name.first}** has left the DIG server. Their verification status has been removed.`,
+        discordMember,
+        change: `- 👋 <@${discordMember.id}>'s character **${character.name.first}** has left the outfit. Their roles and verification status have been stripped.`,
       });
-    }
-
-    // If still in outfit, nothing to do
-    if (character?.outfit_info && character?.outfit_info.outfit_id === this.config.get('ps2.outfitId')) {
       return;
     }
 
-    // If not in the outfit, strip 'em
-    this.logger.log(`User ${character.name.first} has left the outfit`);
-
+    // They remain on the Discord, so now they need their roles stripping.
     const rankMaps: PS2RankMapInterface = this.config.get('ps2.rankMap');
 
     // Remove all private roles from the user
@@ -212,11 +238,6 @@ export class PS2GameScanningService {
         continue;
       }
 
-      // If dry run, don't actually remove the role
-      if (dryRun) {
-        continue;
-      }
-
       try {
         await discordMember.roles.remove(rankMap.discordRoleId);
       }
@@ -225,10 +246,7 @@ export class PS2GameScanningService {
       }
     }
 
-    // If not dry run, delete their record
-    if (!dryRun) {
-      await this.ps2MembersRepository.getEntityManager().removeAndFlush(member);
-    }
+    await this.ps2MembersRepository.getEntityManager().removeAndFlush(member);
 
     this.changesMap.set(member.characterId, {
       character,

--- a/src/ps2/service/ps2.game.scanning.service.ts
+++ b/src/ps2/service/ps2.game.scanning.service.ts
@@ -195,7 +195,6 @@ export class PS2GameScanningService {
       discordMember: null,
       change: `- 🫥️ Discord member for Character **${character.name.first}** has left the DIG Discord server.`,
     });
-    return;
   }
 
   async removeOutfitLeaver(

--- a/src/ps2/service/ps2.game.scanning.service.ts
+++ b/src/ps2/service/ps2.game.scanning.service.ts
@@ -219,10 +219,10 @@ export class PS2GameScanningService {
     const rankMaps: PS2RankMapInterface = this.config.get('ps2.rankMap');
 
     // Remove all private roles from the user
-    for (const rankMap of Object.values(rankMaps)) {
-      const role = message.guild.roles.cache.get(rankMap.discordRoleId);
+    for (const rank of Object.values(rankMaps)) {
+      const role = message.guild.roles.cache.get(rank.discordRoleId);
       // Check if the user has the role to remove in the first place
-      const hasRole = discordMember.roles.cache.has(rankMap.discordRoleId);
+      const hasRole = discordMember.roles.cache.has(rank.discordRoleId);
 
       // If they don't have the role, skip
       if (!hasRole) {
@@ -230,7 +230,7 @@ export class PS2GameScanningService {
       }
 
       try {
-        await discordMember.roles.remove(rankMap.discordRoleId);
+        await discordMember.roles.remove(rank.discordRoleId);
       }
       catch (err) {
         await message.channel.send(`ERROR: Unable to remove role "${role.name}" from ${character.name.first} (${character.character_id}). Pinging <@${this.config.get('discord.devUserId')}>!`);

--- a/src/test.bootstrapper.ts
+++ b/src/test.bootstrapper.ts
@@ -6,11 +6,39 @@ import { TestingModule } from '@nestjs/testing';
 import { MikroORM } from '@mikro-orm/core';
 import { AlbionServer } from './albion/interfaces/albion.api.interfaces';
 import { PS2MembersEntity } from './database/entities/ps2.members.entity';
+import { PS2RankMapInterface } from './config/ps2.app.config';
 
 const guildLeaderRoleUS = '44546543371337';
 const guildLeaderRole = '64354579789809089';
 const guildOfficerRoleUS = '465544343342364';
 const guildOfficerRole = '66343435879886';
+
+const ps2RankMap: PS2RankMapInterface = {
+  '@PS2/Verified': {
+    ranks: null,
+    discordRoleId: '1139909190664601611',
+  },
+  '@PS2/Zealot': {
+    ranks: ['6'],
+    discordRoleId: '1139909319886905496',
+  },
+  '@PS2/SL': {
+    ranks: ['4', '5'],
+    discordRoleId: '1142546129112805517',
+  },
+  '@PS2/PL': {
+    ranks: ['3'],
+    discordRoleId: '1142546081922682900',
+  },
+  '@PS2/Officer': {
+    ranks: ['2'],
+    discordRoleId: '1142546051606257755',
+  },
+  '@PS2/Leader': {
+    ranks: ['1'],
+    discordRoleId: '1142546013685559337',
+  },
+};
 
 // This file helps set up mocks for various tests, which have been copied and pasted across the suite, causing a lot of duplication.
 @Injectable()
@@ -40,7 +68,7 @@ export class TestBootstrapper {
   }
 
   static getMockRepositoryInjected(entity) {
-    return {
+    const repoActions = {
       find: jest.fn().mockResolvedValueOnce([entity]),
       findOne: jest.fn().mockResolvedValueOnce([entity]),
       findAll: jest.fn().mockResolvedValue([entity]),
@@ -48,6 +76,10 @@ export class TestBootstrapper {
       upsert: jest.fn(),
       persistAndFlush: jest.fn().mockResolvedValue([entity]),
       removeAndFlush: jest.fn(),
+    };
+    return {
+      ...repoActions,
+      getEntityManager: jest.fn().mockReturnValue(repoActions),
     } as any;
   }
 
@@ -134,7 +166,7 @@ export class TestBootstrapper {
     } as any;
   }
 
-  static getMockDiscordRole(roleId: string) {
+  static getMockDiscordRole(roleId = '4969797969594') {
     return {
       id: roleId,
       name: 'mockrole',
@@ -326,6 +358,7 @@ export class TestBootstrapper {
       censusTimeout: 30000,
       outfitId: '866685885885885',
       pingRoles: ['1234567890', '9876543210'],
+      rankMap: ps2RankMap,
     },
   };
 

--- a/src/test.bootstrapper.ts
+++ b/src/test.bootstrapper.ts
@@ -256,6 +256,16 @@ export class TestBootstrapper {
     } as any;
   }
 
+  static getMockPS2Outfit(outfitId = '123456') {
+    return {
+      outfit_id: outfitId,
+      name: 'Test Outfit',
+      name_lower: 'test outfit',
+      alias: 'TO',
+      alias_lower: 'to',
+    };
+  }
+
   static getMockPS2MemberEntity(
     characterId = '123456',
     characterName = 'MrBojangles',

--- a/src/test.bootstrapper.ts
+++ b/src/test.bootstrapper.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '@nestjs/config';
 import { TestingModule } from '@nestjs/testing';
 import { MikroORM } from '@mikro-orm/core';
 import { AlbionServer } from './albion/interfaces/albion.api.interfaces';
+import { PS2MembersEntity } from './database/entities/ps2.members.entity';
 
 const guildLeaderRoleUS = '44546543371337';
 const guildLeaderRole = '64354579789809089';
@@ -237,7 +238,7 @@ export class TestBootstrapper {
     } as any;
   }
 
-  static getMockPS2Character(characterId: string, outfitId: string) {
+  static getMockPS2Character(characterId = '123456', outfitId = '123456') {
     return {
       character_id: characterId,
       name: {
@@ -253,6 +254,24 @@ export class TestBootstrapper {
         rank_ordinal: '3',
       },
     } as any;
+  }
+
+  static getMockPS2MemberEntity(
+    characterId = '123456',
+    characterName = 'MrBojangles',
+    discordMemberId = '123456'
+  ): PS2MembersEntity {
+    return {
+      id: 1,
+      createdAt: new Date,
+      updatedAt: new Date,
+      discordId: discordMemberId,
+      characterId: characterId,
+      characterName: characterName,
+      manual: false,
+      manualCreatedByDiscordId: null,
+      manualCreatedByDiscordName: null,
+    };
   }
 
   static readonly mockConfig = {

--- a/src/test.bootstrapper.ts
+++ b/src/test.bootstrapper.ts
@@ -325,6 +325,7 @@ export class TestBootstrapper {
       censusServiceId: 'dignityofwar',
       censusTimeout: 30000,
       outfitId: '866685885885885',
+      pingRoles: ['1234567890', '9876543210'],
     },
   };
 


### PR DESCRIPTION
Re-wrote the verification process to both simplify it and make it handle missing Census data.
Improved test coverage for PS2ScanningService.
Re-enabled PS2 scanning.

Closes #208 