### PR TITLE
chore(renovate): Merge through Renovate rather than GitHub auto-merge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,9 +6,11 @@
   "description": [
     "A release has to have been public for 14 days before Renovate will propose it. With minor and patch updates automerging unattended, this is the window in which a compromised or immediately-yanked publish gets found by someone else before it can land here on its own.",
     "Security fixes are not delayed by this: Renovate's vulnerabilityAlerts defaults are minimumReleaseAge null, an empty schedule and prCreation immediate, so a CVE fix is raised straight away regardless of the wait below.",
-    "This is set at the top level on purpose. It used to be a packageRule matching matchDatasources on dockerfile, github-actions, npm and nvm — but those are manager names, not datasource names, so only npm ever matched and the Dockerfile base image, the Actions versions and the .nvmrc were being proposed the moment they were published."
+    "This is set at the top level on purpose. It used to be a packageRule matching matchDatasources on dockerfile, github-actions, npm and nvm — but those are manager names, not datasource names, so only npm ever matched and the Dockerfile base image, the Actions versions and the .nvmrc were being proposed the moment they were published.",
+    "Renovate merges its own PRs rather than handing them to GitHub's auto-merge, which is disabled on this repo. Left at the default of true, platformAutomerge means every run attempts the platform route, fails, and falls back to merging directly — so this only makes the working behaviour explicit. It is also the stronger gate of the two: main currently has no required status checks, so GitHub auto-merge would merge a PR the moment it was mergeable, suite still running, where Renovate waits for the whole branch to go green."
   ],
   "minimumReleaseAge": "14 days",
+  "platformAutomerge": false,
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,


### PR DESCRIPTION
Sets `platformAutomerge: false` explicitly.

GitHub's own auto-merge is switched off on this repo, so the Renovate default of `true` means every run attempts the platform route, fails, and falls back to merging the PR directly. Setting it false states what already happens.

Keeping merges on Renovate's side is also the stronger gate here, and not just in theory: branch protection on `main` lists **no required status checks**. GitHub auto-merge waits on required checks alone, so it would take a PR the moment it was mergeable with the suite still running. Renovate waits for the whole branch to go green (`ignoreTests` defaults to false).

Worth a separate look: that empty required-checks list also means a red PR can be merged by hand today, with nothing stopping it. Out of scope here.

**Validation:** config parses as JSON. No change to which updates automerge, or to the Saturday window they merge in.