### PR TITLE
fix(ci): Install dependencies inside the Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,7 +16,6 @@ coverage
 provisioning
 scripts
 
-# Build artefacts, the image installs and builds these itself. Copying the host's copies in would
-# make the image depend on whatever the build machine happens to have lying around.
+# The image installs and builds these itself
 node_modules
 dist

--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,8 @@ badges
 coverage
 provisioning
 scripts
+
+# Build artefacts, the image installs and builds these itself. Copying the host's copies in would
+# make the image depend on whatever the build machine happens to have lying around.
+node_modules
+dist

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -20,14 +20,6 @@ jobs:
           fetch-depth: 2
           submodules: true
 
-      - uses: actions/cache@v5
-        name: Pull pnpm cache
-        with:
-          path: node_modules
-          key: "${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}"
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,14 +57,6 @@ jobs:
           fetch-depth: 2
           submodules: true
 
-      - uses: actions/cache@v5
-        name: Pull pnpm cache
-        with:
-          path: node_modules
-          key: "${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}"
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,16 @@ ENV VERSION=${VERSION}
 # Installs pnpm via corepack
 RUN corepack enable
 
+WORKDIR /app
+
+# Install dependencies inside the image rather than relying on node_modules being present in the
+# build context. Kept as its own layer so it is only redone when the manifests change.
+# Dev dependencies are needed at runtime too, entrypoint.sh runs migrations through ts-node.
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
 # Many things are ignored, check .dockerignore
 COPY . /app
-
-WORKDIR /app
 
 # Build and lock the execution down to node non privledged user
 RUN pnpm build && chown node:node /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,8 @@ RUN corepack enable
 
 WORKDIR /app
 
-# Install dependencies inside the image rather than relying on node_modules being present in the
-# build context. Kept as its own layer so it is only redone when the manifests change.
-# Dev dependencies are needed at runtime too, entrypoint.sh runs migrations through ts-node.
-# --ignore-scripts is explicit rather than behavioural, pnpm 10 already blocks dependency build
-# scripts unless they are approved via pnpm.onlyBuiltDependencies, and we approve none.
+# Own layer so it's only redone when the manifests change. Dev deps are kept, entrypoint.sh runs
+# migrations through ts-node.
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --ignore-scripts
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,10 @@ WORKDIR /app
 # Install dependencies inside the image rather than relying on node_modules being present in the
 # build context. Kept as its own layer so it is only redone when the manifests change.
 # Dev dependencies are needed at runtime too, entrypoint.sh runs migrations through ts-node.
+# --ignore-scripts is explicit rather than behavioural, pnpm 10 already blocks dependency build
+# scripts unless they are approved via pnpm.onlyBuiltDependencies, and we approve none.
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # Many things are ignored, check .dockerignore
 COPY . /app


### PR DESCRIPTION
## The problem

`build-docker` is failing on PRs:

```
> nest build
sh: 1: nest: not found
 ELIFECYCLE  Command failed.
 WARN   Local package.json exists, but node_modules missing, did you mean to install?
ERROR: failed to solve: process "/bin/sh -c pnpm build && chown node:node /app" did not complete successfully: exit code: 1
```

The `Dockerfile` runs `pnpm build` but never installs dependencies. It has been working only by accident: the docker jobs had an `actions/cache` step that restored a `node_modules` directory into the workspace, and `COPY . /app` then pulled that into the image.

That cache is written by the `build-test-app` job, which on pull requests runs **in parallel** with `build-docker`. Any run where the cache isn't already populated for the current `pnpm-lock.yaml` hash leaves `build-docker` with no `node_modules`, and the build dies. The `main` pipeline happens to be sequential (`publish` needs `build`), which is why this mostly shows up on PRs.

## The fix

- `Dockerfile` installs its own dependencies with `pnpm install --frozen-lockfile`, in a layer of its own keyed on `package.json` + `pnpm-lock.yaml` so it is only redone when the manifests change. Dev dependencies are deliberately kept: `entrypoint.sh` → `start:prod` runs the migrations through `ts-node`, and `@mikro-orm/cli` and `ts-node` are both dev deps.
- `.dockerignore` now excludes `node_modules` and `dist`, so the image is built from the repository rather than from whatever the build machine happens to have on disk.
- The `node_modules` cache steps are removed from the `build-docker` and `build-docker-images` jobs, since they no longer feed anything.

The `build-test-app` job keeps its cache — that one is genuinely used.

## Testing

No Docker daemon was available in the session, so the image itself was not built. What was verified: the container's build sequence was reproduced against a clean tree (`git archive` of `main`, no `node_modules`, `.npmrc` removed since it is in `.dockerignore`) on Node 24.14.x with pnpm 10.32.1. `pnpm install --frozen-lockfile` followed by `pnpm build` succeeds, produces `dist/src/main.js`, and leaves both `ts-node` and `@mikro-orm/cli` present for the entrypoint. The two edited workflow files were parsed to confirm they are still valid YAML and that the docker jobs kept their remaining steps.

Worth a real CI run to confirm end to end.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkWWuMEut2Xgeym6sswyLk)_