### PR TITLE
ci: Make the deploy step wait for the deploy, and stop wasting a minute on boot

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,11 +9,24 @@ permissions:
 jobs:
   send-webhook:
     runs-on: ubuntu-latest
+    # Backstop only. The step below should resolve long before this.
+    timeout-minutes: 5
     steps:
+      # The receiving hook waits for the deployment to finish and answers 200 or 500,
+      # so this timeout has to cover a whole deploy rather than just the round trip.
+      # Measured deploys run 37-86s; the proxy in front of the hook gives up at ~100s
+      # and returns a 524 of its own. 120s sits above that deliberately: a deploy that
+      # overruns should surface as that 524 — which says the deploy was still running —
+      # rather than as a client-side timeout, which says nothing at all.
+      #
+      # It was 2000ms, which timed out on 2026-07-28 while the deploy underneath it ran
+      # to completion, reporting a failure that had not happened. The reverse was worse:
+      # at 2000ms this step returned before the hook could know the outcome, so a
+      # crashlooping bot came back green.
       - name: Trigger webhook
         uses: ramzzisudip/secure-github-webhook@0.3.0
         with:
           url: "${{ secrets.WEBHOOK_URL }}"
           data: '{ "application": "digletbot" }'
-          timeout: 2000
+          timeout: 120000
           hmacSecret: "${{ secrets.WEBHOOK_SECRET }}"

--- a/src/general/services/healthcheck.service.spec.ts
+++ b/src/general/services/healthcheck.service.spec.ts
@@ -53,6 +53,28 @@ describe('HealthcheckService', () => {
 
   afterEach(() => jest.restoreAllMocks());
 
+  // The heartbeat runs on its own faster tick so a freshly booted container can
+  // go healthy without waiting out the wall-clock minute, which is dead time in
+  // every deploy. It must not depend on the uptime ping half of the service.
+  it('writes the heartbeat on its own tick without pinging', async () => {
+    configure('production', 'some-uuid');
+    const create = jest.spyOn(axios, 'create');
+
+    await healthcheckService.heartbeat();
+
+    expect(mockWriteFile).toHaveBeenCalledWith(HEARTBEAT_PATH, expect.any(String));
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('does not write the heartbeat on its own tick when the database is unreachable', async () => {
+    configure('production', 'some-uuid');
+    execute.mockRejectedValue(new Error('MariaDB is down'));
+
+    await healthcheckService.heartbeat();
+
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
   // The heartbeat is what the container HEALTHCHECK reads, so it has to be
   // written on every tick regardless of environment — otherwise a non-production
   // container reports unhealthy forever.

--- a/src/general/services/healthcheck.service.ts
+++ b/src/general/services/healthcheck.service.ts
@@ -28,9 +28,16 @@ export class HealthcheckService {
     @InjectRepository(ActivityEntity) private readonly activityRepository: EntityRepository<ActivityEntity>,
   ) {}
 
-  @Cron('*/1 * * * *')
-  async check(): Promise<void> {
-    // Written FIRST, and in every environment, on purpose.
+  // Every 30s rather than every minute because this is what gates a deploy.
+  // `@Cron('*/1 * * * *')` fires on the wall-clock minute, so a container that
+  // booted at :01 could not go healthy until :00 — up to 60s of a deploy spent
+  // waiting on nothing. Measured on two consecutive deploys of the same image:
+  // 72s and 22s in `docker compose up -d --wait`, decided purely by where boot
+  // landed in the minute. Halving the tick halves that, and proves exactly as
+  // much: the scheduler is ticking and MariaDB answers.
+  @Cron('*/30 * * * * *')
+  async heartbeat(): Promise<void> {
+    // Written in every environment on purpose.
     //
     // This is the only liveness signal the container has: the bot is a
     // standalone Nest application context (`createApplicationContext`), so there
@@ -56,7 +63,7 @@ export class HealthcheckService {
       }
       catch (err) {
         // Never throw: failing to write the heartbeat must not take out the
-        // uptime ping below.
+        // uptime ping in check().
         this.logger.error(`Could not write heartbeat file: ${err}`);
       }
     }
@@ -66,6 +73,14 @@ export class HealthcheckService {
       // whose bot cannot reach its database.
       this.logger.error(`Database healthcheck failed, heartbeat not written: ${err}`);
     }
+  }
+
+  @Cron('*/1 * * * *')
+  async check(): Promise<void> {
+    // Still written first here, so an outage at hc-ping.com can never be what
+    // marks this container unhealthy. The 30s tick above covers it in its own
+    // right; this call keeps that ordering guarantee true within check() too.
+    await this.heartbeat();
 
     const env = this.config.get('app.environment');
 


### PR DESCRIPTION
The caller-side half of making a deploy result mean something. Pairs with the receiving hook becoming synchronous (`Maelstromeous/webhooks#21`); either can merge first.

## The webhook timeout

`timeout: 2000` covers a round trip and nothing else. On 2026-07-28 it expired while the deploy underneath it ran to completion, reporting a failure that had not happened.

The reverse matters more. Once the hook waits for the deploy and answers `200`/`500`, a 2s ceiling would return *before* the outcome could possibly be known — so a crashlooping bot would come back green. That is not hypothetical either: the same night, a deploy failed on a full disk and `update.sh` caught it correctly in 27 seconds, but nothing about that reached the pipeline.

`120000` covers a measured deploy — 37s and 86s on the two most recent successful ones — and sits deliberately **above** the ~100s point where the proxy in front of the hook gives up. An overrun should surface as that proxy's `524`, which tells you the deploy was still running, rather than as a client-side timeout, which tells you nothing at all. `timeout-minutes: 5` is a backstop, not the mechanism.

## The heartbeat tick

`HealthcheckService` writes the heartbeat the container `HEALTHCHECK` reads, and it only ran on `@Cron('*/1 * * * *')` — the wall-clock minute. A container that booted at :01 could not report healthy until :00, so up to 60s of every deploy was spent waiting on a clock rather than on the bot.

That is the entire variance between these two deploys of the same image:

```
00:48:37 -> 00:50:03   86s    (72s of it inside `up -d --wait`)
01:00:24 -> 01:01:01   37s    (22s)
```

The heartbeat now has its own 30s tick. It proves exactly what it did before — the scheduler is running *and* MariaDB answers — just sooner. `check()` still calls it first, so an hc-ping outage still cannot be what marks the container unhealthy; that property has tests and they are unchanged.

**Deliberately not** writing the heartbeat at bootstrap, which would be faster again. "Healthy" would stop meaning the scheduler ever ticked, and a bot that booted and immediately wedged could pass the deploy gate. That guarantee is the reason the file is shaped the way it is.

## Validation

377 tests across 33 suites, lint and typecheck clean. Two new tests cover the heartbeat on its own tick — that it writes without touching hc-ping, and that it still refuses to write when the database is unreachable.

The real proof is the next deploy: it should be visibly quicker into `healthy`, and once the hook change is synced, a failed deploy should turn the pipeline red on its own merits rather than by coincidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016e1HuqQq3L6nE5cKYcMpYh
