### PR TITLE
chore: Unblock the pnpm 11 upgrade and put dependency bots in one lane

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,23 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Renovate (see renovate.json) owns dependency version updates for this repo. Dependabot is kept
+# only for GitHub's security advisories, which it raises regardless of the config below.
+#
+# Why version updates are off here:
+#   - Renovate and Dependabot were both raising PRs for the same packages, so every bump arrived
+#     twice and the two bots' PRs went stale against each other.
+#   - Dependabot PRs cannot pass CI in this repo anyway: they run without access to repository
+#     secrets, so the SonarCloud step fails with "Not authorized ... check the 'SONAR_TOKEN'"
+#     on every single one.
+#   - Renovate carries the rules that matter here (the MikroORM sibling grouping, the TypeScript
+#     and @types/node caps); Dependabot has no view of them and would happily propose past them.
+#
+# `open-pull-requests-limit: 0` is GitHub's documented way to disable version-update PRs while
+# leaving security updates untouched:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+# These packages' install scripts are deliberately not run: @nestjs/core's is an OpenCollective
+# donation banner, and the other two only *check* that a prebuilt native binary is present — the
+# binaries ship in the published tarballs. The production image installs with --ignore-scripts
+# anyway, so allowing them here would only diverge CI from what actually ships.
+allowBuilds:
+  '@nestjs/core': false
+  '@sentry-internal/node-cpu-profiler': false
+  unrs-resolver: false

--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,20 @@
       "minimumReleaseAge": "7 days"
     },
     {
+      "description": "TypeScript 7 is the native compiler rewrite, and typescript-eslint refuses to load against it (typescript-eslint/typescript-eslint#10940), so `pnpm lint` dies before it reaches a single rule. Hold at 6.x until upstream ships support; lifting this cap is a deliberate decision, not a bot's.",
+      "matchPackageNames": [
+        "typescript"
+      ],
+      "allowedVersions": "<7"
+    },
+    {
+      "description": "@types/node tracks the runtime, which engines pins to Node 24. Types ahead of the runtime typecheck against APIs that do not exist at boot. Raise this together with the engines range and the Dockerfile base image.",
+      "matchPackageNames": [
+        "@types/node"
+      ],
+      "allowedVersions": "<25"
+    },
+    {
       "description": "Automerge linters and formatters",
       "matchDepTypes": [
         "devDependencies"


### PR DESCRIPTION
Fallout from triaging the open Renovate/Dependabot queue. Two commits, both config only — no application code changes.

## 1. `pnpm-workspace.yaml` — unblocks #693

pnpm 11 promotes `ERR_PNPM_IGNORED_BUILDS` from a warning to a hard failure, so `pnpm install` exits 1 until every package carrying an install script is explicitly allowed or denied. That is the entire reason #693 (pnpm 10.32.1 → 11.15.1) is red:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @nestjs/core@11.1.18,
@sentry-internal/node-cpu-profiler@2.2.0, unrs-resolver@1.11.1
```

All three are declared `false`, which preserves current behaviour exactly rather than quietly turning three new build scripts on:

| Package | Install script | Why it stays off |
|---|---|---|
| `@nestjs/core` | `opencollective \|\| exit 0` | Donation banner. |
| `@sentry-internal/node-cpu-profiler` | `node scripts/check-build.js` | Only *checks* for a prebuilt `.node`; the tarball ships prebuilts for every platform/ABI, including linux-x64-glibc. Recompiles only if one is missing. |
| `unrs-resolver` | `napi-postinstall … check` | Only *checks* that the right optional binding installed; the bindings are `optionalDependencies`. |

The production image already runs `pnpm install --frozen-lockfile --ignore-scripts`, so allowing any of these would make CI diverge from what actually ships.

**Verification** (Node 24.14.1, matching `engines` and the Dockerfile):

- pnpm 11.15.1 — `pnpm install` goes from exit 1 to exit 0; `pnpm-lock.yaml` untouched.
- pnpm 10.32.1 — install still exits 0, so this is a no-op on `main` until #693 lands.
- `pnpm lint`, `pnpm build`, `pnpm test:ci` — clean, 31 suites / 364 tests passing.

For the record, pnpm 11 declares `engines.node >= 22.13`, so the pinned Node 24 is in range.

## 2. One bot owns version updates, plus two caps

Renovate and Dependabot were both raising PRs for the same npm packages. Every bump arrived twice and the duplicates went stale against each other — and none of the Dependabot ones could land anyway, because those PRs run without repository secrets and fail the SonarCloud step every time:

```
ERROR Not authorized or project not found. Please check the 'SONAR_TOKEN' environment variable,
the 'sonar.projectKey' and 'sonar.organization' properties, or contact the project administrator
```

`open-pull-requests-limit: 0` is GitHub's documented switch for disabling version-update PRs while leaving security advisories running, so Dependabot keeps doing the job it's still useful for here.

Two caps move to Renovate, each carrying its reasoning in the `description` field so the next person doesn't have to rediscover it:

- **`typescript` < 7** — TypeScript 7 is the native compiler rewrite and typescript-eslint refuses to load against it ([typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940)), so `pnpm lint` dies before evaluating a single rule. 6.x is the target; Renovate should raise 5.9.3 → 6.0.3 on its next run.
- **`@types/node` < 25** — matches the Node 24 range in `engines` and the Dockerfile base image. Types ahead of the runtime typecheck against APIs that aren't there at boot.

Both are decisions to revisit, not permanent pins.

## Queue this came from

| PR | Update | Outcome |
|---|---|---|
| #690 | actions/setup-node v6 → v7 | Merged, green |
| #689 | actions/checkout v6 → v7 | Merged, green |
| #694 | sonarqube-scan-action v7 → v8.2.1 | Merged, green — also moves the action off the deprecated Node 20 runtime |
| #693 | pnpm 10.32.1 → 11.15.1 | Blocked on commit 1 of this PR |
| #691 | typescript 5.9.3 → 7.0.2 | Closed — blocked upstream, capped at `<7` |
| #594 | @types/node 24 → 26 | Closed — runtime mismatch, capped at `<25` |
| #600, #601, #602, #622 | nestjs/core, nestjs/common, ts-eslint parser, diff | Closed — all superseded on `main`, and all built on the pre-rewrite history, sharing no common ancestor with it |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W33EYd6yjgoxVM4gmkJxin

---
_Generated by [Claude Code](https://claude.ai/code/session_01W33EYd6yjgoxVM4gmkJxin)_