### PR TITLE
refactor(albion): Drop the server concept and the abandoned guild members table

### DIFF
--- a/src/albion/commands/register.command.spec.ts
+++ b/src/albion/commands/register.command.spec.ts
@@ -6,7 +6,6 @@ import { AlbionRegisterDto } from '../dto/albion.register.dto';
 import { ReflectMetadataProvider } from '@discord-nestjs/core';
 import { AlbionRegistrationService } from '../services/albion.registration.service';
 import { TestBootstrapper } from '../../test.bootstrapper';
-import { AlbionServer } from '../interfaces/albion.api.interfaces';
 
 const expectedChannelId = TestBootstrapper.mockConfig.discord.channels.albionRegistration;
 
@@ -72,7 +71,6 @@ describe('AlbionRegisterCommand', () => {
       expect(result).toBe('Registration request sent!');
       expect(command.registrationCommandProxy).toHaveBeenCalledWith(
         dto.character,
-        AlbionServer.EUROPE,
         mockDiscordUser.id,
         mockDiscordUser.guild.id,
         mockDiscordInteraction[0].channelId,
@@ -85,7 +83,6 @@ describe('AlbionRegisterCommand', () => {
     it('should call the registration service', async () => {
       await command.registrationCommandProxy(
         dto.character,
-        AlbionServer.EUROPE,
         mockDiscordUser.id,
         mockDiscordUser.guild.id,
         mockDiscordInteraction[0].channelId,
@@ -94,7 +91,6 @@ describe('AlbionRegisterCommand', () => {
 
       expect(albionRegistrationService.handleRegistration).toHaveBeenCalledWith(
         dto.character,
-        AlbionServer.EUROPE,
         mockDiscordUser.id,
         mockDiscordUser.guild.id,
         mockDiscordInteraction[0].channelId,
@@ -113,7 +109,6 @@ describe('AlbionRegisterCommand', () => {
 
       await command.registrationCommandProxy(
         dto.character,
-        AlbionServer.EUROPE,
         mockDiscordUser.id,
         mockDiscordUser.guild.id,
         mockDiscordInteraction[0].channelId,
@@ -122,7 +117,6 @@ describe('AlbionRegisterCommand', () => {
 
       expect(albionRegistrationService.handleRegistration).toHaveBeenCalledWith(
         dto.character,
-        AlbionServer.EUROPE,
         mockDiscordUser.id,
         mockDiscordUser.guild.id,
         mockDiscordInteraction[0].channelId,

--- a/src/albion/commands/register.command.ts
+++ b/src/albion/commands/register.command.ts
@@ -5,7 +5,6 @@ import { AlbionRegisterDto } from '../dto/albion.register.dto';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { AlbionRegistrationService } from '../services/albion.registration.service';
-import { AlbionServer } from '../interfaces/albion.api.interfaces';
 import { getChannel } from '../../discord/discord.hacks';
 
 @Command({
@@ -44,7 +43,6 @@ export class AlbionRegisterCommand {
 
     this.registrationCommandProxy(
       dto.character,
-      AlbionServer.EUROPE,
       member.id,
       member.guild.id,
       interaction[0].channelId,
@@ -58,7 +56,6 @@ export class AlbionRegisterCommand {
   // This is here so we can respond in the command immediately so the command doesn't "fail", and then handle the registration in the background
   async registrationCommandProxy(
     characterName: string,
-    server: AlbionServer,
     discordMemberId: string,
     discordMemberGuildId: string,
     discordChannelId: string,
@@ -67,7 +64,6 @@ export class AlbionRegisterCommand {
     try {
       await this.albionRegistrationService.handleRegistration(
         characterName,
-        server,
         discordMemberId,
         discordMemberGuildId,
         discordChannelId,

--- a/src/albion/commands/scan.command.ts
+++ b/src/albion/commands/scan.command.ts
@@ -37,7 +37,7 @@ export class AlbionScanCommand {
 
     const message = await interaction[0].channel.send('Starting Albion Members scan...');
 
-    this.albionScanningService.startScan(message, dto.dryRun, dto.server);
+    this.albionScanningService.startScan(message, dto.dryRun);
 
     return `Albion Scan initiated!${dto.dryRun ? ' [DRY RUN, NO CHANGES WILL ACTUALLY BE PERFORMED]' : ''}`;
   }

--- a/src/albion/dto/albion.register.dto.ts
+++ b/src/albion/dto/albion.register.dto.ts
@@ -1,5 +1,4 @@
 import { Param } from '@discord-nestjs/core';
-// import { AlbionServer } from '../interfaces/albion.api.interfaces';
 
 export class AlbionRegisterDto {
   @Param({
@@ -11,13 +10,4 @@ export class AlbionRegisterDto {
     maxLength: 16,
   })
   character: string;
-
-  // @Choice(AlbionServer)
-  // @Param({
-  //   name: 'server',
-  //   description:
-  //     'Which server are you on? Americas or Europe?',
-  //   required: true,
-  // })
-  //   server: AlbionServer;
 }

--- a/src/albion/dto/albion.scan.dto.ts
+++ b/src/albion/dto/albion.scan.dto.ts
@@ -1,15 +1,6 @@
-import { Choice, Param, ParamType } from '@discord-nestjs/core';
-import { AlbionServer } from '../interfaces/albion.api.interfaces';
+import { Param, ParamType } from '@discord-nestjs/core';
 
 export class AlbionScanDto {
-  @Choice(AlbionServer)
-  @Param({
-    name: 'server',
-    description:
-      'Which server to scan for? Americas or Europe?',
-    required: true,
-  })
-  server: AlbionServer;
   @Param({
     name: 'dry-run',
     description:

--- a/src/albion/factories/albion.axios.factory.spec.ts
+++ b/src/albion/factories/albion.axios.factory.spec.ts
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import AlbionAxiosFactory from './albion.axios.factory';
-import { AlbionServer } from '../interfaces/albion.api.interfaces';
 
 // Mocking the axios module
 jest.mock('axios');
@@ -23,20 +22,7 @@ describe('AlbionAxiosFactory', () => {
       },
     };
 
-    albionAxiosFactory.createApiClient(AlbionServer.EUROPE);
-    expect(mockedAxios.create).toHaveBeenCalledWith(expectedConfig);
-  });
-
-  it('should create an AxiosInstance with the correct configuration for Europe', () => {
-    // Arrange
-    const expectedConfig = {
-      baseURL: 'https://gameinfo-ams.albiononline.com/api/gameinfo',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    };
-
-    albionAxiosFactory.createApiClient(AlbionServer.EUROPE);
+    albionAxiosFactory.createApiClient();
     expect(mockedAxios.create).toHaveBeenCalledWith(expectedConfig);
   });
 });

--- a/src/albion/factories/albion.axios.factory.ts
+++ b/src/albion/factories/albion.axios.factory.ts
@@ -1,17 +1,8 @@
 import axios, { AxiosInstance } from 'axios';
-import { AlbionApiEndpoint, AlbionServer } from '../interfaces/albion.api.interfaces';
+import { AlbionApiEndpoint } from '../interfaces/albion.api.interfaces';
 
 export default class AlbionAxiosFactory {
-  public createApiClient(server: AlbionServer): AxiosInstance {
-    switch (server) {
-      case AlbionServer.EUROPE:
-        return this.createAlbionApiEuropeClient();
-      default:
-        throw new Error('Invalid Albion API region');
-    }
-  }
-
-  public createAlbionApiEuropeClient(): AxiosInstance {
+  public createApiClient(): AxiosInstance {
     return axios.create({
       baseURL: AlbionApiEndpoint.ALBION_EUROPE,
       headers: {

--- a/src/albion/interfaces/albion.api.interfaces.ts
+++ b/src/albion/interfaces/albion.api.interfaces.ts
@@ -1,11 +1,10 @@
-export enum AlbionServer {
-  EUROPE = 'Europe',
-}
-
 export enum AlbionApiEndpoint {
-  // ALBION_AMERICAS = 'https://gameinfo.albiononline.com/api/gameinfo',
   ALBION_EUROPE = 'https://gameinfo-ams.albiononline.com/api/gameinfo',
 }
+
+// DIG is EU-only, so this is a decoration rather than a distinction. It stays a constant
+// so the Discord messages that carried it read the same as before.
+export const ALBION_GUILD_EMOJI = '🇪🇺';
 
 // Seemingly this interface appears to always return null
 interface AlbionEquipmentInterface {

--- a/src/albion/services/albion.api.service.spec.ts
+++ b/src/albion/services/albion.api.service.spec.ts
@@ -8,7 +8,6 @@ import {
   AlbionApiEndpoint,
   AlbionPlayerInterface,
   AlbionPlayersResponseInterface,
-  AlbionServer,
 } from '../interfaces/albion.api.interfaces';
 
 const mockGuildId = TestBootstrapper.mockConfig.albion.guildId;
@@ -43,14 +42,14 @@ describe('AlbionApiService', () => {
       },
     };
 
-    jest.spyOn(AlbionAxiosFactory.prototype, 'createAlbionApiEuropeClient').mockReturnValue({
+    jest.spyOn(AlbionAxiosFactory.prototype, 'createApiClient').mockReturnValue({
       defaults: {
         baseURL: AlbionApiEndpoint.ALBION_EUROPE,
       },
       get: jest.fn().mockResolvedValue(searchResponse),
     } as any);
 
-    await expect(service.getCharacter('who.dis', AlbionServer.EUROPE))
+    await expect(service.getCharacter('who.dis'))
       .rejects
       .toThrow('Character **who.dis** does not seem to exist on the Europe server. Please ensure: \n1. You\'ve supplied your **exact** character name (case sensitive).\n2. Your character is older than 48 hours.');
   });
@@ -73,7 +72,7 @@ describe('AlbionApiService', () => {
       },
     };
 
-    jest.spyOn(AlbionAxiosFactory.prototype, 'createAlbionApiEuropeClient').mockReturnValue({
+    jest.spyOn(AlbionAxiosFactory.prototype, 'createApiClient').mockReturnValue({
       defaults: {
         baseURL: AlbionApiEndpoint.ALBION_EUROPE,
       },
@@ -82,7 +81,7 @@ describe('AlbionApiService', () => {
       }),
     } as any);
 
-    await expect(service.getCharacter('Maelstrome', AlbionServer.EUROPE))
+    await expect(service.getCharacter('Maelstrome'))
       .resolves
       .toStrictEqual(properResult);
   });
@@ -97,14 +96,14 @@ describe('AlbionApiService', () => {
       data: properResult,
     };
 
-    jest.spyOn(AlbionAxiosFactory.prototype, 'createAlbionApiEuropeClient').mockReturnValue({
+    jest.spyOn(AlbionAxiosFactory.prototype, 'createApiClient').mockReturnValue({
       defaults: {
         baseURL: AlbionApiEndpoint.ALBION_EUROPE,
       },
       get: jest.fn().mockResolvedValueOnce(response),
     } as any);
 
-    await expect(service.getCharacterById(id, AlbionServer.EUROPE))
+    await expect(service.getCharacterById(id))
       .resolves
       .toStrictEqual(properResult);
   });
@@ -122,7 +121,7 @@ describe('AlbionApiService', () => {
       },
     };
 
-    jest.spyOn(AlbionAxiosFactory.prototype, 'createAlbionApiEuropeClient').mockReturnValue({
+    jest.spyOn(AlbionAxiosFactory.prototype, 'createApiClient').mockReturnValue({
       defaults: {
         baseURL: AlbionApiEndpoint.ALBION_EUROPE,
       },
@@ -131,7 +130,7 @@ describe('AlbionApiService', () => {
       }),
     } as any);
 
-    await expect(service.getCharacter('Maelstrome', AlbionServer.EUROPE))
+    await expect(service.getCharacter('Maelstrome'))
       .rejects
       .toThrow(`Character ID \`${id}\` does not match API response consistently. Pinging <@${TestBootstrapper.mockConfig.discord.devUserId}>!`);
   });
@@ -160,7 +159,7 @@ describe('AlbionApiService', () => {
       },
     };
 
-    jest.spyOn(AlbionAxiosFactory.prototype, 'createAlbionApiEuropeClient').mockReturnValue({
+    jest.spyOn(AlbionAxiosFactory.prototype, 'createApiClient').mockReturnValue({
       defaults: {
         baseURL: AlbionApiEndpoint.ALBION_EUROPE,
       },
@@ -169,7 +168,7 @@ describe('AlbionApiService', () => {
         .mockResolvedValueOnce({ data: properResult }),
     } as any);
 
-    await expect(service.getCharacter(characterName, AlbionServer.EUROPE))
+    await expect(service.getCharacter(characterName))
       .resolves
       .toStrictEqual(properResult);
   });
@@ -197,7 +196,7 @@ describe('AlbionApiService', () => {
       },
     };
 
-    jest.spyOn(AlbionAxiosFactory.prototype, 'createAlbionApiEuropeClient').mockReturnValue({
+    jest.spyOn(AlbionAxiosFactory.prototype, 'createApiClient').mockReturnValue({
       defaults: {
         baseURL: AlbionApiEndpoint.ALBION_EUROPE,
       },
@@ -206,7 +205,7 @@ describe('AlbionApiService', () => {
         .mockResolvedValueOnce({ data: properResult }),
     } as any);
 
-    await expect(service.getCharacter(characterName, AlbionServer.EUROPE))
+    await expect(service.getCharacter(characterName))
       .rejects
       .toThrow(`multiple characters for **${characterName}** were found, none of them are a guild member.`);
   });
@@ -241,7 +240,7 @@ describe('AlbionApiService', () => {
       },
     };
 
-    jest.spyOn(AlbionAxiosFactory.prototype, 'createAlbionApiEuropeClient').mockReturnValue({
+    jest.spyOn(AlbionAxiosFactory.prototype, 'createApiClient').mockReturnValue({
       defaults: {
         baseURL: AlbionApiEndpoint.ALBION_EUROPE,
       },
@@ -249,7 +248,7 @@ describe('AlbionApiService', () => {
         .mockResolvedValueOnce(searchResponse),
     } as any);
 
-    await expect(service.getCharacter(characterName, AlbionServer.EUROPE))
+    await expect(service.getCharacter(characterName))
       .rejects
       .toThrow(`multiple characters for **NightRaven2511** were found within the DIG guild. This is an unsupported use case for this registration system. Pinging <@${TestBootstrapper.mockConfig.discord.devUserId}>!`);
   });
@@ -277,7 +276,7 @@ describe('AlbionApiService', () => {
       },
     };
 
-    jest.spyOn(AlbionAxiosFactory.prototype, 'createAlbionApiEuropeClient').mockReturnValue({
+    jest.spyOn(AlbionAxiosFactory.prototype, 'createApiClient').mockReturnValue({
       defaults: {
         baseURL: AlbionApiEndpoint.ALBION_EUROPE,
       },
@@ -286,7 +285,7 @@ describe('AlbionApiService', () => {
         .mockResolvedValueOnce(playerResponse),
     } as any);
 
-    const result = await service.getCharacter('R4L2E1', AlbionServer.EUROPE);
+    const result = await service.getCharacter('R4L2E1');
     expect(result.Name).toBe('R4L2E1');
   });
 
@@ -326,16 +325,16 @@ describe('AlbionApiService', () => {
       get: jest.fn().mockResolvedValue(mockResponse),
     } as any;
 
-    jest.spyOn(AlbionAxiosFactory.prototype, 'createAlbionApiEuropeClient').mockReturnValue(mockRequest);
+    jest.spyOn(AlbionAxiosFactory.prototype, 'createApiClient').mockReturnValue(mockRequest);
 
-    const receivedMembers = await service.getAllGuildMembers(guildId, AlbionServer.EUROPE);
+    const receivedMembers = await service.getAllGuildMembers(guildId);
 
     expect(receivedMembers).toEqual(mockMembers);
     expect(mockRequest.get).toHaveBeenCalledWith(`/guilds/${guildId}/members`);
   });
 
   describe('Europe', () => {
-    it('should properly return a character using expected client generated by createAlbionApiEuropeClient', async () => {
+    it('should properly return a character using expected client generated by createApiClient', async () => {
       const id = 'clhoV9OdRm-5BuYQYZBT_Q';
       const properResult = {
         'Id': id,
@@ -345,14 +344,14 @@ describe('AlbionApiService', () => {
         data: properResult,
       };
 
-      jest.spyOn(AlbionAxiosFactory.prototype, 'createAlbionApiEuropeClient').mockReturnValue({
+      jest.spyOn(AlbionAxiosFactory.prototype, 'createApiClient').mockReturnValue({
         defaults: {
           baseURL: AlbionApiEndpoint.ALBION_EUROPE,
         },
         get: jest.fn().mockResolvedValueOnce(response),
       } as any);
 
-      await expect(service.getCharacterById(id, AlbionServer.EUROPE))
+      await expect(service.getCharacterById(id))
         .resolves
         .toStrictEqual(properResult);
     });
@@ -370,7 +369,7 @@ describe('AlbionApiService', () => {
         },
       };
 
-      jest.spyOn(AlbionAxiosFactory.prototype, 'createAlbionApiEuropeClient').mockReturnValue({
+      jest.spyOn(AlbionAxiosFactory.prototype, 'createApiClient').mockReturnValue({
         defaults: {
           baseURL: AlbionApiEndpoint.ALBION_EUROPE,
         },
@@ -379,7 +378,7 @@ describe('AlbionApiService', () => {
           .mockResolvedValueOnce({ data: correctResult }),
       } as any);
 
-      await expect(service.getCharacter('Lilith1', AlbionServer.EUROPE))
+      await expect(service.getCharacter('Lilith1'))
         .resolves
         .toStrictEqual(correctResult);
     });
@@ -394,14 +393,14 @@ describe('AlbionApiService', () => {
         },
       };
 
-      jest.spyOn(AlbionAxiosFactory.prototype, 'createAlbionApiEuropeClient').mockReturnValue({
+      jest.spyOn(AlbionAxiosFactory.prototype, 'createApiClient').mockReturnValue({
         defaults: {
           baseURL: AlbionApiEndpoint.ALBION_EUROPE,
         },
         get: jest.fn().mockResolvedValueOnce(searchResponse).mockResolvedValueOnce({ data: correctResult }),
       } as any);
 
-      await expect(service.getCharacter('Dedalus17', AlbionServer.EUROPE))
+      await expect(service.getCharacter('Dedalus17'))
         .resolves
         .toStrictEqual(correctResult);
     });
@@ -411,14 +410,14 @@ describe('AlbionApiService', () => {
         data: JSON.parse(correctResultJson),
       };
 
-      jest.spyOn(AlbionAxiosFactory.prototype, 'createAlbionApiEuropeClient').mockReturnValue({
+      jest.spyOn(AlbionAxiosFactory.prototype, 'createApiClient').mockReturnValue({
         defaults: {
           baseURL: AlbionApiEndpoint.ALBION_EUROPE,
         },
         get: jest.fn().mockResolvedValueOnce(searchResponse),
       } as any);
 
-      await expect(service.getCharacterId('Lugasi', AlbionServer.EUROPE))
+      await expect(service.getCharacterId('Lugasi'))
         .resolves
         .toStrictEqual('JRlDBmqHS86m764x-jc96g');
     });
@@ -427,7 +426,6 @@ describe('AlbionApiService', () => {
   describe('checkCharacterGuildMembership', () => {
     it('should return true when direct character lookup indicates membership', async () => {
       const characterName = 'Maelstrome';
-      const server = AlbionServer.EUROPE;
       const guildId = mockGuildId;
 
       const char = { Id: '1', Name: characterName, GuildId: guildId } as any;
@@ -435,14 +433,13 @@ describe('AlbionApiService', () => {
       jest.spyOn(service, 'getCharacter').mockResolvedValue(char);
       jest.spyOn(service, 'getAllGuildMembers').mockResolvedValue([] as any);
 
-      await expect(service.checkCharacterGuildMembership(characterName, server, guildId))
+      await expect(service.checkCharacterGuildMembership(characterName, guildId))
         .resolves
         .toBe(true);
     });
 
     it('should return true when guild member list indicates membership even if character lookup says not in guild', async () => {
       const characterName = 'Maelstrome';
-      const server = AlbionServer.EUROPE;
       const guildId = mockGuildId;
 
       const char = { Id: '1', Name: characterName, GuildId: 'other' } as any;
@@ -451,14 +448,13 @@ describe('AlbionApiService', () => {
       jest.spyOn(service, 'getCharacter').mockResolvedValue(char);
       jest.spyOn(service, 'getAllGuildMembers').mockResolvedValue(members);
 
-      await expect(service.checkCharacterGuildMembership(characterName, server, guildId))
+      await expect(service.checkCharacterGuildMembership(characterName, guildId))
         .resolves
         .toBe(true);
     });
 
     it('should return false when both sources indicate not in guild', async () => {
       const characterName = 'Maelstrome';
-      const server = AlbionServer.EUROPE;
       const guildId = mockGuildId;
 
       const char = { Id: '1', Name: characterName, GuildId: 'other' } as any;
@@ -467,20 +463,19 @@ describe('AlbionApiService', () => {
       jest.spyOn(service, 'getCharacter').mockResolvedValue(char);
       jest.spyOn(service, 'getAllGuildMembers').mockResolvedValue(members);
 
-      await expect(service.checkCharacterGuildMembership(characterName, server, guildId))
+      await expect(service.checkCharacterGuildMembership(characterName, guildId))
         .resolves
         .toBe(false);
     });
 
     it('should return false when both checks fail', async () => {
       const characterName = 'Maelstrome';
-      const server = AlbionServer.EUROPE;
       const guildId = mockGuildId;
 
       jest.spyOn(service, 'getCharacter').mockRejectedValue(new Error('character down'));
       jest.spyOn(service, 'getAllGuildMembers').mockRejectedValue(new Error('members down'));
 
-      await expect(service.checkCharacterGuildMembership(characterName, server, guildId))
+      await expect(service.checkCharacterGuildMembership(characterName, guildId))
         .resolves
         .toBe(false);
     });

--- a/src/albion/services/albion.api.service.ts
+++ b/src/albion/services/albion.api.service.ts
@@ -4,7 +4,6 @@ import {
   AlbionPlayerInterface,
   AlbionPlayersResponseInterface,
   AlbionSearchResponseInterface,
-  AlbionServer,
 } from '../interfaces/albion.api.interfaces';
 import { ConfigService } from '@nestjs/config';
 
@@ -15,17 +14,17 @@ export class AlbionApiService {
     private readonly config: ConfigService,
   ) {}
 
-  async getCharacter(characterName: string, server: AlbionServer): Promise<AlbionPlayerInterface> {
-    const characterId = await this.getCharacterId(characterName, server);
-    return await this.queryCharacter(characterId, server);
+  async getCharacter(characterName: string): Promise<AlbionPlayerInterface> {
+    const characterId = await this.getCharacterId(characterName);
+    return await this.queryCharacter(characterId);
   }
 
-  async getCharacterById(characterId: string, server: AlbionServer): Promise<AlbionPlayerInterface> {
-    return await this.queryCharacter(characterId, server);
+  async getCharacterById(characterId: string): Promise<AlbionPlayerInterface> {
+    return await this.queryCharacter(characterId);
   }
 
-  async queryCharacter(characterId: string, server: AlbionServer): Promise<AlbionPlayerInterface> {
-    const request = new AlbionAxiosFactory().createApiClient(server);
+  async queryCharacter(characterId: string): Promise<AlbionPlayerInterface> {
+    const request = new AlbionAxiosFactory().createApiClient();
 
     const response: AlbionPlayersResponseInterface = await request.get(`/players/${characterId}`);
 
@@ -36,8 +35,8 @@ export class AlbionApiService {
     return response.data;
   }
 
-  async getCharacterId(characterName: string, server: AlbionServer): Promise<string> {
-    const request = new AlbionAxiosFactory().createApiClient(server);
+  async getCharacterId(characterName: string): Promise<string> {
+    const request = new AlbionAxiosFactory().createApiClient();
     const query = `/search?q=${characterName}`;
     this.logger.debug(`Querying Albion API for character ID: ${request.defaults.baseURL}${query}`);
     const response: AlbionSearchResponseInterface = await request.get(query);
@@ -76,8 +75,8 @@ export class AlbionApiService {
     return foundPlayer[0].Id;
   }
 
-  async getAllGuildMembers(guildId: string, server: AlbionServer): Promise<AlbionPlayerInterface[]> {
-    const request = new AlbionAxiosFactory().createApiClient(server);
+  async getAllGuildMembers(guildId: string): Promise<AlbionPlayerInterface[]> {
+    const request = new AlbionAxiosFactory().createApiClient();
     const response: AlbionPlayersResponseInterface = await request.get(`/guilds/${guildId}/members`);
     const data = response.data;
 
@@ -100,11 +99,10 @@ export class AlbionApiService {
    */
   async checkCharacterGuildMembership(
     characterName: string,
-    server: AlbionServer,
     guildId: string,
   ): Promise<boolean> {
-    const getCharacter = this.getCharacter(characterName, server).catch(() => undefined);
-    const getGuildMembers = this.getAllGuildMembers(guildId, server).catch(() => undefined);
+    const getCharacter = this.getCharacter(characterName).catch(() => undefined);
+    const getGuildMembers = this.getAllGuildMembers(guildId).catch(() => undefined);
 
     const [character, guildMembers] = await Promise.all([getCharacter, getGuildMembers]);
 

--- a/src/albion/services/albion.cron.service.ts
+++ b/src/albion/services/albion.cron.service.ts
@@ -4,7 +4,6 @@ import { TextChannel } from 'discord.js';
 import { ConfigService } from '@nestjs/config';
 import { DiscordService } from '../../discord/discord.service';
 import { AlbionScanningService } from './albion.scanning.service';
-import { AlbionServer } from '../interfaces/albion.api.interfaces';
 
 @Injectable()
 export class AlbionCronService implements OnApplicationBootstrap {
@@ -39,6 +38,6 @@ export class AlbionCronService implements OnApplicationBootstrap {
 
     const message = await this.channel.send('Starting EU Scans');
 
-    await this.albionScanningService.startScan(message, false, AlbionServer.EUROPE);
+    await this.albionScanningService.startScan(message, false);
   }
 }

--- a/src/albion/services/albion.deregistration.service.spec.ts
+++ b/src/albion/services/albion.deregistration.service.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { AlbionRegistrationsEntity } from '../../database/entities/albion.registrations.entity';
-import { AlbionPlayerInterface, AlbionServer } from '../interfaces/albion.api.interfaces';
+import { AlbionPlayerInterface } from '../interfaces/albion.api.interfaces';
 import { TestBootstrapper } from '../../test.bootstrapper';
 import { Test } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
@@ -25,7 +25,7 @@ describe('AlbionDeregistrationService', () => {
   let configService: jest.Mocked<ConfigService>;
 
   beforeEach(async () => {
-    mockCharacter = TestBootstrapper.getMockAlbionCharacter(AlbionServer.EUROPE);
+    mockCharacter = TestBootstrapper.getMockAlbionCharacter();
 
     mockRegistration = {
       id: 123456789,

--- a/src/albion/services/albion.registration.retry.cron.service.spec.ts
+++ b/src/albion/services/albion.registration.retry.cron.service.spec.ts
@@ -10,7 +10,7 @@ import {
 } from '../../database/entities/albion.registration.queue.entity';
 import { AlbionRegistrationService } from './albion.registration.service';
 import { TestBootstrapper } from '../../test.bootstrapper';
-import { AlbionServer } from '../interfaces/albion.api.interfaces';
+
 import { AlbionApiService } from './albion.api.service';
 
 describe('AlbionRegistrationRetryCronService', () => {
@@ -145,7 +145,6 @@ describe('AlbionRegistrationRetryCronService', () => {
       discordChannelId: 'dc1',
       discordId: 'u1',
       characterName: 'Char',
-      server: AlbionServer.EUROPE,
       expiresAt,
     });
 
@@ -171,7 +170,6 @@ describe('AlbionRegistrationRetryCronService', () => {
 
     expect(albionRegistrationService.handleRegistration).toHaveBeenCalledWith(
       'Char',
-      AlbionServer.EUROPE,
       'u1',
       'dg1',
       'dc1',
@@ -201,7 +199,6 @@ describe('AlbionRegistrationRetryCronService', () => {
       discordChannelId: 'dc1',
       discordId: 'u1',
       characterName: 'Char',
-      server: AlbionServer.EUROPE,
       expiresAt: new Date(Date.now() + 1000 * 60 * 60),
     });
 
@@ -229,7 +226,6 @@ describe('AlbionRegistrationRetryCronService', () => {
       discordChannelId: 'dc1',
       discordId: 'u1',
       characterName: 'Char',
-      server: AlbionServer.EUROPE,
       expiresAt: new Date(Date.now() + 1000 * 60 * 60),
     });
 
@@ -252,7 +248,6 @@ describe('AlbionRegistrationRetryCronService', () => {
       discordChannelId: 'dc1',
       discordId: 'u1',
       characterName: 'Char',
-      server: AlbionServer.EUROPE,
       expiresAt: new Date(Date.now() + 1000 * 60 * 60),
     });
 
@@ -280,7 +275,6 @@ describe('AlbionRegistrationRetryCronService', () => {
       discordChannelId: 'dc1',
       discordId: 'u1',
       characterName: 'Char',
-      server: AlbionServer.EUROPE,
       expiresAt: new Date(Date.now() - 1000),
     });
 
@@ -308,7 +302,6 @@ describe('AlbionRegistrationRetryCronService', () => {
       discordChannelId: 'dc1',
       discordId: 'u1',
       characterName: 'Char1',
-      server: AlbionServer.EUROPE,
       expiresAt: expiresAt1,
     });
 
@@ -319,7 +312,6 @@ describe('AlbionRegistrationRetryCronService', () => {
       discordChannelId: 'dc1',
       discordId: 'u2',
       characterName: 'Char2',
-      server: AlbionServer.EUROPE,
       expiresAt: expiresAt2,
     });
 
@@ -343,7 +335,6 @@ describe('AlbionRegistrationRetryCronService', () => {
       discordChannelId: 'dc1',
       discordId: 'u1',
       characterName: 'Char',
-      server: AlbionServer.EUROPE,
       expiresAt: new Date(Date.now() + 1000 * 60 * 60),
     });
 
@@ -368,7 +359,6 @@ describe('AlbionRegistrationRetryCronService', () => {
       discordChannelId: 'dc1',
       discordId: 'u1',
       characterName: 'Char',
-      server: AlbionServer.EUROPE,
       expiresAt: new Date(Date.now() + 1000 * 60 * 60),
     });
 
@@ -389,7 +379,6 @@ describe('AlbionRegistrationRetryCronService', () => {
       discordChannelId: 'dc1',
       discordId: 'u1',
       characterName: 'Char',
-      server: AlbionServer.EUROPE,
       expiresAt: new Date(Date.now() + 1000 * 60 * 60),
     });
 
@@ -412,7 +401,6 @@ describe('AlbionRegistrationRetryCronService', () => {
       discordChannelId: 'dc1',
       discordId: 'u1',
       characterName: 'Char',
-      server: AlbionServer.EUROPE,
       expiresAt: new Date(Date.now() + 1000 * 60 * 60),
     });
 
@@ -433,7 +421,6 @@ describe('AlbionRegistrationRetryCronService', () => {
       discordChannelId: 'dc1',
       discordId: 'u1',
       characterName: 'Char',
-      server: AlbionServer.EUROPE,
       expiresAt: new Date(Date.now() - 1000),
     });
 

--- a/src/albion/services/albion.registration.retry.cron.service.ts
+++ b/src/albion/services/albion.registration.retry.cron.service.ts
@@ -111,7 +111,6 @@ export class AlbionRegistrationRetryCronService implements OnApplicationBootstra
       const guildId = this.configService.get('albion.guildId');
       const inGuild = await this.albionApiService.checkCharacterGuildMembership(
         attempt.characterName,
-        attempt.server,
         guildId,
       );
 
@@ -138,7 +137,6 @@ export class AlbionRegistrationRetryCronService implements OnApplicationBootstra
       // This is a scheduled attempt, so we must not re-run the normal registration validation that checks for existing queued attempts.
       await this.albionRegistrationService.handleRegistration(
         attempt.characterName,
-        attempt.server,
         attempt.discordId,
         attempt.discordGuildId,
         attempt.discordChannelId,

--- a/src/albion/services/albion.registration.service.spec.ts
+++ b/src/albion/services/albion.registration.service.spec.ts
@@ -7,7 +7,7 @@ import { ConfigService } from '@nestjs/config';
 import { EntityRepository } from '@mikro-orm/core';
 import { getRepositoryToken } from '@mikro-orm/nestjs';
 import { AlbionRegistrationsEntity } from '../../database/entities/albion.registrations.entity';
-import { AlbionPlayerInterface, AlbionServer } from '../interfaces/albion.api.interfaces';
+import { ALBION_GUILD_EMOJI, AlbionPlayerInterface } from '../interfaces/albion.api.interfaces';
 import { TestBootstrapper } from '../../test.bootstrapper';
 import { AlbionApiService } from './albion.api.service';
 import {
@@ -65,15 +65,12 @@ describe('AlbionRegistrationService', () => {
       getEntityManager: jest.fn().mockReturnValue(TestBootstrapper.getMockEntityManager()),
     } as any;
 
-    mockCharacter = TestBootstrapper.getMockAlbionCharacter(AlbionServer.EUROPE) as any;
+    mockCharacter = TestBootstrapper.getMockAlbionCharacter() as any;
     mockDiscordUser = TestBootstrapper.getMockDiscordUser();
 
     mockRegistrationDataEU = {
       discordMember: mockDiscordUser,
       character: mockCharacter,
-      server: AlbionServer.EUROPE,
-      serverName: 'Europe',
-      serverEmoji: '🇪🇺',
       guildId: TestBootstrapper.mockConfig.albion.guildId,
       guildName: 'Dignity Of War',
       guildPingable: '@ALB/Archmage',
@@ -202,7 +199,7 @@ describe('AlbionRegistrationService', () => {
         discordService.getGuildMember = jest.fn().mockResolvedValue(null);
 
         await expect(service.validate(mockRegistrationDataEU)).rejects.toThrow(
-          `Sorry <@${mockDiscordUser.id}>, character **${mockCharacter.Name}** has already been registered for the ${mockRegistrationDataEU.serverEmoji} ${mockRegistrationDataEU.guildName} Guild, but the user who registered it has left the server.\n\n${contactMessage}`,
+          `Sorry <@${mockDiscordUser.id}>, character **${mockCharacter.Name}** has already been registered for the ${ALBION_GUILD_EMOJI} ${mockRegistrationDataEU.guildName} Guild, but the user who registered it has left the server.\n\n${contactMessage}`,
         );
       });
 
@@ -233,7 +230,7 @@ describe('AlbionRegistrationService', () => {
         discordService.getGuildMember = jest.fn().mockResolvedValue(mockDiscordUser2);
 
         await expect(service.validate(mockRegistrationDataEU)).rejects.toThrow(
-          `Sorry <@${mockDiscordUser.id}>, character **${mockCharacter.Name}** has already been registered for the ${mockRegistrationDataEU.serverEmoji} ${mockRegistrationDataEU.guildName} Guild by Discord user \`@${mockDiscordUser2.displayName}\`.\n\n${contactMessage}`,
+          `Sorry <@${mockDiscordUser.id}>, character **${mockCharacter.Name}** has already been registered for the ${ALBION_GUILD_EMOJI} ${mockRegistrationDataEU.guildName} Guild by Discord user \`@${mockDiscordUser2.displayName}\`.\n\n${contactMessage}`,
         );
       });
 
@@ -246,7 +243,7 @@ describe('AlbionRegistrationService', () => {
         });
 
         await expect(service.validate(mockRegistrationDataEU)).rejects.toThrow(
-          `Sorry <@${mockDiscordUser.id}>, character **${mockCharacter.Name}** has already been registered for the ${mockRegistrationDataEU.serverEmoji} ${mockRegistrationDataEU.guildName} Guild, but the user who registered it has left the server.\n\n${contactMessage}`,
+          `Sorry <@${mockDiscordUser.id}>, character **${mockCharacter.Name}** has already been registered for the ${ALBION_GUILD_EMOJI} ${mockRegistrationDataEU.guildName} Guild, but the user who registered it has left the server.\n\n${contactMessage}`,
         );
 
         expect(service['logger'].warn).toHaveBeenCalledWith(
@@ -265,7 +262,6 @@ describe('AlbionRegistrationService', () => {
           guildId: mockRegistrationDataEU.guildId,
           discordId: String(mockDiscordUser.id),
           characterName: mockCharacter.Name,
-          server: AlbionServer.EUROPE,
           discordChannelId: 'oldChannel',
           discordGuildId: 'oldGuild',
           status: AlbionRegistrationQueueStatus.PENDING,
@@ -297,7 +293,6 @@ describe('AlbionRegistrationService', () => {
           guildId: mockRegistrationDataEU.guildId,
           discordId: String(mockDiscordUser.id),
           characterName: 'OldChar',
-          server: AlbionServer.EUROPE,
           discordChannelId: 'oldChannel',
           discordGuildId: 'oldGuild',
           status: AlbionRegistrationQueueStatus.PENDING,
@@ -354,7 +349,6 @@ describe('AlbionRegistrationService', () => {
             guildId: mockRegistrationDataEU.guildId,
             discordId: 'some-other-user',
             characterName: mockCharacter.Name,
-            server: AlbionServer.EUROPE,
             discordChannelId: 'oldChannel',
             discordGuildId: 'oldGuild',
             status: AlbionRegistrationQueueStatus.PENDING,
@@ -408,7 +402,6 @@ describe('AlbionRegistrationService', () => {
           guildId: mockRegistrationDataEU.guildId,
           discordId: String(mockDiscordUser.id),
           characterName: mockCharacter.Name,
-          server: AlbionServer.EUROPE,
           discordChannelId: 'oldChannel',
           discordGuildId: 'oldGuild',
           status: AlbionRegistrationQueueStatus.PENDING,
@@ -437,7 +430,6 @@ describe('AlbionRegistrationService', () => {
         await expect(
           service.handleRegistration(
             mockRegistrationDataEU.character.Name,
-            mockRegistrationDataEU.server,
             mockRegistrationDataEU.discordMember.id,
             'foo1234',
             mockChannel.id,
@@ -457,7 +449,6 @@ describe('AlbionRegistrationService', () => {
         await expect(
           service.handleRegistration(
             mockRegistrationDataEU.character.Name,
-            mockRegistrationDataEU.server,
             mockRegistrationDataEU.discordMember.id,
             'foo1234',
             mockChannel.id,
@@ -478,7 +469,6 @@ describe('AlbionRegistrationService', () => {
         await expect(
           service.handleRegistration(
             mockRegistrationDataEU.character.Name,
-            mockRegistrationDataEU.server,
             mockRegistrationDataEU.discordMember.id,
             'foo1234',
             mockChannel.id,
@@ -499,7 +489,6 @@ describe('AlbionRegistrationService', () => {
         await expect(
           service.handleRegistration(
             mockRegistrationDataEU.character.Name,
-            mockRegistrationDataEU.server,
             mockRegistrationDataEU.discordMember.id,
             'foo1234',
             mockChannel.id,
@@ -517,7 +506,6 @@ describe('AlbionRegistrationService', () => {
 
         await service.handleRegistration(
           mockRegistrationDataEU.character.Name,
-          mockRegistrationDataEU.server,
           mockRegistrationDataEU.discordMember.id,
           'foo1234',
           mockChannel.id,
@@ -552,7 +540,6 @@ describe('AlbionRegistrationService', () => {
         await expect(
           service.handleRegistration(
             mockRegistrationDataEU.character.Name,
-            mockRegistrationDataEU.server,
             mockRegistrationDataEU.discordMember.id,
             'foo1234',
             mockChannel.id,
@@ -576,7 +563,6 @@ describe('AlbionRegistrationService', () => {
         await expect(
           service.handleRegistration(
             mockRegistrationDataEU.character.Name,
-            mockRegistrationDataEU.server,
             mockRegistrationDataEU.discordMember.id,
             'foo1234',
             mockChannel.id,
@@ -603,7 +589,6 @@ describe('AlbionRegistrationService', () => {
         await expect(
           service.handleRegistration(
             mockRegistrationDataEU.character.Name,
-            mockRegistrationDataEU.server,
             mockRegistrationDataEU.discordMember.id,
             'foo1234',
             mockChannel.id,
@@ -632,7 +617,6 @@ describe('AlbionRegistrationService', () => {
         await expect(
           service.handleRegistration(
             mockRegistrationDataEU.character.Name,
-            mockRegistrationDataEU.server,
             mockRegistrationDataEU.discordMember.id,
             'foo1234',
             mockChannel.id,
@@ -663,7 +647,6 @@ CC <@&${mockEULeaderRoleId}>, <@&${mockEUOfficerRoleId}>`,
         await expect(
           service.handleRegistration(
             mockRegistrationDataEU.character.Name,
-            mockRegistrationDataEU.server,
             mockRegistrationDataEU.discordMember.id,
             mockRegistrationDataEU.discordMember.guild.id,
             mockChannel.id,

--- a/src/albion/services/albion.registration.service.ts
+++ b/src/albion/services/albion.registration.service.ts
@@ -5,7 +5,7 @@ import { InjectRepository } from '@mikro-orm/nestjs';
 import { AlbionRegistrationsEntity } from '../../database/entities/albion.registrations.entity';
 import { EntityRepository } from '@mikro-orm/core';
 import { Channel, GuildMember, MessageFlags, TextChannel } from 'discord.js';
-import { AlbionPlayerInterface, AlbionServer } from '../interfaces/albion.api.interfaces';
+import { ALBION_GUILD_EMOJI, AlbionPlayerInterface } from '../interfaces/albion.api.interfaces';
 import { AlbionApiService } from './albion.api.service';
 import {
   AlbionRegistrationQueueEntity,
@@ -15,9 +15,6 @@ import {
 export interface RegistrationData {
   discordMember: GuildMember
   character: AlbionPlayerInterface
-  server: AlbionServer
-  serverName: string
-  serverEmoji: string
   guildId: string
   guildName: string
   guildPingable: string
@@ -138,7 +135,6 @@ export class AlbionRegistrationService implements OnApplicationBootstrap {
     const previousName = existing.characterName;
 
     existing.characterName = data.character.Name;
-    existing.server = data.server;
     existing.discordGuildId = data.discordMember.guild.id;
     existing.discordChannelId = this.verificationChannelId;
     existing.attemptCount = 0;
@@ -177,7 +173,6 @@ export class AlbionRegistrationService implements OnApplicationBootstrap {
   // This function will throw an error, which will be caught by its caller, and displayed to the user there.
   async handleRegistration(
     characterName: string,
-    server: AlbionServer,
     discordMemberId: string,
     discordGuildId: string,
     discordChannelId: string,
@@ -201,21 +196,18 @@ export class AlbionRegistrationService implements OnApplicationBootstrap {
     }
 
     try {
-      const charData = await this.albionApiService.getCharacter(characterName, server);
+      const charData = await this.albionApiService.getCharacter(characterName);
 
       const data: RegistrationData = {
         character: charData,
         discordMember: await this.discordService.getGuildMember(discordGuildId, discordMemberId),
-        server,
-        serverName: AlbionServer.EUROPE,
-        serverEmoji: '🇪🇺',
         guildId: this.config.get('albion.guildId'),
         guildName: 'Dignity Of War',
         guildPingable: '@ALB/Archmage',
       };
 
       this.logger.debug(
-        `Handling Albion character "${data.character.Name}" registration for "${data.discordMember.displayName}" on server "${data.server}"`,
+        `Handling Albion character "${data.character.Name}" registration for "${data.discordMember.displayName}"`,
       );
 
       await this.validate(data, options);
@@ -274,7 +266,7 @@ export class AlbionRegistrationService implements OnApplicationBootstrap {
 
     if (foundByDiscord?.discordId) {
       this.throwError(
-        `Sorry <@${data.discordMember.id}>, you have already registered a character named **${foundByDiscord.characterName}** for the ${data.serverEmoji} ${data.guildName} Guild. We don't allow multiple character registrations to the same Discord user.\n\n${contactMessage}`,
+        `Sorry <@${data.discordMember.id}>, you have already registered a character named **${foundByDiscord.characterName}** for the ${ALBION_GUILD_EMOJI} ${data.guildName} Guild. We don't allow multiple character registrations to the same Discord user.\n\n${contactMessage}`,
       );
     }
 
@@ -295,18 +287,17 @@ export class AlbionRegistrationService implements OnApplicationBootstrap {
     // If the person who originally registered the character has left the server
     if (!originalDiscordMember?.user?.id) {
       this.throwError(
-        `Sorry <@${data.discordMember.id}>, character **${data.character.Name}** has already been registered for the ${data.serverEmoji} ${data.guildName} Guild, but the user who registered it has left the server.\n\n${contactMessage}`,
+        `Sorry <@${data.discordMember.id}>, character **${data.character.Name}** has already been registered for the ${ALBION_GUILD_EMOJI} ${data.guildName} Guild, but the user who registered it has left the server.\n\n${contactMessage}`,
       );
     }
     this.throwError(
-      `Sorry <@${data.discordMember.id}>, character **${data.character.Name}** has already been registered for the ${data.serverEmoji} ${data.guildName} Guild by Discord user \`@${originalDiscordMember.displayName}\`.\n\n${contactMessage}`,
+      `Sorry <@${data.discordMember.id}>, character **${data.character.Name}** has already been registered for the ${ALBION_GUILD_EMOJI} ${data.guildName} Guild by Discord user \`@${originalDiscordMember.displayName}\`.\n\n${contactMessage}`,
     );
   }
 
   private async checkIfInGuild(data: RegistrationData) {
     const membership = await this.albionApiService.checkCharacterGuildMembership(
       data.character.Name,
-      data.server,
       data.guildId,
     );
 
@@ -333,7 +324,6 @@ export class AlbionRegistrationService implements OnApplicationBootstrap {
       discordChannelId: this.verificationChannelId,
       discordId: String(data.discordMember.user.id),
       characterName: data.character.Name,
-      server: data.server,
       attemptCount: 0,
       expiresAt,
       status: AlbionRegistrationQueueStatus.PENDING,
@@ -344,7 +334,7 @@ export class AlbionRegistrationService implements OnApplicationBootstrap {
     const expiresDiscordTime = `<t:${Math.floor(expiresAt.getTime() / 1000)}:f>`;
 
     this.throwError(
-      `<@${data.discordMember.id}> the character **${data.character.Name}** has not been detected in the ${data.serverEmoji} **${data.guildName}** Guild.\n\n ➡️ **Please ensure you have spelt your character __exactly__ correct as it appears in-game**. If you have mis-spelt it, please run the command again with the correct spelling.\n\n## ⏳ We will automatically retry your registration attempt hourly until ${expiresDiscordTime}.\n Sometimes our data source is slow to update, so please be patient. **If you are not a member of DIG, this WILL fail regardless.**`,
+      `<@${data.discordMember.id}> the character **${data.character.Name}** has not been detected in the ${ALBION_GUILD_EMOJI} **${data.guildName}** Guild.\n\n ➡️ **Please ensure you have spelt your character __exactly__ correct as it appears in-game**. If you have mis-spelt it, please run the command again with the correct spelling.\n\n## ⏳ We will automatically retry your registration attempt hourly until ${expiresDiscordTime}.\n Sometimes our data source is slow to update, so please be patient. **If you are not a member of DIG, this WILL fail regardless.**`,
     );
   }
 

--- a/src/albion/services/albion.reports.service.ts
+++ b/src/albion/services/albion.reports.service.ts
@@ -9,7 +9,7 @@
 // import { AlbionUtilities } from '../utilities/albion.utilities';
 // import { Message } from 'discord.js';
 // import { AlbionApiService } from './albion.api.service';
-// import { AlbionPlayerInterface, AlbionServer } from '../interfaces/albion.api.interfaces';
+// import { AlbionPlayerInterface } from '../interfaces/albion.api.interfaces';
 // import { getChannel } from '../../discord/discord.hacks';
 //
 // export class AlbionReportsService {
@@ -32,7 +32,7 @@
 //     let albionMembers: AlbionPlayerInterface[] = [];
 //
 //     try {
-//       albionMembers = await this.albionApiService.getAllGuildMembers(this.config.get('albion.guildId'), AlbionServer.EUROPE);
+//       albionMembers = await this.albionApiService.getAllGuildMembers(this.config.get('albion.guildId'));
 //     }
 //     catch (err) {
 //       this.logger.error(err);

--- a/src/albion/services/albion.scanning.service.spec.ts
+++ b/src/albion/services/albion.scanning.service.spec.ts
@@ -6,7 +6,7 @@ import { ConfigService } from '@nestjs/config';
 import { EntityRepository } from '@mikro-orm/core';
 import { getRepositoryToken } from '@mikro-orm/nestjs';
 import { AlbionRegistrationsEntity } from '../../database/entities/albion.registrations.entity';
-import { AlbionPlayerInterface, AlbionServer } from '../interfaces/albion.api.interfaces';
+import { ALBION_GUILD_EMOJI, AlbionPlayerInterface } from '../interfaces/albion.api.interfaces';
 import { AlbionScanningService } from './albion.scanning.service';
 import { AlbionApiService } from './albion.api.service';
 import { AlbionUtilities } from '../utilities/albion.utilities';
@@ -42,7 +42,7 @@ describe('AlbionScanningService', () => {
   let mockRegisteredMember: AlbionRegistrationsEntity;
 
   beforeEach(async () => {
-    mockCharacter = TestBootstrapper.getMockAlbionCharacter(AlbionServer.EUROPE);
+    mockCharacter = TestBootstrapper.getMockAlbionCharacter();
     mockRegisteredMember = {
       id: 123456789,
       discordId: '123456789',
@@ -107,42 +107,36 @@ describe('AlbionScanningService', () => {
             discordRoleId: mockGuildLeaderRoleId,
             priority: 1,
             keep: true,
-            server: AlbionServer.EUROPE,
           },
           {
             name: mockOfficerRoleName,
             discordRoleId: mockGuildOfficerRoleId,
             priority: 2,
             keep: false,
-            server: AlbionServer.EUROPE,
           },
           {
             name: mockAdeptRoleName,
             discordRoleId: mockAdeptRoleId,
             priority: 4,
             keep: false,
-            server: AlbionServer.EUROPE,
           },
           {
             name: mockGraduateName,
             discordRoleId: mockGraduateRoleId,
             priority: 5,
             keep: true,
-            server: AlbionServer.EUROPE,
           },
           {
             name: mockDiscipleName,
             discordRoleId: mockDiscipleRoleId,
             priority: 6,
             keep: false,
-            server: AlbionServer.EUROPE,
           },
           {
             name: mockRegisteredName,
             discordRoleId: mockRegisteredRoleId,
             priority: 7,
             keep: true,
-            server: AlbionServer.EUROPE,
           },
         ],
       },
@@ -198,7 +192,7 @@ describe('AlbionScanningService', () => {
       mockAlbionRegistrationsRepository.find = jest.fn().mockResolvedValueOnce([mockRegisteredMember]);
       service.gatherCharacters = jest.fn().mockResolvedValueOnce([]);
 
-      await service.startScan(mockDiscordMessage, false, AlbionServer.EUROPE);
+      await service.startScan(mockDiscordMessage, false);
 
       expect(mockDiscordMessage.edit).toHaveBeenCalledWith('## 🇪🇺 ❌ No characters were gathered from the API!');
     });
@@ -212,7 +206,7 @@ describe('AlbionScanningService', () => {
         throw new Error('Operation went boom');
       });
 
-      await service.startScan(mockDiscordMessage, false, AlbionServer.EUROPE);
+      await service.startScan(mockDiscordMessage, false);
 
       expect(mockDiscordMessage.edit).toHaveBeenLastCalledWith('## 🇪🇺 ❌ An error occurred while scanning!');
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('Error: Operation went boom');
@@ -225,7 +219,7 @@ describe('AlbionScanningService', () => {
       service.reverseRoleScan = jest.fn().mockResolvedValueOnce([]);
       service.roleInconsistencies = jest.fn().mockResolvedValueOnce([]);
 
-      await service.startScan(mockDiscordMessage, false, AlbionServer.EUROPE);
+      await service.startScan(mockDiscordMessage, false);
 
       expect(mockDiscordMessage.edit).toHaveBeenCalledWith('# 🇪🇺 Starting scan...');
       expect(mockDiscordMessage.edit).toHaveBeenCalledWith('# 🇪🇺 Task: [1/4] Gathering 1 characters from the ALB API...');
@@ -244,7 +238,7 @@ describe('AlbionScanningService', () => {
       service.reverseRoleScan = jest.fn().mockResolvedValueOnce([]);
       service.roleInconsistencies = jest.fn().mockResolvedValueOnce([]);
 
-      await service.startScan(mockDiscordMessage, false, AlbionServer.EUROPE);
+      await service.startScan(mockDiscordMessage, false);
 
       // Also expect functions to actually be called
       expect(service.gatherCharacters).toHaveBeenCalledTimes(1);
@@ -266,7 +260,7 @@ describe('AlbionScanningService', () => {
 
       const longText = 'Please review the above actions marked with (‼️) and make any necessary changes manually. To scan again without pinging, run the `/albion-scan` command with the `dry-run` flag set to `true`.';
 
-      await service.startScan(mockDiscordMessage, false, AlbionServer.EUROPE);
+      await service.startScan(mockDiscordMessage, false);
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith(`🔔 <@&${mockGuildLeaderRoleId}>, <@&${mockGuildOfficerRoleId}> ${longText}`);
     });
   });
@@ -278,7 +272,6 @@ describe('AlbionScanningService', () => {
         [mockRegisteredMember],
         mockDiscordMessage,
         0,
-        AlbionServer.EUROPE,
       );
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('🇪🇺 Gathering 1 characters from the Europe ALB API... (attempt #1)');
       expect(result).toEqual([mockCharacter]);
@@ -290,7 +283,6 @@ describe('AlbionScanningService', () => {
         [mockRegisteredMember],
         mockDiscordMessage,
         1,
-        AlbionServer.EUROPE,
       );
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('🇪🇺 Gathering 1 characters from the Europe ALB API... (attempt #2)');
     });
@@ -301,7 +293,6 @@ describe('AlbionScanningService', () => {
         [mockRegisteredMember],
         mockDiscordMessage,
         3,
-        AlbionServer.EUROPE,
       );
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith(`## ❌ An error occurred while gathering data for 1 characters! Giving up after 3 tries! Pinging <@${mockDevUserId}>!`);
       expect(result).toEqual(null);
@@ -316,7 +307,6 @@ describe('AlbionScanningService', () => {
         [mockRegisteredMember],
         mockDiscordMessage,
         0,
-        AlbionServer.EUROPE,
       );
       expect(setTimeout).toHaveBeenCalledTimes(1);
       expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 10000);
@@ -334,7 +324,6 @@ describe('AlbionScanningService', () => {
         [mockCharacter],
         mockDiscordMessage,
         false,
-        AlbionServer.EUROPE,
       );
 
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledTimes(3);
@@ -392,7 +381,6 @@ describe('AlbionScanningService', () => {
         [mockCharacter],
         mockDiscordMessage,
         false,
-        AlbionServer.EUROPE,
       );
 
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledTimes(3);
@@ -427,7 +415,6 @@ describe('AlbionScanningService', () => {
         [mockCharacter],
         mockDiscordMessage,
         false,
-        AlbionServer.EUROPE,
       );
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledTimes(3);
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('### 🇪🇺 Scanned 0/1 registered members...');
@@ -450,7 +437,6 @@ describe('AlbionScanningService', () => {
         [mockCharacter],
         mockDiscordMessage,
         true, // Dry run flagged here
-        AlbionServer.EUROPE,
       );
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledTimes(3);
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('### 🇪🇺 Scanned 0/1 registered members...');
@@ -478,7 +464,6 @@ describe('AlbionScanningService', () => {
         [mockCharacter],
         mockDiscordMessage,
         false,
-        AlbionServer.EUROPE,
       );
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('### 🇪🇺 Scanned 0/1 registered members...');
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('## 🇪🇺 🚪 1 leavers detected!');
@@ -499,7 +484,6 @@ describe('AlbionScanningService', () => {
         [mockCharacter],
         mockDiscordMessage,
         false,
-        AlbionServer.EUROPE,
       );
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledTimes(2);
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('### 🇪🇺 Scanned 0/1 registered members...');
@@ -515,7 +499,6 @@ describe('AlbionScanningService', () => {
         new Array(6).fill(mockCharacter),
         mockDiscordMessage,
         false,
-        AlbionServer.EUROPE,
       );
 
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledTimes(2);
@@ -576,7 +559,7 @@ describe('AlbionScanningService', () => {
           }
         });
 
-      await service.reverseRoleScan(mockDiscordMessage, false, AlbionServer.EUROPE);
+      await service.reverseRoleScan(mockDiscordMessage, false);
 
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('### 🇪🇺 Scanning 6 Discord roles for members who are falsely registered...');
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('🇪🇺 ✅ No invalid users were detected via Reverse Role Scan.');
@@ -651,7 +634,7 @@ describe('AlbionScanningService', () => {
           }
         });
 
-      await service.reverseRoleScan(mockDiscordMessage, false, AlbionServer.EUROPE);
+      await service.reverseRoleScan(mockDiscordMessage, false);
 
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('### 🇪🇺 Scanning 6 Discord roles for members who are falsely registered...');
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('## 🇪🇺 🚨 1 errors detected via Reverse Role Scan!\nAffected users have been **automatically** stripped of their incorrect roles.');
@@ -693,7 +676,7 @@ describe('AlbionScanningService', () => {
           }
         });
 
-      await service.reverseRoleScan(mockDiscordMessage, false, AlbionServer.EUROPE);
+      await service.reverseRoleScan(mockDiscordMessage, false);
 
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('### 🇪🇺 Scanning 6 Discord roles for members who are falsely registered...');
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('## 🇪🇺 🚨 1 errors detected via Reverse Role Scan!\nAffected users have been **automatically** stripped of their incorrect roles.');
@@ -737,7 +720,7 @@ describe('AlbionScanningService', () => {
           }
         });
 
-      await service.reverseRoleScan(mockDiscordMessage, false, AlbionServer.EUROPE);
+      await service.reverseRoleScan(mockDiscordMessage, false);
 
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('### 🇪🇺 Scanning 6 Discord roles for members who are falsely registered...');
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('## 🇪🇺 🚨 3 errors detected via Reverse Role Scan!\nAffected users have been **automatically** stripped of their incorrect roles.');
@@ -779,7 +762,7 @@ describe('AlbionScanningService', () => {
           }
         });
 
-      await service.reverseRoleScan(mockDiscordMessage, true, AlbionServer.EUROPE);
+      await service.reverseRoleScan(mockDiscordMessage, true);
 
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('### 🇪🇺 Scanning 6 Discord roles for members who are falsely registered...');
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('## 🇪🇺 🚨 1 errors detected via Reverse Role Scan!\nAffected users have been **automatically** stripped of their incorrect roles.');
@@ -798,7 +781,6 @@ describe('AlbionScanningService', () => {
         expected: [
           { id: mockGraduateRoleId, name: mockGraduateName, action: 'added', message: '' },
         ],
-        server: AlbionServer.EUROPE,
       },
       {
         title: 'Magister requires Graduate',
@@ -807,7 +789,6 @@ describe('AlbionScanningService', () => {
         expected: [
           { id: mockGraduateRoleId, name: mockGraduateName, action: 'added', message: '' },
         ],
-        server: AlbionServer.EUROPE,
       },
       {
         title: 'Adept requires Graduate',
@@ -816,21 +797,18 @@ describe('AlbionScanningService', () => {
         expected: [
           { id: mockGraduateRoleId, name: mockGraduateName, action: 'added', message: '' },
         ],
-        server: AlbionServer.EUROPE,
       },
       {
         title: 'Graduate has no extra roles',
         roles: [mockGraduateRoleId, mockRegisteredRoleId],
         highestPriorityRole: { id: mockGraduateRoleId, name: mockGraduateName },
         expected: [],
-        server: AlbionServer.EUROPE,
       },
       {
         title: 'Disciples has no extra roles',
         roles: [mockDiscipleRoleId, mockRegisteredRoleId],
         highestPriorityRole: { id: mockDiscipleRoleId, name: mockDiscipleName },
         expected: [],
-        server: AlbionServer.EUROPE,
       },
       {
         title: 'Guild Masters should not have Disciple, and should have Graduate',
@@ -840,7 +818,6 @@ describe('AlbionScanningService', () => {
           { id: mockGraduateRoleId, name: mockGraduateName, action: 'added', message: '' },
           { id: mockDiscipleRoleId, name: mockDiscipleName, action: 'removed', message: '' },
         ],
-        server: AlbionServer.EUROPE,
       },
       {
         title: 'Adepts should not have Disciple',
@@ -849,7 +826,6 @@ describe('AlbionScanningService', () => {
         expected: [
           { id: mockDiscipleRoleId, name: mockDiscipleName, action: 'removed', message: '' },
         ],
-        server: AlbionServer.EUROPE,
       },
       {
         title: 'Adepts should have graduate if missing',
@@ -858,7 +834,6 @@ describe('AlbionScanningService', () => {
         expected: [
           { id: mockGraduateRoleId, name: mockGraduateName, action: 'added', message: '' },
         ],
-        server: AlbionServer.EUROPE,
       },
       {
         title: 'Graduates should have Registered role',
@@ -867,7 +842,6 @@ describe('AlbionScanningService', () => {
         expected: [
           { id: mockRegisteredRoleId, name: mockRegisteredName, action: 'added', message: '' },
         ],
-        server: AlbionServer.EUROPE,
       },
       {
         title: 'Graduates should not have roles of lower priority (Disciple)',
@@ -876,7 +850,6 @@ describe('AlbionScanningService', () => {
         expected: [
           { id: mockDiscipleRoleId, name: mockDiscipleName, action: 'removed', message: '' },
         ],
-        server: AlbionServer.EUROPE,
       },
       {
         title: 'Disciples should always have ALB/Registered role',
@@ -885,7 +858,6 @@ describe('AlbionScanningService', () => {
         expected: [
           { id: mockRegisteredRoleId, name: mockRegisteredName, action: 'added', message: '' },
         ],
-        server: AlbionServer.EUROPE,
       },
       {
         title: 'Registered members should at least have the entry level role',
@@ -894,7 +866,6 @@ describe('AlbionScanningService', () => {
         expected: [
           { id: mockDiscipleRoleId, name: mockDiscipleName, action: 'missingEntryRole', message: '' },
         ],
-        server: AlbionServer.EUROPE,
       },
       {
         title: 'Disciple members should have at least registered role',
@@ -904,7 +875,6 @@ describe('AlbionScanningService', () => {
           { id: mockDiscipleRoleId, name: mockDiscipleName, action: 'added', message: '' },
           { id: mockRegisteredRoleId, name: mockRegisteredName, action: 'added', message: '' },
         ],
-        server: AlbionServer.EUROPE,
       },
     ];
 
@@ -918,7 +888,7 @@ describe('AlbionScanningService', () => {
 
     const generateMessage = (testCase, expected) => {
       // Dynamically generate the expected message
-      const serverEmoji = testCase.server === AlbionServer.EUROPE ? '🇪🇺' : '???';
+      const serverEmoji = ALBION_GUILD_EMOJI;
       let emoji = `${serverEmoji} ➕`;
       let reason = `their highest role is **${testCase.highestPriorityRole.name}**, and the role is marked as "keep".`;
 
@@ -947,14 +917,14 @@ describe('AlbionScanningService', () => {
 
     testCases.forEach(testCase => {
       it(`roleInconsistencies detects ${testCase.title}`, async () => {
-        const serverEmoji = testCase.server === AlbionServer.EUROPE ? '🇪🇺' : '???';
+        const serverEmoji = ALBION_GUILD_EMOJI;
         // Take the test case and fill in the expected messages, as it would be a PITA to define them at the array level
         testCase.expected.forEach((expected, i) => {
           testCase.expected[i].message = generateMessage(testCase, expected);
         });
         setupRoleTestMocks(testCase.roles);
 
-        const result = await service.checkRoleInconsistencies(mockDiscordUser, testCase.server);
+        const result = await service.checkRoleInconsistencies(mockDiscordUser);
 
         expect(result.length).toEqual(testCase.expected.length);
         result.forEach((r, i) => {
@@ -969,7 +939,7 @@ describe('AlbionScanningService', () => {
         });
 
         // Run it again except checking the messages it sends back
-        await service.roleInconsistencies(mockDiscordMessage, false, testCase.server);
+        await service.roleInconsistencies(mockDiscordMessage, false);
 
         if (testCase.expected.length === 0) {
           expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith(`${serverEmoji} ✅ No role inconsistencies were detected.`);
@@ -984,7 +954,7 @@ describe('AlbionScanningService', () => {
     it('roleInconsistencies should properly indicate progress when multiple users are involved', async () => {
       mockAlbionRegistrationsRepository.find = jest.fn().mockResolvedValueOnce([mockRegisteredMember, mockRegisteredMember, mockRegisteredMember, mockRegisteredMember, mockRegisteredMember]);
 
-      await service.roleInconsistencies(mockDiscordMessage, true, AlbionServer.EUROPE);
+      await service.roleInconsistencies(mockDiscordMessage, true);
 
       expect(mockDiscordMessage.channel.send).toHaveBeenCalledWith('## 🇪🇺 Scanning 5 members for role inconsistencies... [0/5]');
     });

--- a/src/albion/services/albion.scanning.service.ts
+++ b/src/albion/services/albion.scanning.service.ts
@@ -5,7 +5,7 @@ import { GuildMember, GuildTextBasedChannel, Message, Role } from 'discord.js';
 import { ConfigService } from '@nestjs/config';
 import { AlbionApiService } from './albion.api.service';
 import { AlbionRegistrationsEntity } from '../../database/entities/albion.registrations.entity';
-import { AlbionPlayerInterface, AlbionServer } from '../interfaces/albion.api.interfaces';
+import { ALBION_GUILD_EMOJI, AlbionPlayerInterface } from '../interfaces/albion.api.interfaces';
 import { AlbionRoleMapInterface } from '../../config/albion.app.config';
 import { AlbionUtilities } from '../utilities/albion.utilities';
 import { getChannel } from '../../discord/discord.hacks';
@@ -37,9 +37,8 @@ export class AlbionScanningService {
   async startScan(
     message: Message,
     dryRun = false,
-    server: AlbionServer = AlbionServer.EUROPE,
   ) {
-    const emoji = this.serverEmoji(server);
+    const emoji = ALBION_GUILD_EMOJI;
     const guildId = this.config.get('albion.guildId');
 
     await message.edit(`# ${emoji} Starting scan...`);
@@ -55,7 +54,7 @@ export class AlbionScanningService {
 
     try {
       await message.edit(`# ${emoji} Task: [1/4] Gathering ${length} characters from the ALB API...`);
-      characters = await this.gatherCharacters(guildMembers, message, 0, server);
+      characters = await this.gatherCharacters(guildMembers, message, 0);
     }
     catch (err) {
       await message.edit(`## ${emoji} ❌ An error occurred while gathering data from the API!`);
@@ -70,16 +69,16 @@ export class AlbionScanningService {
 
     try {
       await message.edit(`# ${emoji} Task: [2/4] Checking ${length} characters for membership status...`);
-      if (await this.removeLeavers(characters, message, dryRun, server)) {
+      if (await this.removeLeavers(characters, message, dryRun)) {
         actionRequired = true;
       }
 
       // Check if members have roles they shouldn't have
       await message.edit(`# ${emoji} Task: [3/4] Performing reverse role scan...`);
-      await this.reverseRoleScan(message, dryRun, server);
+      await this.reverseRoleScan(message, dryRun);
 
       await message.edit(`# ${emoji} Task: [4/4] Checking for role inconsistencies...`);
-      if (await this.roleInconsistencies(message, dryRun, server)) {
+      if (await this.roleInconsistencies(message, dryRun)) {
         actionRequired = true;
       }
     }
@@ -106,9 +105,8 @@ export class AlbionScanningService {
     guildMembers: AlbionRegistrationsEntity[],
     message: Message,
     tries = 0,
-    server: AlbionServer = AlbionServer.EUROPE,
   ) {
-    const emoji = this.serverEmoji(server);
+    const emoji = ALBION_GUILD_EMOJI;
     const characterPromises: Promise<AlbionPlayerInterface>[] = [];
     tries++;
     const length = guildMembers.length;
@@ -116,10 +114,10 @@ export class AlbionScanningService {
       await getChannel(message).send(`## ❌ An error occurred while gathering data for ${length} characters! Giving up after 3 tries! Pinging <@${this.config.get('discord.devUserId')}>!`);
       return null;
     }
-    const statusMessage = await getChannel(message).send(`${emoji} Gathering ${length} characters from the ${server} ALB API... (attempt #${tries})`);
+    const statusMessage = await getChannel(message).send(`${emoji} Gathering ${length} characters from the Europe ALB API... (attempt #${tries})`);
 
     for (const member of guildMembers) {
-      characterPromises.push(this.albionApiService.getCharacterById(member.characterId, server));
+      characterPromises.push(this.albionApiService.getCharacterById(member.characterId));
     }
 
     try {
@@ -128,10 +126,10 @@ export class AlbionScanningService {
     }
     catch (err) {
       await statusMessage.delete();
-      const tempMessage = await getChannel(message).send(`## ⚠️ Couldn't gather characters from ${server} ALB API.\nError: "${err.message}".\nRetrying in 10s...`);
+      const tempMessage = await getChannel(message).send(`## ⚠️ Couldn't gather characters from Europe ALB API.\nError: "${err.message}".\nRetrying in 10s...`);
       await new Promise(resolve => setTimeout(resolve, 10000));
       await tempMessage.delete();
-      return this.gatherCharacters(guildMembers, message, tries, server);
+      return this.gatherCharacters(guildMembers, message, tries);
     }
   }
 
@@ -139,9 +137,8 @@ export class AlbionScanningService {
     characters: AlbionPlayerInterface[],
     message: Message,
     dryRun = false,
-    server: AlbionServer = AlbionServer.EUROPE,
   ): Promise<boolean> {
-    const emoji = this.serverEmoji(server);
+    const emoji = ALBION_GUILD_EMOJI;
     const guildId = this.config.get('albion.guildId');
     // Save all the characters to a map we can easily pick out later via character ID
     const charactersMap = new Map<string, AlbionPlayerInterface>();
@@ -258,16 +255,13 @@ export class AlbionScanningService {
   async reverseRoleScan(
     message: Message,
     dryRun = false,
-    server: AlbionServer = AlbionServer.EUROPE,
   ) {
     const guildId = this.config.get('albion.guildId');
-    const emoji = this.serverEmoji(server);
+    const emoji = ALBION_GUILD_EMOJI;
 
     // Get the list of roles via the Role Map
     const roleMap: AlbionRoleMapInterface[] = this.config.get('albion.roleMap');
-    // Filter to only the server we care about
-    const roleMapServer = roleMap.filter((role) => role.server === server);
-    const roleMapLength = roleMapServer.length;
+    const roleMapLength = roleMap.length;
 
     const scanMessage = await getChannel(message).send(`### ${emoji} Scanning ${roleMapLength} Discord roles for members who are falsely registered...`);
     const scanCountMessage = await getChannel(message).send('.');
@@ -279,7 +273,7 @@ export class AlbionScanningService {
 
     // Loop each role and scan them
     let count = 0;
-    for (const role of roleMapServer) {
+    for (const role of roleMap) {
       count++;
       let discordRole: Role;
 
@@ -380,10 +374,9 @@ export class AlbionScanningService {
   async roleInconsistencies(
     message: Message,
     dryRun = false,
-    server: AlbionServer = AlbionServer.EUROPE,
   ): Promise<boolean> {
     const suggestions: string[] = [];
-    const emoji = this.serverEmoji(server);
+    const emoji = ALBION_GUILD_EMOJI;
     const guildId = this.config.get('albion.guildId');
     let actionRequired = false;
 
@@ -411,7 +404,7 @@ export class AlbionScanningService {
       }
 
       // Get the role inconsistencies
-      const inconsistencies = await this.checkRoleInconsistencies(discordMember, server);
+      const inconsistencies = await this.checkRoleInconsistencies(discordMember);
 
       if (inconsistencies.length > 0) {
         actionRequired = true;
@@ -450,9 +443,8 @@ export class AlbionScanningService {
 
   async checkRoleInconsistencies(
     discordMember: GuildMember,
-    server: AlbionServer = AlbionServer.EUROPE,
   ): Promise<RoleInconsistencyResult[]> {
-    const serverEmoji = this.serverEmoji(server);
+    const serverEmoji = ALBION_GUILD_EMOJI;
     // If the user is excluded from role inconsistency checks, skip them
     const excludedUsers: string[] = this.config.get('albion.scanExcludedUsers');
     if (excludedUsers.includes(discordMember.id)) {
@@ -465,16 +457,8 @@ export class AlbionScanningService {
 
     // If no roles were found, they must have at least registered and initiate
     if (!highestPriorityRole) {
-      let entryRole: AlbionRoleMapInterface;
-      let registeredRole: AlbionRoleMapInterface;
-
-      if (server === AlbionServer.EUROPE) {
-        entryRole = roleMap.filter((role) => role.name === '@ALB/Disciple')[0];
-        registeredRole = roleMap.filter((role) => role.name === '@ALB/Registered')[0];
-      }
-      else {
-        throw new Error('Invalid server!');
-      }
+      const entryRole = roleMap.filter((role) => role.name === '@ALB/Disciple')[0];
+      const registeredRole = roleMap.filter((role) => role.name === '@ALB/Registered')[0];
 
       const action = 'added';
       const reason = 'they have no roles but are registered!';
@@ -496,7 +480,7 @@ export class AlbionScanningService {
     // If their highest role is registered, this shouldn't be the case. They should have at least the entry level role.
     // We need to get the role for the server they're on, and the priority above the registered priority.
     if (highestPriorityRole.name.includes('Registered')) {
-      const entryRole = roleMap.filter((role) => role.server === server && role.priority === highestPriorityRole.priority - 1)[0];
+      const entryRole = roleMap.filter((role) => role.priority === highestPriorityRole.priority - 1)[0];
       const action = 'added';
       const reason = 'they are registered but don\'t have at least the entry level role!';
 
@@ -511,10 +495,6 @@ export class AlbionScanningService {
 
     // Otherwise, this is based off priority of the highest priority role.
     roleMap.forEach((role) => {
-      // If the role is for the wrong server, skip it
-      if (role.server !== server) {
-        return;
-      }
       const shouldHaveRole = role.priority === highestPriorityRole?.priority || (role.priority > highestPriorityRole?.priority && role.keep);
       const hasRole = discordMember.roles.cache.has(role.discordRoleId);
 
@@ -545,9 +525,5 @@ export class AlbionScanningService {
     });
 
     return inconsistencies;
-  }
-
-  serverEmoji(server: AlbionServer) {
-    return server === AlbionServer.EUROPE ? '🇪🇺' : '???';
   }
 }

--- a/src/config/albion.app.config.ts
+++ b/src/config/albion.app.config.ts
@@ -1,11 +1,8 @@
-import { AlbionServer } from '../albion/interfaces/albion.api.interfaces';
-
 export interface AlbionRoleMapInterface {
   name: string,
   discordRoleId: string;
   priority: number;
   keep: boolean
-  server: AlbionServer
 }
 
 const rolesToRankProduction: AlbionRoleMapInterface[] = [
@@ -14,49 +11,42 @@ const rolesToRankProduction: AlbionRoleMapInterface[] = [
     discordRoleId: '1218115619732455474',
     priority: 1,
     keep: true,
-    server: AlbionServer.EUROPE,
   },
   {
     name: '@ALB/Magister',
     discordRoleId: '1218115569455464498',
     priority: 2,
     keep: false,
-    server: AlbionServer.EUROPE,
   },
   {
     name: '@ALB/EldritchMager',
     discordRoleId: '1218115480426905641',
     priority: 3,
     keep: false,
-    server: AlbionServer.EUROPE,
   },
   {
     name: '@ALB/Adept',
     discordRoleId: '1218115422029873153',
     priority: 4,
     keep: false,
-    server: AlbionServer.EUROPE,
   },
   {
     name: '@ALB/Graduate',
     discordRoleId: '1218115340009996339',
     priority: 5,
     keep: true,
-    server: AlbionServer.EUROPE,
   },
   {
     name: '@ALB/Disciple',
     discordRoleId: '1218115269419995166',
     priority: 6,
     keep: false,
-    server: AlbionServer.EUROPE,
   },
   {
     name: '@ALB/Registered',
     discordRoleId: '1224609941260603402',
     priority: 7,
     keep: true,
-    server: AlbionServer.EUROPE,
   },
 ];
 const rolesToRankDevelopment: AlbionRoleMapInterface[] = [
@@ -65,49 +55,42 @@ const rolesToRankDevelopment: AlbionRoleMapInterface[] = [
     discordRoleId: '1232802066414571631',
     priority: 1,
     keep: true,
-    server: AlbionServer.EUROPE,
   },
   {
     name: '@ALB/Magister',
     discordRoleId: '1232802105564205126',
     priority: 2,
     keep: false,
-    server: AlbionServer.EUROPE,
   },
   {
     name: '@ALB/EldritchMage',
     discordRoleId: '1232802165861384305',
     priority: 3,
     keep: false,
-    server: AlbionServer.EUROPE,
   },
   {
     name: '@ALB/Adept',
     discordRoleId: '1232802244219637893',
     priority: 4,
     keep: false,
-    server: AlbionServer.EUROPE,
   },
   {
     name: '@ALB/Graduate',
     discordRoleId: '1232802285734727772',
     priority: 5,
     keep: true,
-    server: AlbionServer.EUROPE,
   },
   {
     name: '@ALB/Disciple',
     discordRoleId: '1232802355733336196',
     priority: 6,
     keep: false,
-    server: AlbionServer.EUROPE,
   },
   {
     name: '@ALB/Registered',
     discordRoleId: '1232778554320879811',
     priority: 7,
     keep: true,
-    server: AlbionServer.EUROPE,
   },
 ];
 const roleMap = process.env.ENVIRONMENT === 'production' ? rolesToRankProduction : rolesToRankDevelopment;

--- a/src/database/entities/albion.registration.queue.entity.ts
+++ b/src/database/entities/albion.registration.queue.entity.ts
@@ -1,6 +1,5 @@
 import { Entity, Enum, Index, Property, Unique } from '@mikro-orm/decorators/legacy';
 import { BaseEntity } from './base.entity';
-import { AlbionServer } from '../../albion/interfaces/albion.api.interfaces';
 
 export enum AlbionRegistrationQueueStatus {
   PENDING = 'pending',
@@ -15,7 +14,6 @@ export interface AlbionRegistrationQueueEntityInterface {
   discordChannelId: string
   discordId: string
   characterName: string
-  server: AlbionServer
   attemptCount?: number
   expiresAt: Date
   status?: AlbionRegistrationQueueStatus
@@ -45,10 +43,6 @@ export class AlbionRegistrationQueueEntity extends BaseEntity {
 
   @Property({ nullable: false })
   characterName: string;
-
-  @Enum(() => AlbionServer)
-  @Property({ nullable: false })
-  server: AlbionServer;
 
   @Enum(() => AlbionRegistrationQueueStatus)
   @Property({ nullable: false, default: AlbionRegistrationQueueStatus.PENDING })

--- a/src/database/migrations/.snapshot-digletbot.json
+++ b/src/database/migrations/.snapshot-digletbot.json
@@ -2,17 +2,8 @@
   "namespaces": [],
   "tables": [
     {
+      "name": "activity_entity",
       "columns": {
-        "id": {
-          "name": "id",
-          "type": "int",
-          "unsigned": true,
-          "autoincrement": true,
-          "primary": true,
-          "nullable": false,
-          "length": null,
-          "mappedType": "integer"
-        },
         "created_at": {
           "name": "created_at",
           "type": "datetime",
@@ -20,17 +11,14 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "datetime",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "discord_id": {
@@ -40,7 +28,14 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": true,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "discord_nickname": {
@@ -50,8 +45,32 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "string"
+        },
+        "id": {
+          "name": "id",
+          "type": "int",
+          "unsigned": true,
+          "autoincrement": true,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
         },
         "last_activity": {
           "name": "last_activity",
@@ -60,67 +79,14 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
-          "mappedType": "datetime"
-        }
-      },
-      "name": "activity_entity",
-      "indexes": [
-        {
-          "columnNames": [
-            "discord_id"
-          ],
-          "composite": false,
-          "keyName": "activity_entity_discord_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "columnNames": [
-            "discord_id"
-          ],
-          "composite": false,
-          "keyName": "activity_entity_discord_id_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "PRIMARY",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "int",
-          "unsigned": true,
-          "autoincrement": true,
-          "primary": true,
-          "nullable": false,
-          "length": null,
-          "mappedType": "integer"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "datetime",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -130,64 +96,57 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "datetime"
+        }
+      },
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "PRIMARY",
+          "primary": true,
+          "unique": true
         },
-        "total_users": {
-          "name": "total_users",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
+        {
+          "columnNames": [
+            "discord_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "activity_entity_discord_id_index",
           "primary": false,
-          "nullable": false,
-          "length": null,
-          "default": "0",
-          "mappedType": "integer"
+          "unique": false
         },
-        "inactive_users": {
-          "name": "inactive_users",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
+        {
+          "columnNames": [
+            "discord_id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "activity_entity_discord_id_unique",
           "primary": false,
-          "nullable": false,
-          "length": null,
-          "default": "0",
-          "mappedType": "integer"
-        },
-        "active_users90d": {
-          "name": "active_users90d",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": null,
-          "default": "0",
-          "mappedType": "integer"
-        },
-        "active_users60d": {
-          "name": "active_users60d",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": null,
-          "default": "0",
-          "mappedType": "integer"
-        },
-        "active_users30d": {
-          "name": "active_users30d",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": null,
-          "default": "0",
-          "mappedType": "integer"
-        },
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "triggers": [],
+      "foreignKeys": {},
+      "comment": null
+    },
+    {
+      "name": "activity_statistics_entity",
+      "columns": {
         "active_users14d": {
           "name": "active_users14d",
           "type": "int",
@@ -195,41 +154,14 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
           "default": "0",
-          "mappedType": "integer"
-        },
-        "active_users7d": {
-          "name": "active_users7d",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": null,
-          "default": "0",
-          "mappedType": "integer"
-        },
-        "active_users3d": {
-          "name": "active_users3d",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": null,
-          "default": "0",
-          "mappedType": "integer"
-        },
-        "active_users2d": {
-          "name": "active_users2d",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": null,
-          "default": "0",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "integer"
         },
         "active_users1d": {
@@ -239,38 +171,116 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
           "default": "0",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "integer"
-        }
-      },
-      "name": "activity_statistics_entity",
-      "indexes": [
-        {
-          "keyName": "PRIMARY",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
+        },
+        "active_users2d": {
+          "name": "active_users2d",
           "type": "int",
-          "unsigned": true,
-          "autoincrement": true,
-          "primary": true,
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "0",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "active_users30d": {
+          "name": "active_users30d",
+          "type": "int",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "0",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "active_users3d": {
+          "name": "active_users3d",
+          "type": "int",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "0",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "active_users60d": {
+          "name": "active_users60d",
+          "type": "int",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "0",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "active_users7d": {
+          "name": "active_users7d",
+          "type": "int",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "0",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "active_users90d": {
+          "name": "active_users90d",
+          "type": "int",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "0",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "integer"
         },
         "created_at": {
@@ -280,8 +290,66 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "datetime"
+        },
+        "id": {
+          "name": "id",
+          "type": "int",
+          "unsigned": true,
+          "autoincrement": true,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "inactive_users": {
+          "name": "inactive_users",
+          "type": "int",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "0",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "total_users": {
+          "name": "total_users",
+          "type": "int",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "0",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
         },
         "updated_at": {
           "name": "updated_at",
@@ -290,9 +358,329 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "PRIMARY",
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "triggers": [],
+      "foreignKeys": {},
+      "comment": null
+    },
+    {
+      "name": "albion_registration_queue_entity",
+      "columns": {
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "int",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "0",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
+        "discord_channel_id": {
+          "name": "discord_channel_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "discord_guild_id": {
+          "name": "discord_guild_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "id": {
+          "name": "id",
+          "type": "int",
+          "unsigned": true,
+          "autoincrement": true,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "varchar(2000)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 2000,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','succeeded','failed','expired')",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "'pending'",
+          "comment": null,
+          "collation": null,
+          "enumItems": [
+            "pending",
+            "succeeded",
+            "failed",
+            "expired"
+          ],
+          "mappedType": "enum"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "PRIMARY",
+          "primary": true,
+          "unique": true
+        },
+        {
+          "columnNames": [
+            "discord_guild_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "albion_registration_queue_entity_discord_guild_id_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "discord_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "albion_registration_queue_entity_discord_id_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "expires_at"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "albion_registration_queue_entity_expires_at_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "guild_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "albion_registration_queue_entity_guild_id_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "status"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "albion_registration_queue_entity_status_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "guild_id",
+            "discord_id",
+            "status"
+          ],
+          "composite": true,
+          "constraint": true,
+          "keyName": "unique_albion_registration_queue_guild_discord_status",
+          "primary": false,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "triggers": [],
+      "foreignKeys": {},
+      "comment": null
+    },
+    {
+      "name": "albion_registrations_entity",
+      "columns": {
         "character_id": {
           "name": "character_id",
           "type": "varchar(255)",
@@ -300,7 +688,14 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "character_name": {
@@ -310,80 +705,15 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "string"
-        },
-        "registered": {
-          "name": "registered",
-          "type": "tinyint(1)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 1,
-          "default": "false",
-          "mappedType": "boolean"
-        },
-        "warned": {
-          "name": "warned",
-          "type": "tinyint(1)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 1,
-          "default": "false",
-          "mappedType": "boolean"
-        }
-      },
-      "name": "albion_guild_members_entity",
-      "indexes": [
-        {
-          "columnNames": [
-            "character_id"
-          ],
-          "composite": false,
-          "keyName": "albion_guild_members_entity_character_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "columnNames": [
-            "character_id"
-          ],
-          "composite": false,
-          "keyName": "albion_guild_members_entity_character_id_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "PRIMARY",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "int",
-          "unsigned": true,
-          "autoincrement": true,
-          "primary": true,
-          "nullable": false,
-          "length": null,
-          "mappedType": "integer"
         },
         "created_at": {
           "name": "created_at",
@@ -392,17 +722,14 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "datetime",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "discord_id": {
@@ -412,27 +739,14 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
-          "mappedType": "string"
-        },
-        "character_id": {
-          "name": "character_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "character_name": {
-          "name": "character_name",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "guild_id": {
@@ -442,8 +756,32 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": true,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "string"
+        },
+        "id": {
+          "name": "id",
+          "type": "int",
+          "unsigned": true,
+          "autoincrement": true,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
         },
         "manual": {
           "name": "manual",
@@ -452,8 +790,14 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "length": 1,
+          "unique": false,
+          "length": null,
+          "precision": 3,
+          "scale": 0,
           "default": "false",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "boolean"
         },
         "manual_created_by_discord_id": {
@@ -463,8 +807,14 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
-          "default": "null",
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "manual_created_by_discord_name": {
@@ -474,91 +824,15 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
-          "default": "null",
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "string"
-        }
-      },
-      "name": "albion_registrations_entity",
-      "indexes": [
-        {
-          "columnNames": [
-            "discord_id"
-          ],
-          "composite": false,
-          "keyName": "albion_registrations_entity_discord_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "columnNames": [
-            "character_id"
-          ],
-          "composite": false,
-          "keyName": "albion_registrations_entity_character_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "unique_guild_discord",
-          "columnNames": [
-            "guild_id",
-            "discord_id"
-          ],
-          "composite": true,
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "unique_guild_character",
-          "columnNames": [
-            "guild_id",
-            "character_id"
-          ],
-          "composite": true,
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "PRIMARY",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "int",
-          "unsigned": true,
-          "autoincrement": true,
-          "primary": true,
-          "nullable": false,
-          "length": null,
-          "mappedType": "integer"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "datetime",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": null,
-          "mappedType": "datetime"
         },
         "updated_at": {
           "name": "updated_at",
@@ -567,7 +841,94 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "PRIMARY",
+          "primary": true,
+          "unique": true
+        },
+        {
+          "columnNames": [
+            "character_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "albion_registrations_entity_character_id_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "discord_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "albion_registrations_entity_discord_id_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "guild_id",
+            "character_id"
+          ],
+          "composite": true,
+          "constraint": true,
+          "keyName": "unique_guild_character",
+          "primary": false,
+          "unique": true
+        },
+        {
+          "columnNames": [
+            "guild_id",
+            "discord_id"
+          ],
+          "composite": true,
+          "constraint": true,
+          "keyName": "unique_guild_discord",
+          "primary": false,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "triggers": [],
+      "foreignKeys": {},
+      "comment": null
+    },
+    {
+      "name": "joiner_leaver_entity",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "discord_id": {
@@ -577,7 +938,14 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": true,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "discord_nickname": {
@@ -587,8 +955,32 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "string"
+        },
+        "id": {
+          "name": "id",
+          "type": "int",
+          "unsigned": true,
+          "autoincrement": true,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
         },
         "join_date": {
           "name": "join_date",
@@ -597,7 +989,14 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "leave_date": {
@@ -607,7 +1006,14 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "rejoin_count": {
@@ -617,69 +1023,15 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
           "default": "0",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "integer"
-        }
-      },
-      "name": "joiner_leaver_entity",
-      "indexes": [
-        {
-          "columnNames": [
-            "discord_id"
-          ],
-          "composite": false,
-          "keyName": "joiner_leaver_entity_discord_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "columnNames": [
-            "discord_id"
-          ],
-          "composite": false,
-          "keyName": "joiner_leaver_entity_discord_id_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "PRIMARY",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "int",
-          "unsigned": true,
-          "autoincrement": true,
-          "primary": true,
-          "nullable": false,
-          "length": null,
-          "mappedType": "integer"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "datetime",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": null,
-          "mappedType": "datetime"
         },
         "updated_at": {
           "name": "updated_at",
@@ -688,8 +1040,124 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "datetime"
+        }
+      },
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "PRIMARY",
+          "primary": true,
+          "unique": true
+        },
+        {
+          "columnNames": [
+            "discord_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "joiner_leaver_entity_discord_id_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "discord_id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "joiner_leaver_entity_discord_id_unique",
+          "primary": false,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "triggers": [],
+      "foreignKeys": {},
+      "comment": null
+    },
+    {
+      "name": "joiner_leaver_statistics_entity",
+      "columns": {
+        "avg_time_to_leave": {
+          "name": "avg_time_to_leave",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": "'0d 0h 0m'",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "early_leavers": {
+          "name": "early_leavers",
+          "type": "int",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "0",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "id": {
+          "name": "id",
+          "type": "int",
+          "unsigned": true,
+          "autoincrement": true,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
         },
         "joiners": {
           "name": "joiners",
@@ -698,8 +1166,14 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
           "default": "0",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "integer"
         },
         "leavers": {
@@ -709,8 +1183,14 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
           "default": "0",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "integer"
         },
         "rejoiners": {
@@ -720,71 +1200,15 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
           "default": "0",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "integer"
-        },
-        "early_leavers": {
-          "name": "early_leavers",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": null,
-          "default": "0",
-          "mappedType": "integer"
-        },
-        "avg_time_to_leave": {
-          "name": "avg_time_to_leave",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "default": "'0d 0h 0m'",
-          "mappedType": "string"
-        }
-      },
-      "name": "joiner_leaver_statistics_entity",
-      "indexes": [
-        {
-          "keyName": "PRIMARY",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "int",
-          "unsigned": true,
-          "autoincrement": true,
-          "primary": true,
-          "nullable": false,
-          "length": null,
-          "mappedType": "integer"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "datetime",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": null,
-          "mappedType": "datetime"
         },
         "updated_at": {
           "name": "updated_at",
@@ -793,7 +1217,86 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "PRIMARY",
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "triggers": [],
+      "foreignKeys": {},
+      "comment": null
+    },
+    {
+      "name": "ps2members_entity",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "discord_id": {
@@ -803,28 +1306,32 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": true,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "string"
         },
-        "character_id": {
-          "name": "character_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
+        "id": {
+          "name": "id",
+          "type": "int",
+          "unsigned": true,
+          "autoincrement": true,
+          "primary": true,
           "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "character_name": {
-          "name": "character_name",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
         },
         "manual": {
           "name": "manual",
@@ -833,8 +1340,14 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "length": 1,
+          "unique": false,
+          "length": null,
+          "precision": 3,
+          "scale": 0,
           "default": "false",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "boolean"
         },
         "manual_created_by_discord_id": {
@@ -844,8 +1357,14 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
-          "default": "null",
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "manual_created_by_discord_name": {
@@ -855,89 +1374,15 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
-          "default": "null",
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "string"
-        }
-      },
-      "name": "ps2members_entity",
-      "indexes": [
-        {
-          "columnNames": [
-            "discord_id"
-          ],
-          "composite": false,
-          "keyName": "ps2members_entity_discord_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "columnNames": [
-            "discord_id"
-          ],
-          "composite": false,
-          "keyName": "ps2members_entity_discord_id_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "columnNames": [
-            "character_id"
-          ],
-          "composite": false,
-          "keyName": "ps2members_entity_character_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "columnNames": [
-            "character_id"
-          ],
-          "composite": false,
-          "keyName": "ps2members_entity_character_id_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "PRIMARY",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "int",
-          "unsigned": true,
-          "autoincrement": true,
-          "primary": true,
-          "nullable": false,
-          "length": null,
-          "mappedType": "integer"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "datetime",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": null,
-          "mappedType": "datetime"
         },
         "updated_at": {
           "name": "updated_at",
@@ -946,9 +1391,77 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "datetime"
+        }
+      },
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "PRIMARY",
+          "primary": true,
+          "unique": true
         },
+        {
+          "columnNames": [
+            "character_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "ps2members_entity_character_id_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "character_id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "ps2members_entity_character_id_unique",
+          "primary": false,
+          "unique": true
+        },
+        {
+          "columnNames": [
+            "discord_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "ps2members_entity_discord_id_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "discord_id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "ps2members_entity_discord_id_unique",
+          "primary": false,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "triggers": [],
+      "foreignKeys": {},
+      "comment": null
+    },
+    {
+      "name": "ps2verification_attempt_entity",
+      "columns": {
         "character_id": {
           "name": "character_id",
           "type": "varchar(255)",
@@ -956,7 +1469,14 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": true,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "character_name": {
@@ -966,58 +1486,15 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "string"
-        }
-      },
-      "name": "ps2verification_attempt_entity",
-      "indexes": [
-        {
-          "columnNames": [
-            "character_id"
-          ],
-          "composite": false,
-          "keyName": "ps2verification_attempt_entity_character_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "columnNames": [
-            "character_id"
-          ],
-          "composite": false,
-          "keyName": "ps2verification_attempt_entity_character_id_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "PRIMARY",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "int",
-          "unsigned": true,
-          "autoincrement": true,
-          "primary": true,
-          "nullable": false,
-          "length": null,
-          "mappedType": "integer"
         },
         "created_at": {
           "name": "created_at",
@@ -1026,8 +1503,32 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "datetime"
+        },
+        "id": {
+          "name": "id",
+          "type": "int",
+          "unsigned": true,
+          "autoincrement": true,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
         },
         "updated_at": {
           "name": "updated_at",
@@ -1036,8 +1537,107 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "datetime"
+        }
+      },
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "PRIMARY",
+          "primary": true,
+          "unique": true
+        },
+        {
+          "columnNames": [
+            "character_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "ps2verification_attempt_entity_character_id_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "character_id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "ps2verification_attempt_entity_character_id_unique",
+          "primary": false,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "triggers": [],
+      "foreignKeys": {},
+      "comment": null
+    },
+    {
+      "name": "role_metrics_entity",
+      "columns": {
+        "community_games": {
+          "name": "community_games",
+          "type": "json",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "id": {
+          "name": "id",
+          "type": "int",
+          "unsigned": true,
+          "autoincrement": true,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
         },
         "onboarded": {
           "name": "onboarded",
@@ -1046,19 +1646,15 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
           "default": "0",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "integer"
-        },
-        "community_games": {
-          "name": "community_games",
-          "type": "json",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": null,
-          "mappedType": "json"
         },
         "rec_games": {
           "name": "rec_games",
@@ -1067,27 +1663,52 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
           "mappedType": "json"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "datetime"
         }
       },
-      "name": "role_metrics_entity",
       "indexes": [
         {
-          "keyName": "PRIMARY",
           "columnNames": [
             "id"
           ],
           "composite": false,
           "constraint": true,
+          "keyName": "PRIMARY",
           "primary": true,
           "unique": true
         }
       ],
       "checks": [],
+      "triggers": [],
       "foreignKeys": {},
-      "nativeEnums": {}
+      "comment": null
     }
   ],
+  "views": [],
   "nativeEnums": {}
 }

--- a/src/database/migrations/Migration20260728012034.ts
+++ b/src/database/migrations/Migration20260728012034.ts
@@ -1,0 +1,31 @@
+import { Migration } from '@mikro-orm/migrations';
+
+// Hand-written rather than generated. The migration snapshot had fallen behind the entities, so
+// `migration:create` believed albion_registration_queue_entity was a new table and emitted a
+// `create table` for it, which would fail against the existing one and wedge the boot.
+export class Migration20260728012034 extends Migration {
+
+  override up(): void | Promise<void> {
+    // DIG is EU-only, so the server column and the AlbionServer enum behind it are gone.
+    this.addSql('alter table `albion_registration_queue_entity` drop index `unique_albion_registration_queue_guild_discord`;');
+    this.addSql('alter table `albion_registration_queue_entity` drop column `server`;');
+    this.addSql('alter table `albion_registration_queue_entity` modify `status` enum(\'pending\',\'succeeded\',\'failed\',\'expired\') not null default \'pending\';');
+    this.addSql('alter table `albion_registration_queue_entity` add unique `unique_albion_registration_queue_guild_discord_status` (`guild_id`, `discord_id`, `status`);');
+
+    // Abandoned guild member tracking. The entity was deleted long ago; only the table was left.
+    this.addSql('drop table if exists `albion_guild_members_entity`;');
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql('alter table `albion_registration_queue_entity` drop index `unique_albion_registration_queue_guild_discord_status`;');
+    this.addSql('alter table `albion_registration_queue_entity` modify `status` varchar(255) not null default \'pending\';');
+    this.addSql('alter table `albion_registration_queue_entity` add `server` varchar(255) not null default \'Europe\';');
+    this.addSql('alter table `albion_registration_queue_entity` add unique `unique_albion_registration_queue_guild_discord` (`guild_id`, `discord_id`);');
+
+    // Recreated empty — the rows dropped above are not recoverable from here.
+    this.addSql('create table `albion_guild_members_entity` (`id` int unsigned not null auto_increment primary key, `created_at` datetime not null, `updated_at` datetime not null, `character_id` varchar(255) not null, `character_name` varchar(255) not null, `registered` tinyint(1) not null default false, `warned` tinyint(1) not null default false) default character set utf8mb4 engine = InnoDB;');
+    this.addSql('alter table `albion_guild_members_entity` add index `albion_guild_members_entity_character_id_index` (`character_id`);');
+    this.addSql('alter table `albion_guild_members_entity` add unique `albion_guild_members_entity_character_id_unique` (`character_id`);');
+  }
+
+}

--- a/src/test.bootstrapper.ts
+++ b/src/test.bootstrapper.ts
@@ -4,7 +4,6 @@ import _ from 'lodash';
 import { ConfigService } from '@nestjs/config';
 import { TestingModule } from '@nestjs/testing';
 import { MikroORM } from '@mikro-orm/core';
-import { AlbionServer } from './albion/interfaces/albion.api.interfaces';
 import { PS2MembersEntity } from './database/entities/ps2.members.entity';
 import { PS2RankMapInterface } from './config/ps2.app.config';
 import { Collection, Role, Snowflake } from 'discord.js';
@@ -316,12 +315,10 @@ export class TestBootstrapper {
     };
   }
 
-  static getMockAlbionCharacter(
-    server: AlbionServer = AlbionServer.EUROPE,
-  ) {
+  static getMockAlbionCharacter() {
     return {
       Id: 'clhoV9OdRm-5BuYQYZBT_Q',
-      Name: `Maelstrome26${server === AlbionServer.EUROPE ? 'EU' : 'US'}`,
+      Name: 'Maelstrome26EU',
       GuildId: this.mockConfig.albion.guildId,
     } as any;
   }
@@ -384,14 +381,12 @@ export class TestBootstrapper {
           discordRoleId: '1218115619732455474',
           priority: 1,
           keep: true,
-          server: AlbionServer.EUROPE,
         },
         {
           name: '@ALB/Magister',
           discordRoleId: '1218115569455464498',
           priority: 2,
           keep: false,
-          server: AlbionServer.EUROPE,
         },
       ],
     },


### PR DESCRIPTION
Clears the entity/migration drift found while upgrading MikroORM, and removes the single-server overhang along with it.

## The server concept

`AlbionServer` had one member. Every branch on it — the axios factory's endpoint switch, `serverEmoji()`, the role map's `server` field and the filters over it, `checkRoleInconsistencies`' `throw new Error('Invalid server!')` — had exactly one reachable path. All of it is gone:

- The `server` column on `albion_registration_queue_entity`, and the parameter threaded through `handleRegistration`, the API service, the scanning service and the retry cron.
- The `server` option on `/albion-scan`. It offered one choice.
- The `server` field on `AlbionRoleMapInterface` and every role map entry.
- The commented-out server param left in `AlbionRegisterDto`.

The 🇪🇺 that appeared in scan and registration messages is now a constant (`ALBION_GUILD_EMOJI`) rather than derived from the server, so **what lands in Discord is byte-identical** — including the awkward `Couldn't gather characters from Europe ALB API.` phrasing, which I kept rather than quietly fixing.

## The abandoned table

`albion_guild_members_entity` had its entity class deleted long ago; only the table survived, with 169 rows. Dropped.

## Why the migration is hand-written

`migration:create` got it wrong, and dangerously so. The snapshot had fallen behind the entities, so it concluded `albion_registration_queue_entity` was a *new* table and emitted a `create table` for it. Applied to production that fails outright — and since `start:prod` is `migration:up && node dist/src/main` with `transactional: false`, a failing migration takes the boot down with it.

That is worth stating plainly because it was not hypothetical: **any unrelated migration generated before this PR would have carried the same `create table`, plus the guild members drop**, and whoever generated it would have had to notice the extra SQL in their own diff.

The hand-written version does what the diff should have done:

```sql
alter table `albion_registration_queue_entity` drop index `unique_albion_registration_queue_guild_discord`;
alter table `albion_registration_queue_entity` drop column `server`;
alter table `albion_registration_queue_entity` modify `status` enum('pending','succeeded','failed','expired') not null default 'pending';
alter table `albion_registration_queue_entity` add unique `unique_albion_registration_queue_guild_discord_status` (`guild_id`, `discord_id`, `status`);
drop table if exists `albion_guild_members_entity`;
```

## Safety, checked against live data rather than assumed

- **Unique key** gains a column. A 3-column key over a table already unique on 2 of them cannot conflict; it only loosens.
- **`status` → enum**: live values are `expired`, `failed` and `succeeded`. All inside the new enum.
- **`server` → dropped**: every row was `Europe`.
- `sql_mode` is `STRICT_TRANS_TABLES`, so an out-of-range value would have errored mid-migration rather than truncating — worth knowing given migrations are non-transactional, though the data is clean.

## Validation

Against a local database at the same migration state as production:

- `migration:up`, `migration:down`, `migration:up` — all apply cleanly, so the rollback is real.
- `schema:update --dump` → **Schema is up-to-date**.
- `migration:create` → **No changes required, schema is up-to-date**. That's the trap closed: the next person to generate a migration gets only what they asked for.
- 375 tests across 33 suites, lint clean.

## Note on the down migration

`down` recreates `albion_guild_members_entity` empty. The 169 rows are not recoverable from the migration, which is inherent to dropping a table you've decided is dead — flagging it rather than burying it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016e1HuqQq3L6nE5cKYcMpYh
