### PR TITLE
feat: Add a container healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,15 @@ RUN pnpm install --frozen-lockfile --ignore-scripts
 # Many things are ignored, check .dockerignore
 COPY . /app
 
-# Build and lock the execution down to node non privledged user
-RUN pnpm build && chown node:node /app
-
-# The heartbeat lives here rather than /tmp: /tmp is world-writable, so any other
-# process could pre-create or symlink a file the deploy gate trusts (Sonar S5443,
-# CodeQL). This directory is owned by the runtime user and writable by nobody else.
-RUN mkdir -p /var/run/digletbot && chown node:node /var/run/digletbot
+# Build, then lock execution down to the unprivileged node user.
+#
+# The heartbeat directory is created here rather than using /tmp: /tmp is
+# world-writable, so any other process could pre-create or symlink a file the
+# deploy gate trusts (Sonar S5443, CodeQL). This one is owned by the runtime user
+# and writable by nobody else.
+RUN pnpm build \
+    && mkdir -p /var/run/digletbot \
+    && chown node:node /app /var/run/digletbot
 
 USER node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,21 @@ RUN pnpm build && chown node:node /app
 
 USER node
 
+# The bot is a standalone Nest application context — no HTTP server, no port to
+# probe — so liveness is a heartbeat file that HealthcheckService touches on its
+# one-minute cron. Stale means the scheduler has stopped, which is what a wedged
+# or crash-looping bot looks like from the outside. A process check would prove
+# nothing: the bot is PID 1, so if it dies the container dies and Docker already
+# knows.
+#
+# This lives here rather than in the server's compose file because that file is
+# not mirrored in any repo — shipping the check with the image means every box
+# gets it without a config change, and there is nothing to drift.
+#
+# start-period covers boot plus up to a minute of waiting for the first tick.
+# The deploy is gated on this: the shared update.sh runs `up -d --wait`, so a bot
+# that starts and wedges now fails the deploy instead of reporting success.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=150s --retries=3 \
+  CMD ["node", "-e", "const{statSync}=require('fs');try{process.exit(Date.now()-statSync('/tmp/digletbot-heartbeat').mtimeMs<180000?0:1)}catch{process.exit(1)}"]
+
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,11 @@ COPY . /app
 # Build and lock the execution down to node non privledged user
 RUN pnpm build && chown node:node /app
 
+# The heartbeat lives here rather than /tmp: /tmp is world-writable, so any other
+# process could pre-create or symlink a file the deploy gate trusts (Sonar S5443,
+# CodeQL). This directory is owned by the runtime user and writable by nobody else.
+RUN mkdir -p /var/run/digletbot && chown node:node /var/run/digletbot
+
 USER node
 
 # The bot is a standalone Nest application context — no HTTP server, no port to
@@ -42,6 +47,6 @@ USER node
 # The deploy is gated on this: the shared update.sh runs `up -d --wait`, so a bot
 # that starts and wedges now fails the deploy instead of reporting success.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=150s --retries=3 \
-  CMD ["node", "-e", "const{statSync}=require('fs');try{process.exit(Date.now()-statSync('/tmp/digletbot-heartbeat').mtimeMs<180000?0:1)}catch{process.exit(1)}"]
+  CMD ["node", "-e", "const{statSync}=require('node:fs');try{process.exit(Date.now()-statSync('/var/run/digletbot/heartbeat').mtimeMs<180000?0:1)}catch{process.exit(1)}"]
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/src/general/services/healthcheck.service.spec.ts
+++ b/src/general/services/healthcheck.service.spec.ts
@@ -3,6 +3,8 @@ import { ConfigService } from '@nestjs/config';
 import { Logger } from '@nestjs/common';
 import axios from 'axios';
 import { writeFile } from 'fs/promises';
+import { getRepositoryToken } from '@mikro-orm/nestjs';
+import { ActivityEntity } from '../../database/entities/activity.entity';
 import { HealthcheckService, HEARTBEAT_PATH } from './healthcheck.service';
 
 jest.mock('fs/promises', () => ({ writeFile: jest.fn() }));
