### PR TITLE
chore(renovate): Hold releases for 14 days, and fix the rule that never matched

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,12 @@
   "extends": [
     "config:recommended"
   ],
+  "description": [
+    "A release has to have been public for 14 days before Renovate will propose it. With minor and patch updates automerging unattended, this is the window in which a compromised or immediately-yanked publish gets found by someone else before it can land here on its own.",
+    "Security fixes are not delayed by this: Renovate's vulnerabilityAlerts defaults are minimumReleaseAge null, an empty schedule and prCreation immediate, so a CVE fix is raised straight away regardless of the wait below.",
+    "This is set at the top level on purpose. It used to be a packageRule matching matchDatasources on dockerfile, github-actions, npm and nvm — but those are manager names, not datasource names, so only npm ever matched and the Dockerfile base image, the Actions versions and the .nvmrc were being proposed the moment they were published."
+  ],
+  "minimumReleaseAge": "14 days",
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,
@@ -18,15 +24,6 @@
         "mikro-orm",
         "/^@mikro-orm/"
       ]
-    },
-    {
-      "matchDatasources": [
-        "dockerfile",
-        "github-actions",
-        "npm",
-        "nvm"
-      ],
-      "minimumReleaseAge": "7 days"
     },
     {
       "description": "TypeScript 7 is the native compiler rewrite, and typescript-eslint refuses to load against it (typescript-eslint/typescript-eslint#10940), so `pnpm lint` dies before it reaches a single rule. Hold at 6.x until upstream ships support; lifting this cap is a deliberate decision, not a bot's.",


### PR DESCRIPTION
Two things here — the raise from 7 to 14 days, and a bug that meant the 7 days was mostly not applying anyway.

## The rule never matched what it claimed to

The existing wait was:

```json
{
  "matchDatasources": ["dockerfile", "github-actions", "npm", "nvm"],
  "minimumReleaseAge": "7 days"
}
```

`dockerfile`, `github-actions` and `nvm` are **manager** names, not **datasource** names. The datasources are `docker`, `github-releases` and `node-version` respectively. Only `npm` is valid in both, which is why it was the sole thing ever matched.

Net effect: the Dockerfile base image, the GitHub Actions versions and the `.nvmrc` have been getting proposed the moment they were published, with no wait at all. npm packages were the only deps actually held.

## The fix

Setting `minimumReleaseAge` at the **top level** covers every manager and datasource without enumerating any of them, so the class of bug above cannot recur. Raised to 14 days at the same time.

Minor and patch updates automerge in this repo, so this is the window in which a compromised or immediately-yanked publish gets caught by someone else before it lands on `main` unattended.

## Security fixes are not delayed

Renovate's built-in `vulnerabilityAlerts` defaults are `minimumReleaseAge: null`, `schedule: []` and `prCreation: "immediate"`, so a CVE fix is still raised the moment the alert lands. Nothing extra needs configuring — restating those defaults would only risk drifting from upstream, so the reasoning is recorded in the `description` block instead.

The MikroORM grouping, the TypeScript `<7` cap, the `@types/node` `<25` cap and both automerge rules are untouched.