### PR TITLE
Prevent rec role ping reminder on edited/deleted messages

### DIFF
--- a/src/general/events/message.events.spec.ts
+++ b/src/general/events/message.events.spec.ts
@@ -59,6 +59,20 @@ describe('MessageEvents', () => {
       expect(recRolePingService.onMessage).toHaveBeenCalledWith(mockMessage);
     });
 
+    it('should not trigger the rec role ping reminder for edited messages', async () => {
+      await messageEvents.handleMessageEvent(mockMessage, 'update');
+
+      expect(databaseService.updateActivity).toHaveBeenCalledWith(mockMessage.member);
+      expect(recRolePingService.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('should not trigger the rec role ping reminder for deleted messages', async () => {
+      await messageEvents.handleMessageEvent(mockMessage, 'delete');
+
+      expect(databaseService.updateActivity).toHaveBeenCalledWith(mockMessage.member);
+      expect(recRolePingService.onMessage).not.toHaveBeenCalled();
+    });
+
     it('should not handle message events for bot users', async () => {
       mockMessage.member.user.bot = true;
 
@@ -144,6 +158,7 @@ describe('MessageEvents', () => {
     it('should handle message creation', async () => {
       await messageEvents.onMessageCreate(mockMessage);
       expect(databaseService.updateActivity).toHaveBeenCalledWith(mockMessage.member);
+      expect(recRolePingService.onMessage).toHaveBeenCalledWith(mockMessage);
     });
     it('should handle message creation from a bot', async () => {
       mockMessage.member = TestBootstrapper.getMockDiscordUser(true);
@@ -154,11 +169,13 @@ describe('MessageEvents', () => {
     it('should handle message update', async () => {
       await messageEvents.onMessageUpdate(mockMessage);
       expect(databaseService.updateActivity).toHaveBeenCalledWith(mockMessage.member);
+      expect(recRolePingService.onMessage).not.toHaveBeenCalled();
     });
 
     it('should handle message deletion', async () => {
       await messageEvents.onMessageDelete(mockMessage);
       expect(databaseService.updateActivity).toHaveBeenCalledWith(mockMessage.member);
+      expect(recRolePingService.onMessage).not.toHaveBeenCalled();
     });
 
     it('should handle message reaction addition', async () => {

--- a/src/general/events/message.events.ts
+++ b/src/general/events/message.events.ts
@@ -36,8 +36,7 @@ export class MessageEvents {
 
     await this.databaseService.updateActivity(message.member);
 
-    // Only new messages should trigger the rec role ping reminder. Edits and deletions of a message
-    // that mentions a rec role would otherwise re-send the reminder every time.
+    // Create only, otherwise edits and deletions re-send the reminder.
     if (type === 'create') {
       await this.recRolePingService.onMessage(message);
     }

--- a/src/general/events/message.events.ts
+++ b/src/general/events/message.events.ts
@@ -35,7 +35,12 @@ export class MessageEvents {
     this.logger.verbose(`Message ${type} event detected from: ${name}`);
 
     await this.databaseService.updateActivity(message.member);
-    await this.recRolePingService.onMessage(message);
+
+    // Only new messages should trigger the rec role ping reminder. Edits and deletions of a message
+    // that mentions a rec role would otherwise re-send the reminder every time.
+    if (type === 'create') {
+      await this.recRolePingService.onMessage(message);
+    }
   }
 
   async handleMessageReaction(


### PR DESCRIPTION
## Summary
Fixes an issue where the rec role ping reminder service was being triggered on message edits and deletions, causing duplicate reminders to be sent whenever a message mentioning a rec role was edited or deleted.

## Changes
- **`message.events.ts`**: Modified `handleMessageEvent()` to only trigger `recRolePingService.onMessage()` for new message creation (`type === 'create'`), not for updates or deletions. Added explanatory comment clarifying the rationale.
- **`message.events.spec.ts`**: Added comprehensive test coverage:
  - New test verifying rec role ping is **not** triggered for edited messages
  - New test verifying rec role ping is **not** triggered for deleted messages
  - Updated existing `onMessageCreate`, `onMessageUpdate`, and `onMessageDelete` tests to explicitly assert the expected behavior of `recRolePingService.onMessage()`

## Implementation Details
The fix ensures that activity tracking (`databaseService.updateActivity()`) continues for all message event types, but the rec role ping reminder is scoped only to initial message creation. This prevents the service from re-sending reminders every time a message containing a rec role mention is edited or deleted.

https://claude.ai/code/session_01KkWWuMEut2Xgeym6sswyLk