@@ -12,6 +14,7 @@ const mockWriteFile = writeFile as jest.Mock;
 describe('HealthcheckService', () => {
   let healthcheckService: HealthcheckService;
   let configService: ConfigService;
+  let execute: jest.Mock;
 
   const configure = (env: string, uuid?: string) => {
     jest.spyOn(configService, 'get').mockImplementation((key: string) => {
@@ -22,12 +25,20 @@ describe('HealthcheckService', () => {
   };
 
   beforeEach(async () => {
+    execute = jest.fn().mockResolvedValue([{ 1: 1 }]);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         HealthcheckService,
         {
           provide: ConfigService,
           useValue: { get: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(ActivityEntity),
+          useValue: {
+            getEntityManager: () => ({ getConnection: () => ({ execute }) }),
+          },
         },
       ],
     }).compile();
@@ -93,6 +104,26 @@ describe('HealthcheckService', () => {
     await healthcheckService.check();
 
     expect(create).not.toHaveBeenCalled();
+  });
+
+  // The whole point of the DB probe: a bot that is resident but cannot reach
+  // MariaDB must not look healthy, so the heartbeat goes stale and the deploy
+  // gate rejects it.
+  it('does not write the heartbeat when the database is unreachable', async () => {
+    configure('development');
+    execute.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await healthcheckService.check();
+
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it('probes the database with a trivial query', async () => {
+    configure('development');
+
+    await healthcheckService.check();
+
+    expect(execute).toHaveBeenCalledWith('select 1');
   });
 
   it('does not ping when no UUID is configured', async () => {

--- a/src/general/services/healthcheck.service.spec.ts
+++ b/src/general/services/healthcheck.service.spec.ts
@@ -2,12 +2,12 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { Logger } from '@nestjs/common';
 import axios from 'axios';
-import { writeFile } from 'fs/promises';
+import { writeFile } from 'node:fs/promises';
 import { getRepositoryToken } from '@mikro-orm/nestjs';
 import { ActivityEntity } from '../../database/entities/activity.entity';
 import { HealthcheckService, HEARTBEAT_PATH } from './healthcheck.service';
 
-jest.mock('fs/promises', () => ({ writeFile: jest.fn() }));
+jest.mock('node:fs/promises', () => ({ writeFile: jest.fn() }));
 
 const mockWriteFile = writeFile as jest.Mock;
 

--- a/src/general/services/healthcheck.service.spec.ts
+++ b/src/general/services/healthcheck.service.spec.ts
@@ -1,0 +1,106 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { Logger } from '@nestjs/common';
+import axios from 'axios';
+import { writeFile } from 'fs/promises';
+import { HealthcheckService, HEARTBEAT_PATH } from './healthcheck.service';
+
+jest.mock('fs/promises', () => ({ writeFile: jest.fn() }));
+
+const mockWriteFile = writeFile as jest.Mock;
+
+describe('HealthcheckService', () => {
+  let healthcheckService: HealthcheckService;
+  let configService: ConfigService;
+
+  const configure = (env: string, uuid?: string) => {
+    jest.spyOn(configService, 'get').mockImplementation((key: string) => {
+      if (key === 'app.environment') return env;
+      if (key === 'app.healthcheckUUID') return uuid;
+      return undefined;
+    });
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HealthcheckService,
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    healthcheckService = module.get<HealthcheckService>(HealthcheckService);
+    configService = module.get<ConfigService>(ConfigService);
+
+    mockWriteFile.mockReset().mockResolvedValue(undefined);
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  // The heartbeat is what the container HEALTHCHECK reads, so it has to be
+  // written on every tick regardless of environment — otherwise a non-production
+  // container reports unhealthy forever.
+  it('writes the heartbeat file outside production', async () => {
+    configure('development');
+
+    await healthcheckService.check();
+
+    expect(mockWriteFile).toHaveBeenCalledWith(HEARTBEAT_PATH, expect.any(String));
+  });
+
+  it('writes the heartbeat file in production', async () => {
+    configure('production', 'some-uuid');
+    jest.spyOn(axios, 'create').mockReturnValue({ get: jest.fn() } as never);
+
+    await healthcheckService.check();
+
+    expect(mockWriteFile).toHaveBeenCalledWith(HEARTBEAT_PATH, expect.any(String));
+  });
+
+  // Ordering matters: the heartbeat is written before the uptime ping, so an
+  // outage at hc-ping.com cannot make the container look unhealthy.
+  it('still writes the heartbeat when the uptime ping fails', async () => {
+    configure('production', 'some-uuid');
+    const get = jest.fn().mockRejectedValue(new Error('hc-ping is down'));
+    jest.spyOn(axios, 'create').mockReturnValue({ get } as never);
+
+    await expect(healthcheckService.check()).rejects.toThrow('hc-ping is down');
+
+    expect(mockWriteFile).toHaveBeenCalledWith(HEARTBEAT_PATH, expect.any(String));
+  });
+
+  // And the reverse: a read-only /tmp must not take out the uptime ping.
+  it('still pings when the heartbeat cannot be written', async () => {
+    configure('production', 'some-uuid');
+    mockWriteFile.mockRejectedValue(new Error('read-only file system'));
+    const get = jest.fn().mockResolvedValue(undefined);
+    jest.spyOn(axios, 'create').mockReturnValue({ get } as never);
+
+    await healthcheckService.check();
+
+    expect(get).toHaveBeenCalledWith('some-uuid');
+  });
+
+  it('does not ping outside production', async () => {
+    configure('development');
+    const create = jest.spyOn(axios, 'create');
+
+    await healthcheckService.check();
+
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('does not ping when no UUID is configured', async () => {
+    configure('production', undefined);
+    const create = jest.spyOn(axios, 'create');
+
+    await healthcheckService.check();
+
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/src/general/services/healthcheck.service.ts
+++ b/src/general/services/healthcheck.service.ts
@@ -2,14 +2,21 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import axios from 'axios';
 import { ConfigService } from '@nestjs/config';
-import { writeFile } from 'fs/promises';
+import { writeFile } from 'node:fs/promises';
 import { InjectRepository } from '@mikro-orm/nestjs';
 import { EntityRepository } from '@mikro-orm/core';
 import { ActivityEntity } from '../../database/entities/activity.entity';
 
 // Touched every cron tick and read by the container HEALTHCHECK in the Dockerfile.
-// /tmp because the image runs as the unprivileged `node` user.
-export const HEARTBEAT_PATH = '/tmp/digletbot-heartbeat';
+//
+// Deliberately NOT /tmp. That directory is world-writable, so any other process
+// in the container could pre-create this path, symlink it elsewhere, or forge a
+// heartbeat — which for a file the deploy gate trusts is a genuine weakness
+// (Sonar S5443, CodeQL). This directory is created in the Dockerfile and owned
+// by the unprivileged `node` user the image runs as, so nothing else can write
+// to it.
+export const HEARTBEAT_DIR = '/var/run/digletbot';
+export const HEARTBEAT_PATH = `${HEARTBEAT_DIR}/heartbeat`;
 
 @Injectable()
 export class HealthcheckService {

--- a/src/general/services/healthcheck.service.ts
+++ b/src/general/services/healthcheck.service.ts
@@ -3,6 +3,9 @@ import { Cron } from '@nestjs/schedule';
 import axios from 'axios';
 import { ConfigService } from '@nestjs/config';
 import { writeFile } from 'fs/promises';
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { EntityRepository } from '@mikro-orm/core';
+import { ActivityEntity } from '../../database/entities/activity.entity';
 
 // Touched every cron tick and read by the container HEALTHCHECK in the Dockerfile.
 // /tmp because the image runs as the unprivileged `node` user.
@@ -14,6 +17,8 @@ export class HealthcheckService {
 
   constructor(
     private readonly config: ConfigService,
+    // Any repository will do — this is only used to reach the connection.
+    @InjectRepository(ActivityEntity) private readonly activityRepository: EntityRepository<ActivityEntity>,
   ) {}
 
   @Cron('*/1 * * * *')
@@ -30,13 +35,29 @@ export class HealthcheckService {
     // It goes before the environment gate so a non-production container is
     // still probeable, and before the hc-ping call so an outage at hc-ping.com
     // cannot mark this container unhealthy.
+    //
+    // The heartbeat is only written if the database answers, so "healthy" means
+    // the scheduler is ticking AND the bot can reach MariaDB — a bot that is
+    // resident but cannot read or write anything is not healthy in any useful
+    // sense. `select 1` is the cheapest possible proof of a live connection and
+    // depends on no schema.
     try {
-      await writeFile(HEARTBEAT_PATH, new Date().toISOString());
+      await this.activityRepository.getEntityManager().getConnection().execute('select 1');
+
+      try {
+        await writeFile(HEARTBEAT_PATH, new Date().toISOString());
+      }
+      catch (err) {
+        // Never throw: failing to write the heartbeat must not take out the
+        // uptime ping below.
+        this.logger.error(`Could not write heartbeat file: ${err}`);
+      }
     }
     catch (err) {
-      // Never throw: failing to write the heartbeat must not take out the
-      // uptime ping below.
-      this.logger.error(`Could not write heartbeat file: ${err}`);
+      // Deliberately leaves the heartbeat stale, so the container healthcheck
+      // starts failing and `docker compose up --wait` will not accept a deploy
+      // whose bot cannot reach its database.
+      this.logger.error(`Database healthcheck failed, heartbeat not written: ${err}`);
     }
 
     const env = this.config.get('app.environment');

--- a/src/general/services/healthcheck.service.ts
+++ b/src/general/services/healthcheck.service.ts
@@ -2,6 +2,11 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import axios from 'axios';
 import { ConfigService } from '@nestjs/config';
+import { writeFile } from 'fs/promises';
+
+// Touched every cron tick and read by the container HEALTHCHECK in the Dockerfile.
+// /tmp because the image runs as the unprivileged `node` user.
+export const HEARTBEAT_PATH = '/tmp/digletbot-heartbeat';
 
 @Injectable()
 export class HealthcheckService {
@@ -13,6 +18,27 @@ export class HealthcheckService {
 
   @Cron('*/1 * * * *')
   async check(): Promise<void> {
+    // Written FIRST, and in every environment, on purpose.
+    //
+    // This is the only liveness signal the container has: the bot is a
+    // standalone Nest application context (`createApplicationContext`), so there
+    // is no HTTP server to probe and no port to open. A process check would be
+    // meaningless because the bot is PID 1 — if it dies the container dies and
+    // Docker already knows. What this proves is that the scheduler is still
+    // ticking, which a wedged or crash-looping bot cannot fake.
+    //
+    // It goes before the environment gate so a non-production container is
+    // still probeable, and before the hc-ping call so an outage at hc-ping.com
+    // cannot mark this container unhealthy.
+    try {
+      await writeFile(HEARTBEAT_PATH, new Date().toISOString());
+    }
+    catch (err) {
+      // Never throw: failing to write the heartbeat must not take out the
+      // uptime ping below.
+      this.logger.error(`Could not write heartbeat file: ${err}`);
+    }
+
     const env = this.config.get('app.environment');
 
     if (env !== 'production') {


### PR DESCRIPTION
digletbot is the one target whose deploys can't tell whether the bot came back up. The shared `update.sh` runs `docker compose up -d --wait`, which blocks on a healthcheck — with none defined it quietly degrades to "is the container running", and says so in the deploy log:

```
digletbot: unchanged (441dbd664b30)
digletbot: NO HEALTHCHECK — --wait only checked it is running
```

## On `@nestjs/terminus`

It exists, it's the idiomatic answer, and it even ships a `MikroOrmHealthIndicator` that does exactly the database check below. **It isn't used here because it's HTTP-first** — it registers a controller, and this bot has no HTTP platform at all: `NestFactory.createApplicationContext`, no `@nestjs/platform-express`, no port.

Adopting Terminus means giving a Discord bot a web server. That's a bigger decision than a healthcheck, so it's flagged rather than taken. If you'd rather have a real curl-able `/health` endpoint, it's a reasonable follow-up — say so and I'll do it.

## What this does instead

`HealthcheckService` already runs a one-minute cron. It now:

1. Runs `select 1` against the database connection.
2. **Only if that succeeds**, touches `/tmp/digletbot-heartbeat`.

The Dockerfile's `HEALTHCHECK` fails if that file is missing or older than three minutes.

So **healthy means the scheduler is ticking *and* the database answers**. A bot that's resident but can't reach MariaDB — up, useless, previously indistinguishable from fine — now goes unhealthy, and `up -d --wait` refuses the deploy.

`select 1` is the cheapest possible proof of a live connection and depends on no schema. The repository injection is only a route to the connection; any entity would have done. No module changes were needed — `DatabaseModule` already exports `MikroOrmModule`.

Discord connectivity is genuinely harder to assert from outside and isn't attempted here.

## Two orderings that matter

- The heartbeat is written **before the environment gate**, so a non-production container is probeable rather than permanently unhealthy.
- It's written **before the hc-ping call**, so an outage at hc-ping.com can't mark your container unhealthy. It also never throws, so a read-only `/tmp` can't take out the uptime ping.

**hc-ping behaviour is deliberately unchanged** — a database outage does *not* currently suppress the uptime ping. If you'd rather a DB outage also paged you through hc-ping, that's a one-line change; I didn't want to alter your alerting as a side effect.

## Why the Dockerfile, not compose

The server's `docker-compose.yml` **isn't mirrored in any repo**. Shipping the check with the image means every box gets it without a config change, and there's nothing to drift — the same reasoning that just moved `update.sh` out of the boxes and into the webhooks repo.

```
--interval=30s --timeout=5s --start-period=150s --retries=3
```

`start-period` covers boot plus up to a minute waiting for the first tick; the 3-minute staleness window tolerates one missed tick.

## Tested

**8 spec cases, all passing** — heartbeat written in both environments; **not** written when the database is unreachable; the query is actually `select 1`; heartbeat still written when the ping fails; ping still sent when the heartbeat write fails; no ping outside production or without a UUID.

`tsc --noEmit` clean. The check expression verified in all three states:

| State | Exit |
| --- | --- |
| Missing file | `1` |
| Fresh heartbeat | `0` |
| Stale (10 min) | `1` |

**ESLint could not be run locally** — 8.57.1 crashes on my Node v26 while the project pins `>=24.12.0 <25.0.0`. That's an environment mismatch on my side, not a code issue, but it means CI is the first real lint run.

## Effect

Once released, digletbot's deploys become health-gated like the other two targets, and its log line changes from `NO HEALTHCHECK` to `healthy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)