### PR TITLE
chore(renovate): Pin the automerge strategy to squash

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,12 @@
     "A release has to have been public for 14 days before Renovate will propose it. With minor and patch updates automerging unattended, this is the window in which a compromised or immediately-yanked publish gets found by someone else before it can land here on its own.",
     "Security fixes are not delayed by this: Renovate's vulnerabilityAlerts defaults are minimumReleaseAge null, an empty schedule and prCreation immediate, so a CVE fix is raised straight away regardless of the wait below.",
     "This is set at the top level on purpose. It used to be a packageRule matching matchDatasources on dockerfile, github-actions, npm and nvm — but those are manager names, not datasource names, so only npm ever matched and the Dockerfile base image, the Actions versions and the .nvmrc were being proposed the moment they were published.",
-    "Renovate merges its own PRs rather than handing them to GitHub's auto-merge, which is disabled on this repo. Left at the default of true, platformAutomerge means every run attempts the platform route, fails, and falls back to merging directly — so this only makes the working behaviour explicit. It is also the stronger gate of the two: main currently has no required status checks, so GitHub auto-merge would merge a PR the moment it was mergeable, suite still running, where Renovate waits for the whole branch to go green."
+    "Renovate merges its own PRs rather than handing them to GitHub's auto-merge. Auto-merge is now enabled on this repo, so platformAutomerge would work — this stays false because Renovate's own merge is still the stronger gate of the two. GitHub auto-merge releases a PR as soon as the required checks pass, where Renovate waits for the whole branch to go green, and build-docker and the CodeQL analyses are not required checks.",
+    "automergeStrategy is pinned to squash because main restricts merges to squash only. Left on the default of auto, Renovate picks a strategy from the repo's settings, and a merge it cannot perform is refused rather than retried."
   ],
   "minimumReleaseAge": "14 days",
   "platformAutomerge": false,
+  "automergeStrategy": "squash",
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,


### PR DESCRIPTION
Follow-up to the settings standardisation. `main` is now squash-only, and Renovate's `automergeStrategy` was left at the default of `auto` — which picks a strategy from the repo settings and refuses a merge it cannot perform rather than retrying. Left as-is, patch and minor updates would quietly stop landing on their own.

Pinned to `squash`, matching what Satisfactory Factories already does for the same reason.

Also corrects the note above it. It said GitHub auto-merge was disabled on this repo; that is no longer true. `platformAutomerge` stays `false`, but now on its own merits — Renovate waiting for the whole branch to go green is a stronger gate than GitHub auto-merge releasing a PR the moment the *required* checks pass.

No behaviour change beyond making automerge keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)