### PR TITLE
ci: Give the build job write access for the coverage badges

### DIFF
--- a/.github/workflows/build-and-test-main.yml
+++ b/.github/workflows/build-and-test-main.yml
@@ -3,8 +3,10 @@ name: Build & Test Main
 on:
   workflow_call:
 
+# contents: write is for the coverage badge step, which commits the regenerated SVGs
+# back to main. Read is not enough and the push 403s.
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,18 @@ on:
   # after fixing something on the receiving side rather than in this repo.
   workflow_dispatch:
 
-# The release job needs contents: write to push the version bump and tag. A called
-# workflow cannot be granted more than its caller holds, so it has to be granted
-# here as well as inside release.yml.
+# The build and release jobs both need contents: write — build to push the coverage
+# badges, release to push the version bump and tag. A called workflow cannot be granted
+# more than its caller holds, so each has to be granted here as well as inside the
+# workflow it calls.
 permissions:
   contents: read
 
 jobs:
   build:
     name: Build & Test application
+    permissions:
+      contents: write
     uses: ./.github/workflows/build-and-test-main.yml
     secrets: inherit
 


### PR DESCRIPTION
The MikroORM v7 merge (#721) failed the pipeline on `main` at the coverage badge step:

```
remote: Permission to dignityofwar/diglet-bot.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/dignityofwar/diglet-bot/': The requested URL returned error: 403
```

This is a token permission problem, not a branch protection one. `jpb06/coverage-badges-action` commits the regenerated SVGs back to `main`, which needs `contents: write`. Declaring per-workflow token permissions in #703 left the build job on `contents: read`.

Two things kept it hidden until now:

- The action runs `git diff --quiet ./badges/*` before pushing and skips entirely when the badges are byte-identical. Every run since #703 has been a dependency bump that didn't move coverage, so it never tried to push. The v7 upgrade shifted the numbers (81.65% → 81.54% total) and it finally did.
- `pr.yml` has no badge step, so nothing about this is visible on a pull request. It only ever fails on `main`.

The grant is declared in both `ci.yml` and `build-and-test-main.yml` for the reason already documented above the caller's permissions block — a called workflow cannot hold more than its caller grants it, so `contents: write` in the called workflow alone would still resolve to `read`. Same treatment the release job already has.

Worth noting this is the second thing writing directly to `main` from CI, alongside the version bump. Neither has to work that way, and there's a separate conversation to be had about moving to a release-PR model so CI needs no write access to the default branch at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016e1HuqQq3L6nE5cKYcMpYh
