### PR TITLE
chore(renovate): Drop the Saturday window, hold MikroORM back instead

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,9 +47,6 @@
         "devDependencies"
       ],
       "automerge": true,
-      "schedule": [
-        "before 6am on saturday"
-      ],
       "matchPackageNames": [
         "/lint/",
         "/prettier/"
@@ -62,10 +59,15 @@
         "patch"
       ],
       "matchCurrentVersion": "!/^0/",
-      "automerge": true,
-      "schedule": [
-        "before 6am on saturday"
-      ]
+      "automerge": true
+    },
+    {
+      "description": "MikroORM stays manual, and this rule sits last on purpose — later rules win, so an exclusion placed above the automerge rules above would be overridden by them. start:prod is `migration:up && node dist/src/main`, so every container boot applies pending migrations to the live database before the app starts, and the ORM config sets transactional false. A half-applied migration is not undone by rolling the image back, which is the one failure the deploy cannot walk away from. A green suite runs against mocks and cannot speak for it.",
+      "matchPackageNames": [
+        "mikro-orm",
+        "/^@mikro-orm/"
+      ],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
The `before 6am on saturday` window was there because unattended updates kept breaking the bot. Two things have changed, so it comes off — but with one exclusion added that the window had been covering by accident.

## Why the window can go

The container now has a healthcheck, and `update.sh` brings services up with `--wait`. A bad image now fails the deploy loudly instead of reporting success while the old container keeps running.

Worth being clear about the limit: there is still no rollback. A failed deploy leaves the bot down until someone acts. What changed is that the failure is visible within a few minutes (150s start period, up to 3×30s retries) rather than silent.

## Why MikroORM is now held

`start:prod` is `migration:up && node dist/src/main`. Every container boot applies pending migrations to the live database before the app starts, and `mikro-orm.config.ts` sets `transactional: false`. A half-applied migration is not undone by rolling the image back, and the suite runs entirely against mocks, so nothing in CI speaks for it.

The group rule set `groupName` only. The blanket automerge rule sits below it and later rules win, so those packages were in scope for unattended merging — the equivalent of the `pg` / `node-pg-migrate` exclusion albionroads already has, which this repo never had. The new rule is placed **last** for that same precedence reason.

## Net effect

- Everything that automerges now does so when it goes green, rather than waiting for the weekend.
- MikroORM updates now wait for a human, grouped as before.
- `lockFileMaintenance` keeps its own Sunday schedule, untouched.

**Validation:** config parses as JSON. Rule ordering checked against Renovate's later-rules-win precedence, which is the bug being fixed here as much as the new exclusion.