### PR TITLE
ci: Allow the production pipeline to be run manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,13 @@ on:
       - 'mikro-orm.config.ts'      # MikroORM configuration
       - 'sonar-project.properties' # SonarQube configuration'
 
+  # Run the full production pipeline by hand from the Actions tab. The paths filter above
+  # means a commit touching nothing it lists — an empty commit, a README tweak — will not
+  # deploy, so without this there is no way to re-run a deployment without an artificial
+  # code change. Useful for verifying the deploy webhook end to end, and for re-deploying
+  # after fixing something on the receiving side rather than in this repo.
+  workflow_dispatch:
+
 jobs:
   build:
     name: Build & Test application


### PR DESCRIPTION
Adds `workflow_dispatch` to the production deployment workflow.

## Why

The `push` trigger carries a paths filter, so a commit that touches none of the listed paths — an empty commit, a README tweak — does not deploy. That is correct for pushes, but it means there is no way to re-run a deployment without inventing an artificial code change.

Wanted right now to validate the deploy webhook end to end (the webhooks server was just refactored — Maelstromeous/webhooks#7), and useful thereafter for re-deploying when the fix was on the receiving side rather than in this repo.

## Note

Merging this to `main` will itself trigger a full production run, because `.github/workflows/**` is in the paths filter. That is intended here — the run *is* the end-to-end test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)