### PR TITLE
chore(deps): Update MikroORM to v7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Local MariaDB runs via `docker compose up -d` (host port 3307, credentials root/
 pnpm migration:create | migration:up | migration:down | migration:list
 ```
 
-If `migration:up` fails with "MikroORM config file not found", run `pnpm build` first — the CLI needs the compiled entities in `dist/`.
+If `migration:up` fails with "MikroORM config file not found", run `pnpm build` first — the CLI is pinned to the compiled output (`preferTs: false` in package.json), so it needs `dist/mikro-orm.config.js` and the compiled entities and migrations under `dist/src/database/`. New migrations are still emitted as TypeScript into `src/database/migrations` via `migrations.pathTs`.
 
 `./start.sh` runs the full local sequence (DB, build, migrations, dev mode); `./stop.sh` stops the containers.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN corepack enable
 WORKDIR /app
 
 # Own layer so it's only redone when the manifests change. Dev deps are kept, entrypoint.sh runs
-# migrations through ts-node.
+# migrations through the MikroORM CLI.
 COPY package.json pnpm-lock.yaml ./
 RUN corepack install && chmod -R a+rX "$COREPACK_HOME"
 RUN pnpm install --frozen-lockfile --ignore-scripts

--- a/README.md
+++ b/README.md
@@ -56,6 +56,6 @@ If `~/.claude/projects/<slug>/memory` already exists as a real directory with fi
 # Troubleshooting
 ## Running migration:up fails
 ```
-Error: MikroORM config file not found in ['./src/mikro-orm.config.ts', './mikro-orm.config.ts']
+Error: MikroORM config file not found in ['./dist/mikro-orm.config.js', './mikro-orm.config.js']
 ```
-This is due to ts-node not properly transpiling typescript into javascript which the package understands. To get round this, you can run `pnpm build` to in effect create the files for the migration to be able to run. Don't ask me why it works, it just does.
+The MikroORM CLI runs against the compiled output rather than the TypeScript sources, so run `pnpm build` first and the config and entities it is looking for will be there.

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,7 +22,8 @@ module.exports = {
     '**/*.{ts,tsx}', // Include only TypeScript and TSX files
     '**/*.spec.ts', // Explicitly exclude test files
     '**/*index.ts', // Exclude index files if they just re-export, as an example
-    '!database/**', // Exclude database folder, filled with migrations that's pointless to test
+    '!database/migrations/**', // Exclude migrations, pointless to test
+    '!database/entities/**', // Exclude entities, they're declarations rather than logic
     '!config/**', // Exclude config folder, mostly pointless to test
     '!**/*.module.ts', // Exclude module files, really hard to test with not much value
     '!main.ts', // Exclude main.ts, as it's the entrypoint to the app

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,13 @@ module.exports = {
   ],
   rootDir: 'src',
   testRegex: '.*\\.spec\\.ts$',
+  // MikroORM v7 ships as native ESM. Jest's CJS runtime can't require it, so its JS is
+  // transpiled down alongside our TypeScript instead of being skipped as a node_module.
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {}],
+    '^.+\\.m?js$': './jest-esm-transformer.js',
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*@mikro-orm)'],
   collectCoverage: true,
   collectCoverageFrom: [
     '**/*.{ts,tsx}', // Include only TypeScript and TSX files

--- a/mikro-orm.config.ts
+++ b/mikro-orm.config.ts
@@ -1,14 +1,17 @@
 import 'dotenv/config'; // Needed as of mikro-orm v6
 import { SqlHighlighter } from '@mikro-orm/sql-highlighter';
 import { Logger } from '@nestjs/common';
-import { defineConfig, Options } from '@mikro-orm/mariadb';
+import { defineConfig } from '@mikro-orm/mariadb';
+import { ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
 
 const logger = new Logger('MikroORM');
 const port = Number(process.env.DB_PORT) || 3306;
 
-const config: Options = defineConfig({
+const config = defineConfig({
   entities: ['./dist/src/database/entities'],
   entitiesTs: ['./src/database/entities'],
+  // v7 no longer defaults to reflect-metadata; the entities use legacy decorators.
+  metadataProvider: ReflectMetadataProvider,
   highlighter: new SqlHighlighter(),
   // clientUrl: dbURL,
   host: process.env.DB_HOST,
@@ -19,7 +22,8 @@ const config: Options = defineConfig({
   // extensions: [SeedManager, EntityGenerator],
   debug: process.env.DB_DEBUG === 'true',
   migrations: {
-    path: './src/database/migrations',
+    path: './dist/src/database/migrations',
+    pathTs: './src/database/migrations',
     transactional: false,
   },
   logger: logger.log.bind(logger),

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "migration:create": "pnpx ts-node node_modules/@mikro-orm/cli/cli.js migration:create",
-    "migration:up": "pnpx ts-node node_modules/@mikro-orm/cli/cli.js migration:up",
-    "migration:down": "pnpx ts-node node_modules/@mikro-orm/cli/cli.js migration:down",
-    "migration:list": "pnpx ts-node node_modules/@mikro-orm/cli/cli.js migration:list",
+    "migration:create": "mikro-orm migration:create",
+    "migration:up": "mikro-orm migration:up",
+    "migration:down": "mikro-orm migration:down",
+    "migration:list": "mikro-orm migration:list",
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "ts-node node_modules/@mikro-orm/cli/cli.js migration:up && node dist/src/main",
+    "start:prod": "mikro-orm migration:up && node dist/src/main",
     "test": "jest --coverage",
     "test:wsl": "jest --coverage --maxWorkers=4",
     "test:ci": "jest --ci --coverage",
@@ -23,6 +23,9 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand"
   },
   "packageManager": "pnpm@11.15.1",
+  "mikro-orm": {
+    "preferTs": false
+  },
   "engines": {
     "npm": ">=10.9.2",
     "pnpm": ">=10.25.0",
@@ -31,11 +34,12 @@
   "dependencies": {
     "@discord-nestjs/common": "^5.2.12",
     "@discord-nestjs/core": "^5.3.14",
-    "@mikro-orm/core": "6.6.10",
-    "@mikro-orm/mariadb": "6.6.10",
-    "@mikro-orm/migrations": "6.6.10",
-    "@mikro-orm/nestjs": "^6.0.0",
-    "@mikro-orm/seeder": "6.6.10",
+    "@mikro-orm/core": "7.1.6",
+    "@mikro-orm/decorators": "7.1.6",
+    "@mikro-orm/mariadb": "7.1.6",
+    "@mikro-orm/migrations": "7.1.6",
+    "@mikro-orm/nestjs": "^7.0.0",
+    "@mikro-orm/seeder": "7.1.6",
     "@mikro-orm/sql-highlighter": "^1.0.1",
     "@nestjs/common": "11.1.17",
     "@nestjs/config": "4.0.3",
@@ -47,11 +51,12 @@
     "discord.js": "^14.18.0",
     "dotenv": "^17.0.0",
     "lodash": "^4.17.21",
-    "ps2census": "^4.6.0"
+    "ps2census": "^4.6.0",
+    "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
-    "@mikro-orm/cli": "6.6.10",
+    "@mikro-orm/cli": "7.1.6",
     "@nestjs/cli": "11.0.16",
     "@nestjs/schematics": "11.0.9",
     "@nestjs/testing": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,20 +15,23 @@ importers:
         specifier: ^5.3.14
         version: 5.5.1(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.18(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(discord.js@14.25.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@mikro-orm/core':
-        specifier: 6.6.10
-        version: 6.6.10
+        specifier: 7.1.6
+        version: 7.1.6(dataloader@2.2.3)
+      '@mikro-orm/decorators':
+        specifier: 7.1.6
+        version: 7.1.6(@mikro-orm/core@7.1.6(dataloader@2.2.3))(reflect-metadata@0.2.2)
       '@mikro-orm/mariadb':
-        specifier: 6.6.10
-        version: 6.6.10(@mikro-orm/core@6.6.10)(supports-color@8.1.1)
+        specifier: 7.1.6
+        version: 7.1.6(@mikro-orm/core@7.1.6(dataloader@2.2.3))(@types/node@24.12.0)
       '@mikro-orm/migrations':
-        specifier: 6.6.10
-        version: 6.6.10(@mikro-orm/core@6.6.10)(@types/node@24.12.0)(mariadb@3.4.5)(supports-color@8.1.1)
+        specifier: 7.1.6
+        version: 7.1.6(@mikro-orm/core@7.1.6(dataloader@2.2.3))
       '@mikro-orm/nestjs':
-        specifier: ^6.0.0
-        version: 6.1.2(@mikro-orm/core@6.6.10)(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.18(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))
+        specifier: ^7.0.0
+        version: 7.0.2(@mikro-orm/core@7.1.6(dataloader@2.2.3))(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.18(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)
       '@mikro-orm/seeder':
-        specifier: 6.6.10
-        version: 6.6.10(@mikro-orm/core@6.6.10)
+        specifier: 7.1.6
+        version: 7.1.6(@mikro-orm/core@7.1.6(dataloader@2.2.3))
       '@mikro-orm/sql-highlighter':
         specifier: ^1.0.1
         version: 1.0.1
@@ -65,13 +68,16 @@ importers:
       ps2census:
         specifier: ^4.6.0
         version: 4.9.1(debug@4.4.3(supports-color@8.1.1))
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
     devDependencies:
       '@eslint/js':
         specifier: 10.0.1
         version: 10.0.1(eslint@10.7.0(supports-color@8.1.1))
       '@mikro-orm/cli':
-        specifier: 6.6.10
-        version: 6.6.10(mariadb@3.4.5)(supports-color@8.1.1)
+        specifier: 7.1.6
+        version: 7.1.6(dataloader@2.2.3)
       '@nestjs/cli':
         specifier: 11.0.16
         version: 11.0.16(@types/node@24.12.0)(uglify-js@3.19.3)
@@ -611,9 +617,6 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
-  '@jercle/yargonaut@1.1.5':
-    resolution: {integrity: sha512-zBp2myVvBHp1UaJsNTyS6q4UDKT7eRiqTS4oNTS6VQMd6mpxYOdbeK4pY279cDCdakGy6hG0J3ejoXZVsPwHqw==}
-
   '@jest/console@30.3.0':
     resolution: {integrity: sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -722,60 +725,72 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
-  '@mikro-orm/cli@6.6.10':
-    resolution: {integrity: sha512-tKQeQUuhEf8wjeOX9VU8DPD0lN0uNa/5q+u7XHjEk5xE5dkbOzDo7zpnRmV+CdWra4dV+3EY9XAc2uLaQSpGEg==}
-    engines: {node: '>= 18.12.0'}
+  '@mikro-orm/cli@7.1.6':
+    resolution: {integrity: sha512-qu4r7x3j49uqEjLdo5BD4ZZNsozDCZ9KiA3Kw797OIk/b/1uAnrFzG3I3uJ1tk2y+J7mhjQR2vBFNnKh4YH9Lg==}
+    engines: {node: '>= 22.17.0'}
     hasBin: true
 
-  '@mikro-orm/core@6.6.10':
-    resolution: {integrity: sha512-XdnipWmZ0BG+lzMBv6TykSKGLgBtNwqdJqh4Er+n1kTP0IZmXCtgluzHB66sNXkcYHomuIn2olIVbcVb0m/jDw==}
-    engines: {node: '>= 18.12.0'}
-
-  '@mikro-orm/knex@6.6.10':
-    resolution: {integrity: sha512-FOGkanJcHhKofjlc63YTpNtlB/7gdFRCfmbsBe2A1r36lx2aFdu2lqEAqFr8mUbOiwfTAQEBH8P9DGhd0T1j8g==}
-    engines: {node: '>= 18.12.0'}
+  '@mikro-orm/core@7.1.6':
+    resolution: {integrity: sha512-p9mMyGYS+xE0dB29fdtxTj50wuYzrevtCensCsZ6+StvwoTSA6B0ELEm/A0Cch7FfCLYORbND7ui9pW6ugE2tQ==}
+    engines: {node: '>= 22.17.0'}
     peerDependencies:
-      '@mikro-orm/core': ^6.0.0
-      better-sqlite3: '*'
-      libsql: '*'
-      mariadb: '*'
+      dataloader: 2.2.3
     peerDependenciesMeta:
-      better-sqlite3:
-        optional: true
-      libsql:
-        optional: true
-      mariadb:
+      dataloader:
         optional: true
 
-  '@mikro-orm/mariadb@6.6.10':
-    resolution: {integrity: sha512-ODihHa3gXBfR028gwrlNPCCKrXR5qCyvcuW1BsTKAWDFbWvMS1HBgrh8lBBR0rE7veLNxZhFVxMrMjNjgjGwMQ==}
-    engines: {node: '>= 18.12.0'}
+  '@mikro-orm/decorators@7.1.6':
+    resolution: {integrity: sha512-6pnkyYg6keb25NAdAa/adkOIqDEfI2YkzfugqA62b1QVbSVlMxqyS6VW4BAHf/9XtJMczJBRKVRuPBsXnrQZRA==}
+    engines: {node: '>= 22.17.0'}
     peerDependencies:
-      '@mikro-orm/core': ^6.0.0
+      '@mikro-orm/core': 7.1.6
+      reflect-metadata: ^0.1.0 || ^0.2.0
+    peerDependenciesMeta:
+      reflect-metadata:
+        optional: true
 
-  '@mikro-orm/migrations@6.6.10':
-    resolution: {integrity: sha512-+eQEIudtoRK4Fh688OmUxDXZZv7fR+N4gOJfYsJE+lJjUA3D6s0zg8zcxXZkUtGaIqRdSFhGPVc+pJQJPcT3wg==}
-    engines: {node: '>= 18.12.0'}
+  '@mikro-orm/mariadb@7.1.6':
+    resolution: {integrity: sha512-dekF0edgv3QmADxGZMh0Yp8aAOpjDurEhFKx/9Hql/9T1p2zqPHgQm6ZibnsjVeTBMn8pShI2aQUCn0J9wJLFQ==}
+    engines: {node: '>= 22.17.0'}
     peerDependencies:
-      '@mikro-orm/core': ^6.0.0
+      '@mikro-orm/core': 7.1.6
 
-  '@mikro-orm/nestjs@6.1.2':
-    resolution: {integrity: sha512-rITNvXusRVAB7PjEftT5ooDg6U2FZHwpn0u9f5RJyc9gVJGL2XroSJ6iX7VbDXasY8GUT1agdeeKmImx+MThdw==}
-    engines: {node: '>= 18.12.0'}
+  '@mikro-orm/migrations@7.1.6':
+    resolution: {integrity: sha512-857wUGF8o2gB9h+NxBXyhep9LWBLSX8eli/CdB6gU21GrHe1WUh5OAg/vSbhBV0GHzFsM8vclNvsLNAIFvqtsg==}
+    engines: {node: '>= 22.17.0'}
     peerDependencies:
-      '@mikro-orm/core': ^6.0.0 || ^6.0.0-dev.0 || ^7.0.0-dev.0
-      '@nestjs/common': ^10.0.0 || ^11.0.5
-      '@nestjs/core': ^10.0.0 || ^11.0.5
+      '@mikro-orm/core': 7.1.6
 
-  '@mikro-orm/seeder@6.6.10':
-    resolution: {integrity: sha512-76YiPE4n2TSGK22U1uZ/ifzN4rgizqcIf0qODipuKpC0TUsse+zyzyxiCgKlOZcCOL5emSqBUqcObWWEp7Ho+g==}
-    engines: {node: '>= 18.12.0'}
+  '@mikro-orm/mysql@7.1.6':
+    resolution: {integrity: sha512-+7WKPZyetPcitzNYLRcHlnkovIuohswV4g0sLkqHwh/0RkmV09spo+mXscyLccSpX2Qjl74LDWM+dlApdHnAkA==}
+    engines: {node: '>= 22.17.0'}
     peerDependencies:
-      '@mikro-orm/core': ^6.0.0
+      '@mikro-orm/core': 7.1.6
+
+  '@mikro-orm/nestjs@7.0.2':
+    resolution: {integrity: sha512-0iEr+YzhXQ8cZaAKzfJNijHHAL1Fg/PrauaMiwlZpaxOy0aMAPCQEwaSuxsz43X6XShrCv/TlE6kRn/QPIMzZA==}
+    engines: {node: '>= 22.17.0'}
+    peerDependencies:
+      '@mikro-orm/core': ^7.0.0 || ^7.0.0-dev.0
+      '@nestjs/common': ^11.0.5
+      '@nestjs/core': ^11.0.5
+      reflect-metadata: ^0.1.0 || ^0.2.0
+
+  '@mikro-orm/seeder@7.1.6':
+    resolution: {integrity: sha512-GRdP+aM8wISZQZaCmH7SzE/6iY2dJixzuuAOATBaEowZej/5lwvDCD+sJ8kkLV0sBgOY0oNJzVhJ85Qx3nJlOA==}
+    engines: {node: '>= 22.17.0'}
+    peerDependencies:
+      '@mikro-orm/core': 7.1.6
 
   '@mikro-orm/sql-highlighter@1.0.1':
     resolution: {integrity: sha512-iO+FwRNuqNDVlIo5zfgOu2mMGVicX/FqzP+F/A0xpJLHyqvWyXzVwntgAMimBjQaxiX9Rpmc0u3Jq6/A6V6JQA==}
     engines: {node: '>= 10.13.0'}
+
+  '@mikro-orm/sql@7.1.6':
+    resolution: {integrity: sha512-GPyOWd7mX0eiePvzFAW9xneulu/YA/Aa/i6E3vqoeulyG0+86N1Wh0Ow7GIu4ZAS5lm4+tFR/vOCAux/Bx5vBg==}
+    engines: {node: '>= 22.17.0'}
+    peerDependencies:
+      '@mikro-orm/core': 7.1.6
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -866,18 +881,6 @@ packages:
         optional: true
       '@nestjs/platform-express':
         optional: true
-
-  '@nodelib/fs.scandir@2.1.5':
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
-
-  '@nodelib/fs.stat@2.0.5':
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
-
-  '@nodelib/fs.walk@1.2.8':
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
 
   '@nuxt/opencollective@0.4.1':
     resolution: {integrity: sha512-GXD3wy50qYbxCJ652bDrDzgMr3NFEkIS374+IgFQKkCvk9yiYcLvX2XDYr7UyQxf4wK0e+yqDYRubZ0DtOxnmQ==}
@@ -1107,25 +1110,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.8
 
-  '@rushstack/node-core-library@5.13.0':
-    resolution: {integrity: sha512-IGVhy+JgUacAdCGXKUrRhwHMTzqhWwZUI+qEPcdzsb80heOw0QPbhhoVsoiMF7Klp8eYsp7hzpScMXmOa3Uhfg==}
-    peerDependencies:
-      '@types/node': '*'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@rushstack/terminal@0.15.2':
-    resolution: {integrity: sha512-7Hmc0ysK5077R/IkLS9hYu0QuNafm+TbZbtYVzCMbeOdMjaRboLKrhryjwZSRJGJzu+TV1ON7qZHeqf58XfLpA==}
-    peerDependencies:
-      '@types/node': '*'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@rushstack/ts-command-line@4.23.7':
-    resolution: {integrity: sha512-Gr9cB7DGe6uz5vq2wdr89WbVDKz0UeuFEn5H2CfWDe7JvjFFaiV15gi6mqDBTbHhHCWS7w8mF1h3BnIfUndqdA==}
-
   '@sapphire/async-queue@1.5.5':
     resolution: {integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
@@ -1233,9 +1217,6 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
-  '@types/argparse@1.0.38':
-    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
-
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1262,9 +1243,6 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
-  '@types/geojson@7946.0.16':
-    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -1568,14 +1546,6 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
-  ajv-draft-04@1.0.0:
-    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
-    peerDependencies:
-      ajv: ^8.5.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -1604,9 +1574,6 @@ packages:
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
-
-  ajv@8.13.0:
-    resolution: {integrity: sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==}
 
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
@@ -1662,12 +1629,12 @@ packages:
   array-timsort@1.0.3:
     resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
 
-  array-union@2.1.0:
-    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
-    engines: {node: '>=8'}
-
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  aws-ssl-profiles@1.1.2:
+    resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
+    engines: {node: '>= 6.0.0'}
 
   axios@1.13.6:
     resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
@@ -1839,20 +1806,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  colorette@2.0.19:
-    resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
-
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
-
-  commander@10.0.1:
-    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
-    engines: {node: '>=14'}
-
-  commander@14.0.3:
-    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
-    engines: {node: '>=20'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -1901,15 +1857,6 @@ packages:
   dataloader@2.2.3:
     resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
 
-  debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1956,10 +1903,6 @@ packages:
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
-
-  dir-glob@3.0.1:
-    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
-    engines: {node: '>=8'}
 
   discord-api-types@0.38.43:
     resolution: {integrity: sha512-sSoBf/nK6m7BGtw65mi+QBuvEWaHE8MMziFLqWL+gT6ME/BLg34dRSVKS3Husx40uU06bvxUc3/X+D9Y6/zAbw==}
@@ -2092,10 +2035,6 @@ packages:
       jiti:
         optional: true
 
-  esm@3.2.25:
-    resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
-    engines: {node: '>=6'}
-
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2154,10 +2093,6 @@ packages:
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
 
-  fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
-    engines: {node: '>=8.6.0'}
-
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -2170,9 +2105,6 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fastq@1.20.1:
-    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
-
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
@@ -2184,11 +2116,6 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
-
-  figlet@1.11.0:
-    resolution: {integrity: sha512-EEx3OS/l2bFqcUNN2NM9FPJp8vAMrgbCxsbl2hbcJNNxOEwVe3mEzrhan7TbJQViZa8mMqhihlbCaqD+LyYKTQ==}
-    engines: {node: '>= 17.0.0'}
-    hasBin: true
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2248,10 +2175,6 @@ packages:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
 
-  fs-extra@11.3.3:
-    resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
-    engines: {node: '>=14.14'}
-
   fs-monkey@1.1.0:
     resolution: {integrity: sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==}
 
@@ -2265,6 +2188,9 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  generate-function@2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -2290,13 +2216,6 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
-  getopts@2.3.0:
-    resolution: {integrity: sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA==}
-
-  glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
-
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -2316,10 +2235,6 @@ packages:
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
-  globby@11.1.0:
-    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
-    engines: {node: '>=10'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -2360,10 +2275,6 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
 
-  iconv-lite@0.6.3:
-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
-    engines: {node: '>=0.10.0'}
-
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -2390,10 +2301,6 @@ packages:
     resolution: {integrity: sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg==}
     engines: {node: '>=18'}
 
-  import-lazy@4.0.0:
-    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
-    engines: {node: '>=8'}
-
   import-local@3.2.0:
     resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
     engines: {node: '>=8'}
@@ -2410,16 +2317,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  interpret@2.2.0:
-    resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
-    engines: {node: '>= 0.10'}
-
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-
-  is-core-module@2.16.1:
-    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
-    engines: {node: '>= 0.4'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -2444,6 +2343,9 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-property@1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -2620,9 +2522,6 @@ packages:
       node-notifier:
         optional: true
 
-  jju@1.4.0:
-    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
-
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2668,33 +2567,9 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
-  knex@3.1.0:
-    resolution: {integrity: sha512-GLoII6hR0c4ti243gMs5/1Rb3B+AjwMOfjYm97pu0FOQa7JH56hgBxYf5WK2525ceSbBY1cjeZ9yk99GPMB6Kw==}
-    engines: {node: '>=16'}
-    hasBin: true
-    peerDependencies:
-      better-sqlite3: '*'
-      mysql: '*'
-      mysql2: '*'
-      pg: '*'
-      pg-native: '*'
-      sqlite3: '*'
-      tedious: '*'
-    peerDependenciesMeta:
-      better-sqlite3:
-        optional: true
-      mysql:
-        optional: true
-      mysql2:
-        optional: true
-      pg:
-        optional: true
-      pg-native:
-        optional: true
-      sqlite3:
-        optional: true
-      tedious:
-        optional: true
+  kysely@0.29.3:
+    resolution: {integrity: sha512-VHtBdW6XB/pgoTSqraM3UAa2rYoYdNXqnNPpX+8XXP+cwYbVEFuAp3HyPt1vpNfU9l7Y2kpUrA9QDPsy8uUqOQ==}
+    engines: {node: '>=22.0.0'}
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -2742,6 +2617,9 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -2752,9 +2630,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lru-cache@6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
+  lru.min@1.1.4:
+    resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
+    engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
 
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
@@ -2776,10 +2654,6 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
-  mariadb@3.4.5:
-    resolution: {integrity: sha512-gThTYkhIS5rRqkVr+Y0cIdzr+GRqJ9sA2Q34e0yzmyhMCwyApf3OKAC1jnF23aSlIOqJuyaUFUcj7O1qZslmmQ==}
-    engines: {node: '>= 14'}
-
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2791,17 +2665,13 @@ packages:
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
-  merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
-
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  mikro-orm@6.6.10:
-    resolution: {integrity: sha512-9z+F31IYQx4sDOO+2gtTS9JUz8SxoSrMQte0p300RIzWj+KByBYkpPZLhAToyIkuUCXHf2sGah8HSpExToCm6Q==}
-    engines: {node: '>= 18.12.0'}
+  mikro-orm@7.1.6:
+    resolution: {integrity: sha512-Uoqd4p5r5SRNQt6jLIN5FgLaWdrpi8PjYGnG2/8a8gWXEt/KaGhobFyNu2110A5wjO59WNMgR2MQV0iL8ygfXg==}
+    engines: {node: '>= 22.17.0'}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -2836,15 +2706,22 @@ packages:
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
-  ms@2.1.2:
-    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  mysql2@3.22.6:
+    resolution: {integrity: sha512-fPKmeDGUzvFP7bMD5SASlJ5zIgvCC4hbanTmhbUlEmhyrY1hR4Hi3xLOWgTd3luYjLVifx6uGvMNJ2m/LlqEpg==}
+    engines: {node: '>= 8.0'}
+    peerDependencies:
+      '@types/node': '>= 8'
+
+  named-placeholders@1.1.6:
+    resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
+    engines: {node: '>=8.0.0'}
 
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
@@ -2923,10 +2800,6 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
-  parent-require@1.0.0:
-    resolution: {integrity: sha512-2MXDNZC4aXdkkap+rBBMv0lUsfJqvX5/2FiYYnfCnorZt3Pk06/IOR5KeaoghgS2w07MLWgjbsnyaq6PdHn2LQ==}
-    engines: {node: '>= 0.4.0'}
-
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
@@ -2943,9 +2816,6 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  path-parse@1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
@@ -2960,9 +2830,6 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
-
-  pg-connection-string@2.6.2:
-    resolution: {integrity: sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==}
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -3001,10 +2868,6 @@ packages:
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
-
-  pony-cause@2.1.11:
-    resolution: {integrity: sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg==}
-    engines: {node: '>=12.0.0'}
 
   postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
@@ -3065,9 +2928,6 @@ packages:
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
-  queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
@@ -3078,10 +2938,6 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
-
-  rechoir@0.8.0:
-    resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
-    engines: {node: '>= 10.13.0'}
 
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
@@ -3110,21 +2966,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
-  resolve@1.22.11:
-    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
-    engines: {node: '>= 0.4'}
-    hasBin: true
-
   restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
-
-  reusify@1.1.0:
-    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
-  run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
@@ -3145,11 +2989,6 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
-  semver@7.5.4:
-    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
-    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.7.4:
@@ -3197,6 +3036,10 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  sql-escaper@1.5.1:
+    resolution: {integrity: sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==}
+    engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
+
   sqlstring@2.3.3:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
     engines: {node: '>= 0.6'}
@@ -3204,10 +3047,6 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
-
-  string-argv@0.3.2:
-    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
-    engines: {node: '>=0.6.19'}
 
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
@@ -3260,10 +3099,6 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
-  supports-preserve-symlinks-flag@1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
-    engines: {node: '>= 0.4'}
-
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
@@ -3275,10 +3110,6 @@ packages:
   tapable@2.3.2:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
-
-  tarn@3.0.2:
-    resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
-    engines: {node: '>=8.0.0'}
 
   terser-webpack-plugin@5.4.0:
     resolution: {integrity: sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==}
@@ -3303,10 +3134,6 @@ packages:
 
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
-    engines: {node: '>=8'}
-
-  tildify@2.0.0:
-    resolution: {integrity: sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==}
     engines: {node: '>=8'}
 
   tinyglobby@0.2.15:
@@ -3430,10 +3257,6 @@ packages:
   uint8array-extras@1.5.0:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
-
-  umzug@3.8.2:
-    resolution: {integrity: sha512-BEWEF8OJjTYVC56GjELeHl/1XjFejrD7aHzn+HldRJTx+pL1siBrKHZC8n4K/xL3bEzVA9o++qD1tK2CpZu4KA==}
-    engines: {node: '>=12'}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -3569,9 +3392,6 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -4152,12 +3972,6 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@jercle/yargonaut@1.1.5':
-    dependencies:
-      chalk: 4.1.2
-      figlet: 1.11.0
-      parent-require: 1.0.0
-
   '@jest/console@30.3.0':
     dependencies:
       '@jest/types': 30.3.0
@@ -4366,103 +4180,66 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
-  '@mikro-orm/cli@6.6.10(mariadb@3.4.5)(supports-color@8.1.1)':
+  '@mikro-orm/cli@7.1.6(dataloader@2.2.3)':
     dependencies:
-      '@jercle/yargonaut': 1.1.5
-      '@mikro-orm/core': 6.6.10
-      '@mikro-orm/knex': 6.6.10(@mikro-orm/core@6.6.10)(mariadb@3.4.5)(supports-color@8.1.1)
-      fs-extra: 11.3.3
-      tsconfig-paths: 4.2.0
+      '@mikro-orm/core': 7.1.6(dataloader@2.2.3)
+      mikro-orm: 7.1.6
       yargs: 17.7.2
     transitivePeerDependencies:
-      - better-sqlite3
-      - libsql
-      - mariadb
-      - mysql
-      - mysql2
-      - pg
-      - pg-native
-      - sqlite3
-      - supports-color
-      - tedious
+      - dataloader
 
-  '@mikro-orm/core@6.6.10':
-    dependencies:
+  '@mikro-orm/core@7.1.6(dataloader@2.2.3)':
+    optionalDependencies:
       dataloader: 2.2.3
-      dotenv: 17.3.1
-      esprima: 4.0.1
-      fs-extra: 11.3.3
-      globby: 11.1.0
-      mikro-orm: 6.6.10
+
+  '@mikro-orm/decorators@7.1.6(@mikro-orm/core@7.1.6(dataloader@2.2.3))(reflect-metadata@0.2.2)':
+    dependencies:
+      '@mikro-orm/core': 7.1.6(dataloader@2.2.3)
+    optionalDependencies:
       reflect-metadata: 0.2.2
 
-  '@mikro-orm/knex@6.6.10(@mikro-orm/core@6.6.10)(mariadb@3.4.5)(supports-color@8.1.1)':
+  '@mikro-orm/mariadb@7.1.6(@mikro-orm/core@7.1.6(dataloader@2.2.3))(@types/node@24.12.0)':
     dependencies:
-      '@mikro-orm/core': 6.6.10
-      fs-extra: 11.3.3
-      knex: 3.1.0(supports-color@8.1.1)
-      sqlstring: 2.3.3
-    optionalDependencies:
-      mariadb: 3.4.5
-    transitivePeerDependencies:
-      - mysql
-      - mysql2
-      - pg
-      - pg-native
-      - sqlite3
-      - supports-color
-      - tedious
-
-  '@mikro-orm/mariadb@6.6.10(@mikro-orm/core@6.6.10)(supports-color@8.1.1)':
-    dependencies:
-      '@mikro-orm/core': 6.6.10
-      '@mikro-orm/knex': 6.6.10(@mikro-orm/core@6.6.10)(mariadb@3.4.5)(supports-color@8.1.1)
-      mariadb: 3.4.5
-    transitivePeerDependencies:
-      - better-sqlite3
-      - libsql
-      - mysql
-      - mysql2
-      - pg
-      - pg-native
-      - sqlite3
-      - supports-color
-      - tedious
-
-  '@mikro-orm/migrations@6.6.10(@mikro-orm/core@6.6.10)(@types/node@24.12.0)(mariadb@3.4.5)(supports-color@8.1.1)':
-    dependencies:
-      '@mikro-orm/core': 6.6.10
-      '@mikro-orm/knex': 6.6.10(@mikro-orm/core@6.6.10)(mariadb@3.4.5)(supports-color@8.1.1)
-      fs-extra: 11.3.3
-      umzug: 3.8.2(@types/node@24.12.0)
+      '@mikro-orm/core': 7.1.6(dataloader@2.2.3)
+      '@mikro-orm/mysql': 7.1.6(@mikro-orm/core@7.1.6(dataloader@2.2.3))(@types/node@24.12.0)
+      kysely: 0.29.3
     transitivePeerDependencies:
       - '@types/node'
-      - better-sqlite3
-      - libsql
-      - mariadb
-      - mysql
-      - mysql2
-      - pg
-      - pg-native
-      - sqlite3
-      - supports-color
-      - tedious
 
-  '@mikro-orm/nestjs@6.1.2(@mikro-orm/core@6.6.10)(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.18(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))':
+  '@mikro-orm/migrations@7.1.6(@mikro-orm/core@7.1.6(dataloader@2.2.3))':
     dependencies:
-      '@mikro-orm/core': 6.6.10
+      '@mikro-orm/core': 7.1.6(dataloader@2.2.3)
+      '@mikro-orm/sql': 7.1.6(@mikro-orm/core@7.1.6(dataloader@2.2.3))
+
+  '@mikro-orm/mysql@7.1.6(@mikro-orm/core@7.1.6(dataloader@2.2.3))(@types/node@24.12.0)':
+    dependencies:
+      '@mikro-orm/core': 7.1.6(dataloader@2.2.3)
+      '@mikro-orm/sql': 7.1.6(@mikro-orm/core@7.1.6(dataloader@2.2.3))
+      kysely: 0.29.3
+      mysql2: 3.22.6(@types/node@24.12.0)
+      sqlstring: 2.3.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@mikro-orm/nestjs@7.0.2(@mikro-orm/core@7.1.6(dataloader@2.2.3))(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.18(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)':
+    dependencies:
+      '@mikro-orm/core': 7.1.6(dataloader@2.2.3)
       '@nestjs/common': 11.1.17(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1)
       '@nestjs/core': 11.1.18(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      reflect-metadata: 0.2.2
 
-  '@mikro-orm/seeder@6.6.10(@mikro-orm/core@6.6.10)':
+  '@mikro-orm/seeder@7.1.6(@mikro-orm/core@7.1.6(dataloader@2.2.3))':
     dependencies:
-      '@mikro-orm/core': 6.6.10
-      fs-extra: 11.3.3
-      globby: 11.1.0
+      '@mikro-orm/core': 7.1.6(dataloader@2.2.3)
 
   '@mikro-orm/sql-highlighter@1.0.1':
     dependencies:
       ansi-colors: 4.1.3
+
+  '@mikro-orm/sql@7.1.6(@mikro-orm/core@7.1.6(dataloader@2.2.3))':
+    dependencies:
+      '@mikro-orm/core': 7.1.6(dataloader@2.2.3)
+      kysely: 0.29.3
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -4573,18 +4350,6 @@ snapshots:
       '@nestjs/common': 11.1.17(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1)
       '@nestjs/core': 11.1.18(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1)
       tslib: 2.8.1
-
-  '@nodelib/fs.scandir@2.1.5':
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      run-parallel: 1.2.0
-
-  '@nodelib/fs.stat@2.0.5': {}
-
-  '@nodelib/fs.walk@1.2.8':
-    dependencies:
-      '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.20.1
 
   '@nuxt/opencollective@0.4.1':
     dependencies:
@@ -4870,35 +4635,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rushstack/node-core-library@5.13.0(@types/node@24.12.0)':
-    dependencies:
-      ajv: 8.13.0
-      ajv-draft-04: 1.0.0(ajv@8.13.0)
-      ajv-formats: 3.0.1(ajv@8.13.0)
-      fs-extra: 11.3.3
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.11
-      semver: 7.5.4
-    optionalDependencies:
-      '@types/node': 24.12.0
-
-  '@rushstack/terminal@0.15.2(@types/node@24.12.0)':
-    dependencies:
-      '@rushstack/node-core-library': 5.13.0(@types/node@24.12.0)
-      supports-color: 8.1.1
-    optionalDependencies:
-      '@types/node': 24.12.0
-
-  '@rushstack/ts-command-line@4.23.7(@types/node@24.12.0)':
-    dependencies:
-      '@rushstack/terminal': 0.15.2(@types/node@24.12.0)
-      '@types/argparse': 1.0.38
-      argparse: 1.0.10
-      string-argv: 0.3.2
-    transitivePeerDependencies:
-      - '@types/node'
-
   '@sapphire/async-queue@1.5.5': {}
 
   '@sapphire/shapeshift@4.0.0':
@@ -5030,8 +4766,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/argparse@1.0.38': {}
-
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.2
@@ -5070,8 +4804,6 @@ snapshots:
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.8': {}
-
-  '@types/geojson@7946.0.16': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -5388,17 +5120,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ajv-draft-04@1.0.0(ajv@8.13.0):
-    optionalDependencies:
-      ajv: 8.13.0
-
   ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
-
-  ajv-formats@3.0.1(ajv@8.13.0):
-    optionalDependencies:
-      ajv: 8.13.0
 
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
@@ -5418,13 +5142,6 @@ snapshots:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
-      uri-js: 4.4.1
-
-  ajv@8.13.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
       uri-js: 4.4.1
 
   ajv@8.17.1:
@@ -5476,9 +5193,9 @@ snapshots:
 
   array-timsort@1.0.3: {}
 
-  array-union@2.1.0: {}
-
   asynckit@0.4.0: {}
+
+  aws-ssl-profiles@1.1.2: {}
 
   axios@1.13.6(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
@@ -5676,15 +5393,9 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  colorette@2.0.19: {}
-
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
-
-  commander@10.0.1: {}
-
-  commander@14.0.3: {}
 
   commander@2.20.3: {}
 
@@ -5726,13 +5437,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  dataloader@2.2.3: {}
-
-  debug@4.3.4(supports-color@8.1.1):
-    dependencies:
-      ms: 2.1.2
-    optionalDependencies:
-      supports-color: 8.1.1
+  dataloader@2.2.3:
+    optional: true
 
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
@@ -5759,10 +5465,6 @@ snapshots:
   detect-newline@3.1.0: {}
 
   diff@4.0.4: {}
-
-  dir-glob@3.0.1:
-    dependencies:
-      path-type: 4.0.0
 
   discord-api-types@0.38.43: {}
 
@@ -5910,8 +5612,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  esm@3.2.25: {}
-
   espree@10.4.0:
     dependencies:
       acorn: 8.16.0
@@ -5971,14 +5671,6 @@ snapshots:
 
   fast-diff@1.3.0: {}
 
-  fast-glob@3.3.3:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
-
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
@@ -5987,10 +5679,6 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fastq@1.20.1:
-    dependencies:
-      reusify: 1.1.0
-
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
@@ -5998,10 +5686,6 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
-
-  figlet@1.11.0:
-    dependencies:
-      commander: 14.0.3
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -6079,12 +5763,6 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
-  fs-extra@11.3.3:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.0
-      universalify: 2.0.1
-
   fs-monkey@1.1.0: {}
 
   fs.realpath@1.0.0: {}
@@ -6093,6 +5771,10 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  generate-function@2.3.1:
+    dependencies:
+      is-property: 1.0.2
 
   gensync@1.0.0-beta.2: {}
 
@@ -6119,12 +5801,6 @@ snapshots:
       es-object-atoms: 1.1.2
 
   get-stream@6.0.1: {}
-
-  getopts@2.3.0: {}
-
-  glob-parent@5.1.2:
-    dependencies:
-      is-glob: 4.0.3
 
   glob-parent@6.0.2:
     dependencies:
@@ -6155,15 +5831,6 @@ snapshots:
       minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
-
-  globby@11.1.0:
-    dependencies:
-      array-union: 2.1.0
-      dir-glob: 3.0.1
-      fast-glob: 3.3.3
-      ignore: 5.3.2
-      merge2: 1.4.1
-      slash: 3.0.0
 
   gopd@1.2.0: {}
 
@@ -6201,10 +5868,6 @@ snapshots:
 
   human-signals@2.1.0: {}
 
-  iconv-lite@0.6.3:
-    dependencies:
-      safer-buffer: 2.1.2
-
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -6234,8 +5897,6 @@ snapshots:
       cjs-module-lexer: 2.2.0
       module-details-from-path: 1.0.4
 
-  import-lazy@4.0.0: {}
-
   import-local@3.2.0:
     dependencies:
       pkg-dir: 4.2.0
@@ -6250,13 +5911,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  interpret@2.2.0: {}
-
   is-arrayish@0.2.1: {}
-
-  is-core-module@2.16.1:
-    dependencies:
-      hasown: 2.0.4
 
   is-extglob@2.1.1: {}
 
@@ -6271,6 +5926,8 @@ snapshots:
   is-interactive@1.0.0: {}
 
   is-number@7.0.0: {}
+
+  is-property@1.0.2: {}
 
   is-stream@2.0.1: {}
 
@@ -6638,8 +6295,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jju@1.4.0: {}
-
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -6677,24 +6332,7 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  knex@3.1.0(supports-color@8.1.1):
-    dependencies:
-      colorette: 2.0.19
-      commander: 10.0.1
-      debug: 4.3.4(supports-color@8.1.1)
-      escalade: 3.2.0
-      esm: 3.2.25
-      get-package-type: 0.1.0
-      getopts: 2.3.0
-      interpret: 2.2.0
-      lodash: 4.18.1
-      pg-connection-string: 2.6.2
-      rechoir: 0.8.0
-      resolve-from: 5.0.0
-      tarn: 3.0.2
-      tildify: 2.0.0
-    transitivePeerDependencies:
-      - supports-color
+  kysely@0.29.3: {}
 
   leven@3.1.0: {}
 
@@ -6732,6 +6370,8 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
+  long@5.3.2: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@11.2.7: {}
@@ -6740,9 +6380,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lru-cache@6.0.0:
-    dependencies:
-      yallist: 4.0.0
+  lru.min@1.1.4: {}
 
   luxon@3.7.2: {}
 
@@ -6762,14 +6400,6 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
-  mariadb@3.4.5:
-    dependencies:
-      '@types/geojson': 7946.0.16
-      '@types/node': 24.12.0
-      denque: 2.1.0
-      iconv-lite: 0.6.3
-      lru-cache: 10.4.3
-
   math-intrinsics@1.1.0: {}
 
   memfs@3.5.3:
@@ -6778,14 +6408,12 @@ snapshots:
 
   merge-stream@2.0.0: {}
 
-  merge2@1.4.1: {}
-
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
 
-  mikro-orm@6.6.10: {}
+  mikro-orm@7.1.6: {}
 
   mime-db@1.52.0: {}
 
@@ -6813,11 +6441,25 @@ snapshots:
 
   module-details-from-path@1.0.4: {}
 
-  ms@2.1.2: {}
-
   ms@2.1.3: {}
 
   mute-stream@2.0.0: {}
+
+  mysql2@3.22.6(@types/node@24.12.0):
+    dependencies:
+      '@types/node': 24.12.0
+      aws-ssl-profiles: 1.1.2
+      denque: 2.1.0
+      generate-function: 2.3.1
+      iconv-lite: 0.7.2
+      long: 5.3.2
+      lru.min: 1.1.4
+      named-placeholders: 1.1.6
+      sql-escaper: 1.5.1
+
+  named-placeholders@1.1.6:
+    dependencies:
+      lru.min: 1.1.4
 
   napi-postinstall@0.3.4: {}
 
@@ -6898,8 +6540,6 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
-  parent-require@1.0.0: {}
-
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -6912,8 +6552,6 @@ snapshots:
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
-
-  path-parse@1.0.7: {}
 
   path-scurry@1.11.1:
     dependencies:
@@ -6928,8 +6566,6 @@ snapshots:
   path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
-
-  pg-connection-string@2.6.2: {}
 
   pg-int8@1.0.1: {}
 
@@ -6958,8 +6594,6 @@ snapshots:
       find-up: 4.1.0
 
   pluralize@8.0.0: {}
-
-  pony-cause@2.1.11: {}
 
   postgres-array@2.0.0: {}
 
@@ -7002,8 +6636,6 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
-  queue-microtask@1.2.3: {}
-
   react-is@18.3.1: {}
 
   readable-stream@3.6.2:
@@ -7013,10 +6645,6 @@ snapshots:
       util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
-
-  rechoir@0.8.0:
-    dependencies:
-      resolve: 1.22.11
 
   reflect-metadata@0.2.2: {}
 
@@ -7039,22 +6667,10 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
-  resolve@1.22.11:
-    dependencies:
-      is-core-module: 2.16.1
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-
   restore-cursor@3.1.0:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
-
-  reusify@1.1.0: {}
-
-  run-parallel@1.2.0:
-    dependencies:
-      queue-microtask: 1.2.3
 
   rxjs@7.8.1:
     dependencies:
@@ -7078,10 +6694,6 @@ snapshots:
       ajv-keywords: 5.1.0(ajv@8.18.0)
 
   semver@6.3.1: {}
-
-  semver@7.5.4:
-    dependencies:
-      lru-cache: 6.0.0
 
   semver@7.7.4: {}
 
@@ -7115,13 +6727,13 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  sql-escaper@1.5.1: {}
+
   sqlstring@2.3.3: {}
 
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
-
-  string-argv@0.3.2: {}
 
   string-length@4.0.2:
     dependencies:
@@ -7172,8 +6784,6 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  supports-preserve-symlinks-flag@1.0.0: {}
-
   symbol-observable@4.0.0: {}
 
   synckit@0.11.12:
@@ -7181,8 +6791,6 @@ snapshots:
       '@pkgr/core': 0.2.9
 
   tapable@2.3.2: {}
-
-  tarn@3.0.2: {}
 
   terser-webpack-plugin@5.4.0(uglify-js@3.19.3)(webpack@5.104.1(uglify-js@3.19.3)):
     dependencies:
@@ -7206,8 +6814,6 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
       minimatch: 3.1.5
-
-  tildify@2.0.0: {}
 
   tinyglobby@0.2.15:
     dependencies:
@@ -7317,16 +6923,6 @@ snapshots:
       '@lukeed/csprng': 1.1.0
 
   uint8array-extras@1.5.0: {}
-
-  umzug@3.8.2(@types/node@24.12.0):
-    dependencies:
-      '@rushstack/ts-command-line': 4.23.7(@types/node@24.12.0)
-      emittery: 0.13.1
-      fast-glob: 3.3.3
-      pony-cause: 2.1.11
-      type-fest: 4.41.0
-    transitivePeerDependencies:
-      - '@types/node'
 
   undici-types@7.16.0: {}
 
@@ -7473,8 +7069,6 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
-
-  yallist@4.0.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,4 +3,4 @@ sonar.organization=dignityofwar
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.typescript.tsconfigPaths=tsconfig.json
 sonar.typescript.file.suffixes=.ts
-sonar.exclusions=**/*.spec.ts,src/database/migrations/*.ts,src/database/entities/*.ts,mikro-orm.config.ts
+sonar.exclusions=**/*.spec.ts,src/jest-*.js,src/database/migrations/*.ts,src/database/entities/*.ts,mikro-orm.config.ts

--- a/src/albion/services/albion.deregistration.service.spec.ts
+++ b/src/albion/services/albion.deregistration.service.spec.ts
@@ -193,13 +193,12 @@ describe('AlbionDeregistrationService', () => {
 
   describe('stripRegistration', () => {
     it('should remove registration and confirm', async () => {
-      const removeAndFlushSpy = jest
-        .spyOn(mockAlbionRegistrationsRepository.getEntityManager(), 'removeAndFlush')
-        .mockResolvedValue();
+      const entityManager = mockAlbionRegistrationsRepository.getEntityManager();
 
       await service.stripRegistration(mockRegistration, mockChannel);
 
-      expect(removeAndFlushSpy).toHaveBeenCalledWith(mockRegistration);
+      expect(entityManager.remove).toHaveBeenCalledWith(mockRegistration);
+      expect(entityManager.flush).toHaveBeenCalled();
       expect(mockChannel.send).toHaveBeenCalledWith(
         `Successfully deregistered Character ${mockRegistration.characterName}.`,
       );
@@ -208,7 +207,7 @@ describe('AlbionDeregistrationService', () => {
     it('should report error on failure', async () => {
       const error = new Error('DB fail');
       jest
-        .spyOn(mockAlbionRegistrationsRepository.getEntityManager(), 'removeAndFlush')
+        .spyOn(mockAlbionRegistrationsRepository.getEntityManager(), 'flush')
         .mockRejectedValue(error);
 
       await service.stripRegistration(mockRegistration, mockChannel);

--- a/src/albion/services/albion.deregistration.service.ts
+++ b/src/albion/services/albion.deregistration.service.ts
@@ -83,7 +83,7 @@ export class AlbionDeregistrationService {
   ): Promise<void> {
     // Remove the registration record from the database
     try {
-      await this.albionRegistrationsRepository.getEntityManager().removeAndFlush(registration);
+      await this.albionRegistrationsRepository.getEntityManager().remove(registration).flush();
       await responseChannel.send(`Successfully deregistered Character ${registration.characterName}.`);
     }
     catch (err) {

--- a/src/albion/services/albion.registration.retry.cron.service.spec.ts
+++ b/src/albion/services/albion.registration.retry.cron.service.spec.ts
@@ -85,9 +85,7 @@ describe('AlbionRegistrationRetryCronService', () => {
     queueRepo = {
       find: jest.fn(),
       findOne: jest.fn(),
-      getEntityManager: jest.fn().mockReturnValue({
-        flush: jest.fn().mockResolvedValue(true),
-      }),
+      getEntityManager: jest.fn().mockReturnValue(TestBootstrapper.getMockEntityManager()),
     };
 
     albionRegistrationService = {

--- a/src/albion/services/albion.registration.retry.cron.service.ts
+++ b/src/albion/services/albion.registration.retry.cron.service.ts
@@ -98,7 +98,8 @@ export class AlbionRegistrationRetryCronService implements OnApplicationBootstra
       this.logger.error(`Failed to get guild member for Discord ID ${attempt.discordId} during registration retry for character ${attempt.characterName}: ${err?.message ?? String(err)}`);
       attempt.status = AlbionRegistrationQueueStatus.FAILED;
       attempt.lastError = 'User is no longer in the Discord guild.';
-      await this.albionRegistrationQueueRepository.getEntityManager().flush();
+      // v7 no longer change-tracks scalar properties automatically, hence the explicit persist on every flush below.
+      await this.albionRegistrationQueueRepository.getEntityManager().persist(attempt).flush();
       await this.registrationQueueSend(
         `Registration attempt for character **${attempt.characterName}** has failed because the Discord member has left the server.`,
       );
@@ -117,14 +118,14 @@ export class AlbionRegistrationRetryCronService implements OnApplicationBootstra
       if (!inGuild) {
         attempt.attemptCount += 1;
         attempt.lastError = 'Character not found in guild yet.';
-        await this.albionRegistrationQueueRepository.getEntityManager().flush();
+        await this.albionRegistrationQueueRepository.getEntityManager().persist(attempt).flush();
         return;
       }
     }
     catch (err) {
       attempt.attemptCount += 1;
       attempt.lastError = `Failed to fetch guild members: ${err?.message ?? String(err)}`;
-      await this.albionRegistrationQueueRepository.getEntityManager().flush();
+      await this.albionRegistrationQueueRepository.getEntityManager().persist(attempt).flush();
       return;
     }
 
@@ -132,7 +133,7 @@ export class AlbionRegistrationRetryCronService implements OnApplicationBootstra
       attempt.attemptCount += 1;
       attempt.lastError = null;
 
-      await this.albionRegistrationQueueRepository.getEntityManager().flush();
+      await this.albionRegistrationQueueRepository.getEntityManager().persist(attempt).flush();
 
       // This is a scheduled attempt, so we must not re-run the normal registration validation that checks for existing queued attempts.
       await this.albionRegistrationService.handleRegistration(
@@ -146,7 +147,7 @@ export class AlbionRegistrationRetryCronService implements OnApplicationBootstra
 
       attempt.status = AlbionRegistrationQueueStatus.SUCCEEDED;
       attempt.lastError = null;
-      await this.albionRegistrationQueueRepository.getEntityManager().flush();
+      await this.albionRegistrationQueueRepository.getEntityManager().persist(attempt).flush();
 
       // Send a message in the queue channel to also say it was successful otherwise it's confusing and looks like something is wrong.
       await this.registrationQueueSend(`✅ Registration successful for **${attempt.characterName}**!`);
@@ -158,12 +159,12 @@ export class AlbionRegistrationRetryCronService implements OnApplicationBootstra
       // If the error looks like the character isn't in guild (our retryable case), keep it pending.
       // Everything else we treat as failed and we tell the user to try again / contact leadership.
       if (message.includes('has not been detected in')) {
-        await this.albionRegistrationQueueRepository.getEntityManager().flush();
+        await this.albionRegistrationQueueRepository.getEntityManager().persist(attempt).flush();
         return;
       }
 
       attempt.status = AlbionRegistrationQueueStatus.FAILED;
-      await this.albionRegistrationQueueRepository.getEntityManager().flush();
+      await this.albionRegistrationQueueRepository.getEntityManager().persist(attempt).flush();
 
       await this.registrationSend(
         `⚠️ Albion registration retry failed for <@${attempt.discordId}> (character **${attempt.characterName}**).\n\nReason: ${message}\n\nPlease try again or contact \`@ALB/Archmage\`.`,
@@ -188,7 +189,7 @@ export class AlbionRegistrationRetryCronService implements OnApplicationBootstra
   private async expireAttempt(attempt: AlbionRegistrationQueueEntity): Promise<void> {
     this.logger.log(`Expiring Albion registration attempt for Discord ID ${attempt.discordId} (character ${attempt.characterName})`);
     attempt.status = AlbionRegistrationQueueStatus.EXPIRED;
-    await this.albionRegistrationQueueRepository.getEntityManager().flush();
+    await this.albionRegistrationQueueRepository.getEntityManager().persist(attempt).flush();
 
     await this.registrationSend(
       `⏰ <@${attempt.discordId}> your registration attempt timed out. You are either truly not in the guild, or there is another problem. If you are in the guild, you are recommended to play the game for at least 1 hour, then retry registration. If you are not in the guild, then... why are you trying? :P`,

--- a/src/albion/services/albion.registration.service.spec.ts
+++ b/src/albion/services/albion.registration.service.spec.ts
@@ -62,9 +62,7 @@ describe('AlbionRegistrationService', () => {
       findOne: jest.fn(),
       nativeDelete: jest.fn().mockResolvedValue(1),
       flush: jest.fn().mockResolvedValue(true),
-      getEntityManager: jest.fn().mockReturnValue({
-        flush: jest.fn().mockResolvedValue(true),
-      }),
+      getEntityManager: jest.fn().mockReturnValue(TestBootstrapper.getMockEntityManager()),
     } as any;
 
     mockCharacter = TestBootstrapper.getMockAlbionCharacter(AlbionServer.EUROPE) as any;

--- a/src/albion/services/albion.registration.service.ts
+++ b/src/albion/services/albion.registration.service.ts
@@ -145,7 +145,8 @@ export class AlbionRegistrationService implements OnApplicationBootstrap {
     existing.lastError = 'Character name updated by user.';
     existing.expiresAt = expiresAt;
 
-    await this.albionRegistrationQueueRepository.getEntityManager().flush();
+    // v7 no longer change-tracks scalar properties automatically, so the entity has to be persisted explicitly.
+    await this.albionRegistrationQueueRepository.getEntityManager().persist(existing).flush();
 
     const expiresDiscordTime = `<t:${Math.floor(expiresAt.getTime() / 1000)}:f>`;
 

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
+import mikroOrmConfig from '../../mikro-orm.config';
 import { PS2VerificationAttemptEntity } from './entities/ps2.verification.attempt.entity';
 import { PS2MembersEntity } from './entities/ps2.members.entity';
 import { AlbionRegistrationsEntity } from './entities/albion.registrations.entity';
@@ -13,7 +14,7 @@ import { AlbionRegistrationQueueEntity } from './entities/albion.registration.qu
 
 @Module({
   imports: [
-    MikroOrmModule.forRoot(),
+    MikroOrmModule.forRoot(mikroOrmConfig),
     MikroOrmModule.forFeature({
       entities: [
         ActivityEntity,

--- a/src/database/entities/activity.entity.ts
+++ b/src/database/entities/activity.entity.ts
@@ -1,5 +1,5 @@
 import { BaseEntity } from './base.entity';
-import { Entity, Index, Property, Unique } from '@mikro-orm/core';
+import { Entity, Index, Property, Unique } from '@mikro-orm/decorators/legacy';
 
 interface ActivityEntityOptions {
   discordId: string;

--- a/src/database/entities/activity.statistics.entity.ts
+++ b/src/database/entities/activity.statistics.entity.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, BaseEntityOptions } from './base.entity';
-import { Entity, Property } from '@mikro-orm/core';
+import { Entity, Property } from '@mikro-orm/decorators/legacy';
 
 interface ActivityStatisticsEntityOptions extends BaseEntityOptions {
   totalUsers: number;

--- a/src/database/entities/albion.registration.queue.entity.ts
+++ b/src/database/entities/albion.registration.queue.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Enum, Index, Property, Unique } from '@mikro-orm/core';
+import { Entity, Enum, Index, Property, Unique } from '@mikro-orm/decorators/legacy';
 import { BaseEntity } from './base.entity';
 import { AlbionServer } from '../../albion/interfaces/albion.api.interfaces';
 

--- a/src/database/entities/albion.registrations.entity.ts
+++ b/src/database/entities/albion.registrations.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Index, Property, Unique } from '@mikro-orm/core';
+import { Entity, Index, Property, Unique } from '@mikro-orm/decorators/legacy';
 import { BaseEntity } from './base.entity';
 
 export interface AlbionRegistrationsEntityInterface {

--- a/src/database/entities/base.entity.ts
+++ b/src/database/entities/base.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+import { Entity, PrimaryKey, Property } from '@mikro-orm/decorators/legacy';
 
 export interface BaseEntityOptions {
   id?: number;

--- a/src/database/entities/joiner.leaver.entity.ts
+++ b/src/database/entities/joiner.leaver.entity.ts
@@ -1,5 +1,5 @@
 import { BaseEntity } from './base.entity';
-import { Entity, Index, Property, Unique } from '@mikro-orm/core';
+import { Entity, Index, Property, Unique } from '@mikro-orm/decorators/legacy';
 
 interface JoinerLeaverEntityOptions {
   discordId: string;

--- a/src/database/entities/joiner.leaver.statistics.entity.ts
+++ b/src/database/entities/joiner.leaver.statistics.entity.ts
@@ -1,5 +1,5 @@
 import { BaseEntity } from './base.entity';
-import { Entity, Property } from '@mikro-orm/core';
+import { Entity, Property } from '@mikro-orm/decorators/legacy';
 
 interface JoinerLeaverStatisticsEntityOptions {
   joiners: number;

--- a/src/database/entities/ps2.members.entity.ts
+++ b/src/database/entities/ps2.members.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Index, Property, Unique } from '@mikro-orm/core';
+import { Entity, Index, Property, Unique } from '@mikro-orm/decorators/legacy';
 import { BaseEntity } from './base.entity';
 
 export interface PS2MembersEntityInterface {

--- a/src/database/entities/ps2.verification.attempt.entity.ts
+++ b/src/database/entities/ps2.verification.attempt.entity.ts
@@ -1,5 +1,5 @@
 import { BaseEntity } from './base.entity';
-import { Entity, Index, Property, Unique } from '@mikro-orm/core';
+import { Entity, Index, Property, Unique } from '@mikro-orm/decorators/legacy';
 import { GuildMember, Message } from 'discord.js';
 
 interface PS2VerificationAttemptEntityOptions {

--- a/src/database/entities/role.metrics.entity.ts
+++ b/src/database/entities/role.metrics.entity.ts
@@ -1,5 +1,5 @@
 import { BaseEntity } from './base.entity';
-import { Entity, Property } from '@mikro-orm/core';
+import { Entity, Property } from '@mikro-orm/decorators/legacy';
 
 interface GameMetrics {
   [gameId: string]: number

--- a/src/database/services/database.service.spec.ts
+++ b/src/database/services/database.service.spec.ts
@@ -1,0 +1,91 @@
+import { Test } from '@nestjs/testing';
+import { GuildMember } from 'discord.js';
+import { getRepositoryToken } from '@mikro-orm/nestjs';
+import { EntityRepository } from '@mikro-orm/core';
+import { DatabaseService } from './database.service';
+import { ActivityEntity } from '../entities/activity.entity';
+import { TestBootstrapper } from '../../test.bootstrapper';
+
+describe('DatabaseService', () => {
+  let service: DatabaseService;
+  let mockActivityRepository: EntityRepository<ActivityEntity>;
+
+  const mockMember = {
+    id: '123456',
+    displayName: 'testuser',
+    nickname: null,
+    user: { username: 'testuser' },
+  } as unknown as GuildMember;
+
+  const mockActivityEntity = {
+    discordId: '123456',
+    discordNickname: 'testuser',
+  } as ActivityEntity;
+
+  beforeEach(async () => {
+    mockActivityRepository = TestBootstrapper.getMockRepositoryInjected(mockActivityEntity);
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        DatabaseService,
+        {
+          provide: getRepositoryToken(ActivityEntity),
+          useValue: mockActivityRepository,
+        },
+      ],
+    }).compile();
+
+    service = moduleRef.get<DatabaseService>(DatabaseService);
+    mockActivityRepository = moduleRef.get<EntityRepository<ActivityEntity>>(getRepositoryToken(ActivityEntity));
+
+    jest.spyOn(service['logger'], 'verbose');
+    jest.spyOn(service['logger'], 'error');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('updateActivity', () => {
+    it('should update the timestamp of an existing record', async () => {
+      mockActivityRepository.findOne = jest.fn().mockResolvedValue(mockActivityEntity);
+      const entityManager = mockActivityRepository.getEntityManager();
+
+      await service.updateActivity(mockMember);
+
+      expect(mockActivityRepository.findOne).toHaveBeenCalledWith({ discordId: mockMember.id });
+      // The explicit persist matters: v7 does not change-track scalars, so without it the flush is a no-op.
+      expect(entityManager.persist).toHaveBeenCalledWith(mockActivityEntity);
+      expect(entityManager.flush).toHaveBeenCalled();
+      expect(mockActivityEntity.lastActivity).toBeInstanceOf(Date);
+      expect(service['logger'].verbose).toHaveBeenCalledWith(`Updated activity for ${mockMember.id}`);
+    });
+
+    it('should create a record when the member has none', async () => {
+      mockActivityRepository.findOne = jest.fn().mockResolvedValue(null);
+      const entityManager = mockActivityRepository.getEntityManager();
+
+      await service.updateActivity(mockMember);
+
+      expect(entityManager.persist).toHaveBeenCalledWith(expect.objectContaining({
+        discordId: mockMember.id,
+        discordNickname: mockMember.displayName,
+      }));
+      expect(entityManager.flush).toHaveBeenCalled();
+    });
+
+    it('should log an error when the flush fails', async () => {
+      mockActivityRepository.findOne = jest.fn().mockResolvedValue(mockActivityEntity);
+      const entityManager = mockActivityRepository.getEntityManager();
+      entityManager.flush = jest.fn().mockRejectedValue(new Error('Database went boom!'));
+
+      await service.updateActivity(mockMember);
+
+      expect(service['logger'].error).toHaveBeenCalledWith(`Error updating activity for ${mockMember.id}: Database went boom!`);
+    });
+  });
+});

--- a/src/database/services/database.service.ts
+++ b/src/database/services/database.service.ts
@@ -31,7 +31,7 @@ export class DatabaseService {
     entity.lastActivity = new Date();
 
     try {
-      await this.activityRepository.getEntityManager().persistAndFlush(entity);
+      await this.activityRepository.getEntityManager().persist(entity).flush();
       this.logger.verbose(`Updated activity for ${member.id}`);
     }
     catch (err) {

--- a/src/general/events/guild.member.events.spec.ts
+++ b/src/general/events/guild.member.events.spec.ts
@@ -54,7 +54,7 @@ describe('GuildMemberEvents', () => {
       await service.onGuildMemberRemove(mockMember);
 
       expect(mockActivityRepository.findOne).not.toHaveBeenCalled();
-      expect(mockActivityRepository.getEntityManager().removeAndFlush).not.toHaveBeenCalled();
+      expect(mockActivityRepository.getEntityManager().remove).not.toHaveBeenCalled();
       expect(service['logger'].debug).not.toHaveBeenCalled();
       expect(service['logger'].log).not.toHaveBeenCalled();
       expect(service['logger'].warn).not.toHaveBeenCalled();
@@ -78,7 +78,7 @@ describe('GuildMemberEvents', () => {
 
       expect(mockActivityRepository.findOne).toHaveBeenCalledWith({ discordId: mockMember.id });
       expect(service['logger'].debug).toHaveBeenCalledWith(`Member "${mockMember.displayName}" has left the server.`);
-      expect(mockActivityRepository.getEntityManager().removeAndFlush).toHaveBeenCalledWith(mockActivityRecord);
+      expect(mockActivityRepository.getEntityManager().remove).toHaveBeenCalledWith(mockActivityRecord);
       expect(service['logger'].log).toHaveBeenCalledWith(`Removed activity record for leaver ${mockActivityRecord.discordNickname} (${mockActivityRecord.discordId})`);
     });
 
@@ -94,7 +94,7 @@ describe('GuildMemberEvents', () => {
       await service.onGuildMemberRemove(mockMember);
 
       expect(mockActivityRepository.findOne).toHaveBeenCalledWith({ discordId: '123' });
-      expect(mockActivityRepository.getEntityManager().removeAndFlush).not.toHaveBeenCalled();
+      expect(mockActivityRepository.getEntityManager().remove).not.toHaveBeenCalled();
       expect(service['logger'].debug).not.toHaveBeenCalled();
       expect(service['logger'].log).not.toHaveBeenCalled();
       expect(service['logger'].warn).toHaveBeenCalledWith('No activity record was found for leaver TestUser (123), likely left immediately after joining.');

--- a/src/general/events/guild.member.events.ts
+++ b/src/general/events/guild.member.events.ts
@@ -22,7 +22,7 @@ export class GuildMemberEvents {
     // If they have an activity record (they won't if they immediately left the server), delete it.
     if (activityRecord) {
       this.logger.debug(`Member "${member.displayName}" has left the server.`);
-      await this.activityRepository.getEntityManager().removeAndFlush(activityRecord);
+      await this.activityRepository.getEntityManager().remove(activityRecord).flush();
       this.logger.log(`Removed activity record for leaver ${activityRecord.discordNickname} (${activityRecord.discordId})`);
     }
     else {

--- a/src/general/services/activity.service.spec.ts
+++ b/src/general/services/activity.service.spec.ts
@@ -77,22 +77,22 @@ describe('ActivityService', () => {
     it('should remove the activity record', async () => {
       await activityService.removeActivityRecord(mockActivityEntity, false);
 
-      expect(mockActivityRepository.getEntityManager().removeAndFlush).toHaveBeenCalledWith(mockActivityEntity);
+      expect(mockActivityRepository.getEntityManager().remove).toHaveBeenCalledWith(mockActivityEntity);
     });
 
     it('should not remove the activity record on a dry run', async () => {
       await activityService.removeActivityRecord(mockActivityEntity, true);
-      expect(mockActivityRepository.getEntityManager().removeAndFlush).toHaveBeenCalledTimes(0);
+      expect(mockActivityRepository.getEntityManager().remove).toHaveBeenCalledTimes(0);
     });
 
     it('should properly handle database errors and throw an custom error', async () => {
-      mockActivityRepository.getEntityManager().removeAndFlush = jest.fn().mockImplementation(() => {throw new Error('Database went boom!');});
+      mockActivityRepository.getEntityManager().flush = jest.fn().mockImplementation(() => {throw new Error('Database went boom!');});
 
       await expect(activityService.removeActivityRecord(mockActivityEntity, false))
         .rejects
         .toThrow('Error removing activity record for leaver testuser (123456). Error: Database went boom!');
 
-      expect(mockActivityRepository.getEntityManager().removeAndFlush).toHaveBeenCalledTimes(1);
+      expect(mockActivityRepository.getEntityManager().flush).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -160,7 +160,7 @@ describe('ActivityService', () => {
 
       mockActivityRepository.findAll = jest.fn().mockResolvedValue(activityRecords);
 
-      mockActivityStatisticsRepository.getEntityManager().persistAndFlush = jest.fn();
+      mockActivityStatisticsRepository.getEntityManager().persist = jest.fn().mockReturnThis();
     });
 
     it('should collate activity records and create statistics', async () => {
@@ -185,11 +185,11 @@ describe('ActivityService', () => {
         },
       );
 
-      expect(mockActivityStatisticsRepository.getEntityManager().persistAndFlush).toHaveBeenCalledWith(mockStatistics);
+      expect(mockActivityStatisticsRepository.getEntityManager().persist).toHaveBeenCalledWith(mockStatistics);
     });
 
     it('should handle database errors', async () => {
-      mockActivityStatisticsRepository.getEntityManager().persistAndFlush = jest.fn().mockRejectedValue(new Error('Database error'));
+      mockActivityStatisticsRepository.getEntityManager().flush = jest.fn().mockRejectedValue(new Error('Database error'));
 
       await expect(activityService.enumerateActivity()).rejects.toThrow('Error enumerating activity records. Error: Database error');
     });

--- a/src/general/services/activity.service.ts
+++ b/src/general/services/activity.service.ts
@@ -22,7 +22,7 @@ export class ActivityService {
   ): Promise<void> {
     try {
       if (!dryRun) {
-        await this.activityRepository.getEntityManager().removeAndFlush(activityRecord);
+        await this.activityRepository.getEntityManager().remove(activityRecord).flush();
       }
       this.logger.log(`Removed activity record for leaver ${activityRecord.discordNickname} (${activityRecord.discordId})`);
     }
@@ -118,7 +118,7 @@ export class ActivityService {
       // Check if there is already a report on the same date, if so, delete it
       const existingReport = await this.activityStatisticsRepository.findOne({ createdAt: date });
       if (existingReport) {
-        await this.activityStatisticsRepository.getEntityManager().removeAndFlush(existingReport);
+        await this.activityStatisticsRepository.getEntityManager().remove(existingReport).flush();
         this.logger.warn(`Removed existing report for date ${date}`);
       }
 
@@ -139,7 +139,7 @@ export class ActivityService {
       });
 
       // Commit
-      await this.activityStatisticsRepository.getEntityManager().persistAndFlush(activityStatistics);
+      await this.activityStatisticsRepository.getEntityManager().persist(activityStatistics).flush();
     }
     catch (err) {
       const error = `Error enumerating activity records. Error: ${err.message}`;

--- a/src/general/services/joinerleaver.service.spec.ts
+++ b/src/general/services/joinerleaver.service.spec.ts
@@ -96,7 +96,7 @@ describe('JoinerLeaverService', () => {
 
       expect(mockJoinerLeaverRepository.findOne).toHaveBeenCalledWith({ discordId: mockGuildMember.id });
 
-      expect(mockJoinerLeaverRepository.getEntityManager().persistAndFlush).toHaveBeenCalledWith({
+      expect(mockJoinerLeaverRepository.getEntityManager().persist).toHaveBeenCalledWith({
         discordId: mockGuildMember.id,
         discordNickname: mockGuildMember.displayName,
         joinDate: expect.any(Date),
@@ -118,7 +118,7 @@ describe('JoinerLeaverService', () => {
 
       expect(mockJoinerLeaverRepository.findOne).toHaveBeenCalledWith({ discordId: mockGuildMember.id });
 
-      expect(mockJoinerLeaverRepository.getEntityManager().persistAndFlush).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockJoinerLeaverRepository.getEntityManager().persist).toHaveBeenCalledWith(expect.objectContaining({
         discordId: mockGuildMember.id,
         discordNickname: mockGuildMember.displayName,
         joinDate: expect.any(Date),
@@ -140,7 +140,7 @@ describe('JoinerLeaverService', () => {
 
       await joinerLeaverService.recordJoiner(mockGuildMember);
 
-      expect(mockJoinerLeaverRepository.getEntityManager().persistAndFlush).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockJoinerLeaverRepository.getEntityManager().persist).toHaveBeenCalledWith(expect.objectContaining({
         discordId: mockGuildMember.id,
         discordNickname: mockGuildMember.displayName,
         joinDate: expect.any(Date),
@@ -160,7 +160,7 @@ describe('JoinerLeaverService', () => {
       await joinerLeaverService.recordJoiner(mockMember);
 
       expect(mockJoinerLeaverRepository.findOne).not.toHaveBeenCalled();
-      expect(mockJoinerLeaverRepository.getEntityManager().persistAndFlush).not.toHaveBeenCalled();
+      expect(mockJoinerLeaverRepository.getEntityManager().persist).not.toHaveBeenCalled();
       expect(joinerLeaverService['logger'].log).not.toHaveBeenCalled();
     });
   });
@@ -175,7 +175,7 @@ describe('JoinerLeaverService', () => {
 
       expect(mockJoinerLeaverRepository.findOne).toHaveBeenCalledWith({ discordId: mockGuildMember.id });
 
-      expect(mockJoinerLeaverRepository.getEntityManager().persistAndFlush).toHaveBeenCalledWith(
+      expect(mockJoinerLeaverRepository.getEntityManager().persist).toHaveBeenCalledWith(
         expect.objectContaining({
           discordId: mockGuildMember.id,
           discordNickname: mockGuildMember.displayName,
@@ -209,7 +209,7 @@ describe('JoinerLeaverService', () => {
     await joinerLeaverService.recordLeaver(mockMember);
 
     expect(mockJoinerLeaverRepository.findOne).not.toHaveBeenCalled();
-    expect(mockJoinerLeaverRepository.getEntityManager().persistAndFlush).not.toHaveBeenCalled();
+    expect(mockJoinerLeaverRepository.getEntityManager().persist).not.toHaveBeenCalled();
     expect(joinerLeaverService['logger'].log).not.toHaveBeenCalled();
   });
 
@@ -280,7 +280,7 @@ Stats as of April 5th 2025
 
       expect(mockJoinerLeaverRepository.findAll).toHaveBeenCalled();
 
-      expect(mockJoinerLeaverStatisticsRepository.getEntityManager().persistAndFlush).toHaveBeenCalledWith({
+      expect(mockJoinerLeaverStatisticsRepository.getEntityManager().persist).toHaveBeenCalledWith({
         joiners: 6,
         leavers: 3,
         rejoiners: 1,

--- a/src/general/services/joinerleaver.service.ts
+++ b/src/general/services/joinerleaver.service.ts
@@ -42,7 +42,7 @@ export class JoinerLeaverService {
     record.joinDate = new Date();
 
     // Save the record
-    await this.joinerLeaverRepository.getEntityManager().persistAndFlush(record);
+    await this.joinerLeaverRepository.getEntityManager().persist(record).flush();
 
     this.logger.log(`Recorded joiner ${guildMember.user.tag} (${guildMember.id})`);
   }
@@ -57,7 +57,7 @@ export class JoinerLeaverService {
 
     if (record) {
       record.leaveDate = new Date();
-      await this.joinerLeaverRepository.getEntityManager().persistAndFlush(record);
+      await this.joinerLeaverRepository.getEntityManager().persist(record).flush();
       this.logger.log(`Recorded leaver ${guildMember.user.tag} (${guildMember.id})`);
     }
     else {
@@ -139,7 +139,7 @@ Stats as of April 5th 2025
     // Check if there is already a report on the same date, if so, delete it
     const existingReport = await this.joinerLeaverStatisticsRepository.findOne({ createdAt: date });
     if (existingReport) {
-      await this.joinerLeaverStatisticsRepository.getEntityManager().removeAndFlush(existingReport);
+      await this.joinerLeaverStatisticsRepository.getEntityManager().remove(existingReport).flush();
       this.logger.warn(`Removed existing report for date ${date}`);
     }
 
@@ -152,7 +152,7 @@ Stats as of April 5th 2025
       earlyLeavers,
       avgTimeToLeave,
     });
-    await this.joinerLeaverStatisticsRepository.getEntityManager().persistAndFlush(entity);
+    await this.joinerLeaverStatisticsRepository.getEntityManager().persist(entity).flush();
 
     this.logger.log('Enumerated joiner leavers');
   }

--- a/src/general/services/role.metrics.service.spec.ts
+++ b/src/general/services/role.metrics.service.spec.ts
@@ -377,7 +377,7 @@ Stats as of April 5th 2025. All statistics state members who have the role AND a
     it('should properly record the role metrics', async () => {
       await roleMetricsService.enumerateRoleMetrics(mockRoleList, mockGuild);
 
-      expect(mockRoleMetricsRepository.getEntityManager().persistAndFlush).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockRoleMetricsRepository.getEntityManager().persist).toHaveBeenCalledWith(expect.objectContaining({
         onboarded: 3, // NOT 4
         communityGames: {
           'Albion Online': 2,
@@ -404,7 +404,7 @@ Stats as of April 5th 2025. All statistics state members who have the role AND a
       mockRoleMetricsRepository.find = jest.fn().mockResolvedValue([mockRoleMetricsEntityToday]);
       await roleMetricsService.enumerateRoleMetrics(mockRoleList, mockGuild);
 
-      expect(mockRoleMetricsRepository.getEntityManager().removeAndFlush).toHaveBeenCalledWith([mockRoleMetricsEntityToday]);
+      expect(mockRoleMetricsRepository.getEntityManager().remove).toHaveBeenCalledWith([mockRoleMetricsEntityToday]);
     });
   });
 

--- a/src/general/services/role.metrics.service.ts
+++ b/src/general/services/role.metrics.service.ts
@@ -205,7 +205,7 @@ ${recGames}
     // If there is already a record, delete it
     const existingRecords = await this.roleMetricsRepository.find({ createdAt });
     if (existingRecords) {
-      await this.roleMetricsRepository.getEntityManager().removeAndFlush(existingRecords);
+      await this.roleMetricsRepository.getEntityManager().remove(existingRecords).flush();
     }
 
     // Create the role metrics entity
@@ -218,7 +218,7 @@ ${recGames}
     });
 
     // Persist the entity to the database
-    await this.roleMetricsRepository.getEntityManager().persistAndFlush(roleMetrics);
+    await this.roleMetricsRepository.getEntityManager().persist(roleMetrics).flush();
 
     this.logger.log('Role metrics enumeration completed.');
   }

--- a/src/jest-esm-transformer.js
+++ b/src/jest-esm-transformer.js
@@ -1,0 +1,29 @@
+// MikroORM v7 is published as native ESM. The app itself is fine — Node 24 can `require()` ESM —
+// but Jest's CommonJS runtime cannot, so its JS is transpiled down here (see transformIgnorePatterns
+// in jest.config.js). `import.meta.resolve` has no CommonJS form and would be emitted verbatim,
+// so it is swapped for the `require.resolve` equivalent, which takes the same specifiers.
+/* eslint-disable no-undef */
+const tsJest = require('ts-jest').default.createTransformer({
+  tsconfig: {
+    allowJs: true,
+    declaration: false,
+    isolatedModules: true,
+    module: 'commonjs',
+    moduleResolution: 'node10',
+    ignoreDeprecations: '6.0',
+  },
+});
+
+const IMPORT_META_RESOLVE = 'import.meta.resolve(';
+const SHIM = 'const __importMetaResolve = (s) => require(\'node:url\').pathToFileURL(require.resolve(s)).href;\n';
+
+const patch = (source) => (
+  source.includes(IMPORT_META_RESOLVE)
+    ? SHIM + source.split(IMPORT_META_RESOLVE).join('__importMetaResolve(')
+    : source
+);
+
+module.exports = {
+  process: (source, path, options) => tsJest.process(patch(source), path, options),
+  getCacheKey: (source, path, options) => tsJest.getCacheKey(patch(source), path, options),
+};

--- a/src/ps2/service/ps2.game.scanning.service.spec.ts
+++ b/src/ps2/service/ps2.game.scanning.service.spec.ts
@@ -376,7 +376,7 @@ describe('PS2GameScanningService', () => {
         false,
       );
 
-      expect(mockPS2MembersRepository.getEntityManager().removeAndFlush).toHaveBeenCalledWith(mockPS2MemberEntity);
+      expect(mockPS2MembersRepository.getEntityManager().remove).toHaveBeenCalledWith(mockPS2MemberEntity);
       expect(service['changesMap'].set).toHaveBeenCalledWith(
         mockPS2Character.character_id,
         {
@@ -395,7 +395,7 @@ describe('PS2GameScanningService', () => {
         true,
       );
 
-      expect(mockPS2MembersRepository.getEntityManager().removeAndFlush).toHaveBeenCalledTimes(0);
+      expect(mockPS2MembersRepository.getEntityManager().remove).toHaveBeenCalledTimes(0);
       expect(service['changesMap'].set).toHaveBeenCalledWith(
         mockPS2Character.character_id,
         {
@@ -421,7 +421,7 @@ describe('PS2GameScanningService', () => {
         true,
       );
 
-      expect(mockPS2MembersRepository.getEntityManager().removeAndFlush).toHaveBeenCalledTimes(0);
+      expect(mockPS2MembersRepository.getEntityManager().remove).toHaveBeenCalledTimes(0);
       expect(service['changesMap'].set).toHaveBeenCalledWith(
         mockPS2MemberEntity.characterId,
         {
@@ -464,7 +464,7 @@ describe('PS2GameScanningService', () => {
       expect(mockDiscordMember.roles.remove).toHaveBeenCalledTimes(2);
 
       // Asset the member was removed from the outfit database
-      expect(mockPS2MembersRepository.getEntityManager().removeAndFlush).toHaveBeenCalledTimes(1);
+      expect(mockPS2MembersRepository.getEntityManager().remove).toHaveBeenCalledTimes(1);
 
       // Asset the change was logged
       expect(service['changesMap'].set).toHaveBeenCalledWith(

--- a/src/ps2/service/ps2.game.scanning.service.ts
+++ b/src/ps2/service/ps2.game.scanning.service.ts
@@ -203,7 +203,7 @@ export class PS2GameScanningService {
     dryRun = false,
   ): Promise<void> {
     if (!dryRun) {
-      await this.ps2MembersRepository.getEntityManager().removeAndFlush(member);
+      await this.ps2MembersRepository.getEntityManager().remove(member).flush();
     }
 
     this.changesMap.set(member.characterId, {
@@ -252,7 +252,7 @@ export class PS2GameScanningService {
       }
     }
 
-    await this.ps2MembersRepository.getEntityManager().removeAndFlush(member);
+    await this.ps2MembersRepository.getEntityManager().remove(member).flush();
 
     this.changesMap.set(member.characterId, {
       character,

--- a/src/ps2/service/ps2.game.verification.service.ts
+++ b/src/ps2/service/ps2.game.verification.service.ts
@@ -106,7 +106,7 @@ export class PS2GameVerificationService implements OnApplicationBootstrap {
         characterName: character.name.first,
       },
     );
-    await this.ps2VerificationAttemptRepository.getEntityManager().persistAndFlush(verificationAttemptEntity);
+    await this.ps2VerificationAttemptRepository.getEntityManager().persist(verificationAttemptEntity).flush();
 
     // Force the message to wait so the reply is sent first and messages are rendered in the proper order
     setTimeout(async () => {
@@ -174,7 +174,7 @@ export class PS2GameVerificationService implements OnApplicationBootstrap {
       return 'ERROR';
     }
 
-    await this.ps2MembersRepository.getEntityManager().removeAndFlush(entity);
+    await this.ps2MembersRepository.getEntityManager().remove(entity).flush();
 
     await this.sendMessage(`🗑️ <@${targetMember.id}> your verification status has been manually removed by <@${createdByMember.id}>! You will need to re-verify yourself should you wish to regain full membership.
 ===================`);
@@ -197,7 +197,7 @@ export class PS2GameVerificationService implements OnApplicationBootstrap {
     // Flush any pending verification attempts that were in progress
     const verificationAttempts = await this.ps2VerificationAttemptRepository.findAll();
     for (const verificationAttempt of verificationAttempts) {
-      await this.ps2VerificationAttemptRepository.getEntityManager().removeAndFlush(verificationAttempt);
+      await this.ps2VerificationAttemptRepository.getEntityManager().remove(verificationAttempt).flush();
     }
 
     for (const verificationAttempt of verificationAttempts) {
@@ -275,7 +275,7 @@ export class PS2GameVerificationService implements OnApplicationBootstrap {
 
       try {
         const entity = await this.ps2VerificationAttemptRepository.find({ characterId: character.character_id });
-        await this.ps2VerificationAttemptRepository.getEntityManager().removeAndFlush(entity);
+        await this.ps2VerificationAttemptRepository.getEntityManager().remove(entity).flush();
       }
       catch (err) {
         // Fucked
@@ -320,7 +320,7 @@ export class PS2GameVerificationService implements OnApplicationBootstrap {
 
     try {
       const entity = await this.ps2VerificationAttemptRepository.find({ characterId: character.character_id });
-      await this.ps2VerificationAttemptRepository.getEntityManager().removeAndFlush(entity);
+      await this.ps2VerificationAttemptRepository.getEntityManager().remove(entity).flush();
     }
     catch (err) {
       const errorMessage = 'Failed to delete PS2 member verification attempt from the database!';

--- a/src/test.bootstrapper.ts
+++ b/src/test.bootstrapper.ts
@@ -41,8 +41,9 @@ const ps2RankMap: PS2RankMapInterface = {
 
 // Define a type for your EntityManager mock if you like:
 interface EntityManagerMock {
-  persistAndFlush: jest.Mock;
-  removeAndFlush: jest.Mock;
+  persist: jest.Mock;
+  remove: jest.Mock;
+  flush: jest.Mock;
 }
 
 // This file helps set up mocks for various tests, which have been copied and pasted across the suite, causing a lot of duplication.
@@ -57,18 +58,35 @@ export class TestBootstrapper {
     } as any;
   }
 
+  static getMockEntityManager(overrides?: Partial<EntityManagerMock>) {
+    const entityManagerMock: EntityManagerMock = {
+      persist: jest.fn(),
+      remove: jest.fn(),
+      flush: jest.fn().mockResolvedValue(true),
+      // Overrides let a test have, say, flush reject
+      ...overrides,
+    };
+    // persist()/remove() return the EM so `em.persist(x).flush()` chains as it does in MikroORM v7
+    entityManagerMock.persist.mockReturnValue(entityManagerMock);
+    entityManagerMock.remove.mockReturnValue(entityManagerMock);
+
+    return entityManagerMock as any;
+  }
+
   static mockORM() {
     const mockEntityManager = {
       find: jest.fn(),
-      persistAndFlush: jest.fn(),
+      persist: jest.fn(),
+      flush: jest.fn(),
       getRepository: jest.fn().mockReturnValue({
         find: jest.fn(),
       }),
       getEntityManager: jest.fn().mockResolvedValue({
         findOne: jest.fn(),
         find: jest.fn(),
-        persistAndFlush: jest.fn(),
-        removeAndFlush: jest.fn(),
+        persist: jest.fn(),
+        remove: jest.fn(),
+        flush: jest.fn(),
       }),
     } as any;
 
@@ -82,13 +100,7 @@ export class TestBootstrapper {
     entity: any,
     entityManagerOverrides?: Partial<EntityManagerMock>,
   ) {
-    const defaultEntityManagerMock: EntityManagerMock = {
-      persistAndFlush: jest.fn().mockResolvedValue(true),
-      removeAndFlush: jest.fn().mockResolvedValue(true),
-    };
-
-    // Merge in any overrides, for instance to have removeAndFlush reject
-    const entityManagerMock = { ...defaultEntityManagerMock, ...entityManagerOverrides };
+    const entityManagerMock = this.getMockEntityManager(entityManagerOverrides);
     return {
       find: jest.fn().mockResolvedValueOnce([entity]),
       findOne: jest.fn().mockResolvedValueOnce(entity),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "include": ["src/**/*", "mikro-orm.config.ts"],
   "exclude": ["node_modules", "dist"],
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,
@@ -11,6 +12,8 @@
     "target": "ES2022",
     "sourceMap": true,
     "outDir": "./dist",
+    // Matches what tsc already infers; without it ts-jest's per-file compiles trip TS5011.
+    "rootDir": ".",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": false,


### PR DESCRIPTION
Supersedes #697. Renovate's PR only bumped the packages, which left 54 compile errors — v7 has a long list of breaking changes that need code alongside it. This branch is that work, cut fresh from `main` so it also carries the TypeScript 6 bump.

## What v7 broke, and what was done about it

**Decorators moved out of core.** `Entity`, `Property`, `PrimaryKey`, `Index`, `Unique` and `Enum` now live in `@mikro-orm/decorators`, which has to be installed explicitly. All ten entities import from `@mikro-orm/decorators/legacy` (matching our `experimentalDecorators` setup). `ReflectMetadataProvider` moved with them and is no longer the default, so `mikro-orm.config.ts` now sets it explicitly — without it, entity metadata simply isn't discovered.

**`persistAndFlush` / `removeAndFlush` are gone.** Replaced throughout with `em.persist(entity).flush()` and `em.remove(entity).flush()`.

**Change detection is no longer automatic on scalar properties.** This is the one that would have bitten silently: a bare `flush()` after mutating an entity is now a no-op unless the entity is explicitly persisted. Every such site is in the Albion registration queue — the hourly retry cron and the character-rename requeue — so all eight of them now call `persist()`. Without this, queued registrations would have kept their status forever and the queue would never drain.

**`moduleResolution` must be `nodenext`, `node20` or `bundler`,** because v7 leans on `exports` maps that the legacy `node10` resolution can't read. `tsconfig.json` moves to `nodenext`, and `rootDir` is pinned to what tsc already infers — without it, per-file compiles trip the new TS6 diagnostic TS5011. That one is worth calling out separately: it already breaks `pnpm migration:up` on `main` today, as a consequence of the TypeScript 6 bump rather than this one. Confirmed by reproducing it on `main` in a scratch worktree.

**`MikroOrmModule.forRoot()` now requires the config,** so `database.module.ts` imports it directly instead of relying on the CLI config being discovered off disk.

**The CLI dropped ts-node** in favour of loaders we don't have (oxc, swc, tsx, jiti, tsimp). Rather than adding a native loader dependency, the CLI is pinned to the compiled output with `"mikro-orm": { "preferTs": false }` and now runs as the `mikro-orm` binary. That matches the workflow already documented in the README, where you have to `pnpm build` before running migrations. `migrations.pathTs` keeps newly created migrations emitting TypeScript into `src/database/migrations`, while `migrations.path` points the runner at `dist/`.

## The Jest wrinkle

MikroORM v7 is a native ESM package. The app itself is unaffected — Node 24 can `require()` ESM — but Jest's CommonJS runtime cannot, and throws `ERR_REQUIRE_ESM`. Transpiling the packages down is most of the answer, except `import.meta.resolve` (three call sites in core) has no CommonJS form and gets emitted verbatim, which is a syntax error.

`src/jest-esm-transformer.js` is a ~20 line wrapper around ts-jest that swaps those calls for the `require.resolve` equivalent before transpiling. It is confined to test infrastructure and doesn't touch what ships. The alternative was moving the whole suite to Jest's ESM mode, which would mean adding `--experimental-vm-modules`, importing `jest` from `@jest/globals` in all 32 spec files, and rewriting the six `jest.mock` call sites as `unstable_mockModule` — a much bigger blast radius for the same result.

Test mocks moved with the API: `TestBootstrapper` gained a shared `getMockEntityManager()` whose `persist()`/`remove()` return the manager so the new chained form works, and two specs that hand-rolled their own manager mock now use it.

## Validation

Against a local MariaDB:

- `migration:list`, `migration:up` and `migration:create` all work; `migration:create` still emits TypeScript into `src/database/migrations`.
- `schema:update --dump` produces the same diff under v6 and v7, checked side by side against `main` in a scratch worktree. The diff is pre-existing entity/migration drift on `main` (the queue entity's unique index and enum columns), not something this upgrade introduced — flagging it since it's worth a follow-up migration, but it's out of scope here.
- The app boots through `MikroOrmCoreModule`, `DatabaseModule` and every feature module, up to the point of connecting to Discord.
- Full suite green: 372 tests, 32 suites. `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016e1HuqQq3L6nE5cKYcMpYh
