### PR TITLE
ci: Declare token permissions per workflow

### DIFF
--- a/.github/workflows/build-and-test-main.yml
+++ b/.github/workflows/build-and-test-main.yml
@@ -3,6 +3,9 @@ name: Build & Test Main
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ on:
   # after fixing something on the receiving side rather than in this repo.
   workflow_dispatch:
 
+# The release job needs contents: write to push the version bump and tag. A called
+# workflow cannot be granted more than its caller holds, so it has to be granted
+# here as well as inside release.yml.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build & Test application
@@ -33,6 +39,8 @@ jobs:
   release:
     name: Create Release
     needs: build
+    permissions:
+      contents: write
     uses: ./.github/workflows/release.yml
     secrets: inherit
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,9 @@ name: Trigger Deployment Webhook
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   send-webhook:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -10,6 +10,9 @@ on:
         required: true
         default: '0.0.0'
 
+permissions:
+  contents: read
+
 jobs:
   build-docker-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,9 @@ name: PR Build & Tests
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-test-app:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Part of standardising GitHub settings across the repos. This is the code half; the settings half is applied directly.

The repository default for `GITHUB_TOKEN` is `write`, which is more than any workflow here needs. Each one now declares what it wants, so the default can drop to read-only.

| Workflow | Permissions | Why |
|---|---|---|
| PR Build & Tests, Build & Test Main | `contents: read` | checkout and cache only |
| Build & Publish, Trigger Deployment Webhook | `contents: read` | authenticate with their own secrets |
| Production Deployment | `contents: read`, plus `contents: write` on the release job | see below |
| Release | unchanged | already declared `contents: write` at job level |
| Clear All Caches, Cleanup runner caches | unchanged | already declared `actions: write` at job level |

The one subtlety is `ci.yml`. A called workflow cannot be granted more permission than its caller holds, so `release.yml` declaring `contents: write` internally is not enough once the default drops — the calling job in `ci.yml` has to grant it too, or the version bump loses its push access. That is the change most likely to have broken quietly, so it is worth a look.

## Validation

All eight workflow files parse as YAML. `PR Build & Tests` on this PR exercises the read-only path. The release path is only exercised on a push to `main`, so that one is verified by the next deployment rather than by this PR.

Once this merges, the default token permission drops to read-only and the branch ruleset requires `build-test-app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)