### PR TITLE
fix(deps): Patch @discord-nestjs/core onto discord.js' clientReady event

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,12 @@ WORKDIR /app
 
 # Own layer so it's only redone when the manifests change. Dev deps are kept, entrypoint.sh runs
 # migrations through the MikroORM CLI.
-COPY package.json pnpm-lock.yaml ./
+#
+# pnpm-workspace.yaml and patches/ are manifests too, not extras: the lockfile records the
+# patch, pnpm-workspace.yaml declares it, and the patch file is what gets applied. Copy the
+# lockfile without the other two and --frozen-lockfile fails on the mismatch.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches ./patches
 RUN corepack install && chmod -R a+rX "$COREPACK_HOME"
 RUN pnpm install --frozen-lockfile --ignore-scripts
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@sentry/node": "^10.0.0",
     "@sentry/profiling-node": "^10.0.0",
     "axios": "^1.7.2",
-    "discord.js": "^14.18.0",
+    "discord.js": "^14.22.0",
     "dotenv": "^17.0.0",
     "lodash": "^4.17.21",
     "ps2census": "^4.6.0",

--- a/patches/@discord-nestjs__core@5.5.1.patch
+++ b/patches/@discord-nestjs__core@5.5.1.patch
@@ -1,0 +1,14 @@
+diff --git a/dist/services/register-command.service.js b/dist/services/register-command.service.js
+index 1a2762f81c7ed930eae528422dcb52f5411cd076..80cd9c00be63c779b6ba23a6a7a5a741a11b820f 100644
+--- a/dist/services/register-command.service.js
++++ b/dist/services/register-command.service.js
+@@ -32,7 +32,8 @@ let RegisterCommandService = RegisterCommandService_1 = class RegisterCommandSer
+     }
+     async register() {
+         const options = this.discordOptionService.getClientData();
+-        this.client.on('ready', () => this.registerCommands(this.client, options));
++        // 'ready' is deprecated in discord.js v14 and gone in v15, taking command registration with it.
++        this.client.on('clientReady', () => this.registerCommands(this.client, options));
+     }
+     async registerCommands(client, { registerCommandOptions }) {
+         const commands = this.discordCommandProvider.getAllCommands();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,16 +4,19 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@discord-nestjs/core@5.5.1': d513283518530669362cbdf943b23f7fc63d0dc8e65b52273d27dad9e5a34f68
+
 importers:
 
   .:
     dependencies:
       '@discord-nestjs/common':
         specifier: ^5.2.12
-        version: 5.3.2(@discord-nestjs/core@5.5.1(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(discord.js@14.26.5)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(discord.js@14.26.5)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+        version: 5.3.2(@discord-nestjs/core@5.5.1(patch_hash=d513283518530669362cbdf943b23f7fc63d0dc8e65b52273d27dad9e5a34f68)(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(discord.js@14.26.5)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(discord.js@14.26.5)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@discord-nestjs/core':
         specifier: ^5.3.14
-        version: 5.5.1(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(discord.js@14.26.5)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+        version: 5.5.1(patch_hash=d513283518530669362cbdf943b23f7fc63d0dc8e65b52273d27dad9e5a34f68)(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(discord.js@14.26.5)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@mikro-orm/core':
         specifier: 7.1.6
         version: 7.1.6(dataloader@2.2.3)
@@ -57,7 +60,7 @@ importers:
         specifier: ^1.7.2
         version: 1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       discord.js:
-        specifier: ^14.18.0
+        specifier: ^14.22.0
         version: 14.26.5
       dotenv:
         specifier: ^17.0.0
@@ -3719,9 +3722,9 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@discord-nestjs/common@5.3.2(@discord-nestjs/core@5.5.1(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(discord.js@14.26.5)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(discord.js@14.26.5)(reflect-metadata@0.2.2)(rxjs@7.8.1)':
+  '@discord-nestjs/common@5.3.2(@discord-nestjs/core@5.5.1(patch_hash=d513283518530669362cbdf943b23f7fc63d0dc8e65b52273d27dad9e5a34f68)(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(discord.js@14.26.5)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(discord.js@14.26.5)(reflect-metadata@0.2.2)(rxjs@7.8.1)':
     dependencies:
-      '@discord-nestjs/core': 5.5.1(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(discord.js@14.26.5)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@discord-nestjs/core': 5.5.1(patch_hash=d513283518530669362cbdf943b23f7fc63d0dc8e65b52273d27dad9e5a34f68)(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(discord.js@14.26.5)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/common': 11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1)
       '@nestjs/core': 11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/mapped-types': 2.1.0(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
@@ -3731,7 +3734,7 @@ snapshots:
       reflect-metadata: 0.2.2
       rxjs: 7.8.1
 
-  '@discord-nestjs/core@5.5.1(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(discord.js@14.26.5)(reflect-metadata@0.2.2)(rxjs@7.8.1)':
+  '@discord-nestjs/core@5.5.1(patch_hash=d513283518530669362cbdf943b23f7fc63d0dc8e65b52273d27dad9e5a34f68)(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1))(discord.js@14.26.5)(reflect-metadata@0.2.2)(rxjs@7.8.1)':
     dependencies:
       '@nestjs/common': 11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1)
       '@nestjs/core': 11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,7 @@ allowBuilds:
   '@nestjs/core': false
   '@sentry-internal/node-cpu-profiler': false
   unrs-resolver: false
+# Command registration hangs off discord.js' `ready` event, which v15 removes. Upstream has had no
+# release since Jan 2025, so we swap it for `clientReady` ourselves — see issue #724.
+patchedDependencies:
+  '@discord-nestjs/core@5.5.1': patches/@discord-nestjs__core@5.5.1.patch


### PR DESCRIPTION
Closes #724.

## What's wrong

discord.js renamed the `ready` event to `clientReady`, to distinguish it from the gateway READY event. `ready` still fires in v14 with a deprecation warning — the one in #724 — and stops existing in v15.

`@discord-nestjs/core` hangs slash command registration off exactly that event:

```js
this.client.on('ready', () => this.registerCommands(this.client, options));
```

The deprecation warning is the harmless part. The real problem is what happens on v15: not an error, just a listener that never fires. Commands stop being registered and the bot carries on looking perfectly healthy while its slash commands quietly go stale. That is a much worse failure than a noisy log line, and it would be genuinely hard to attribute after the fact.

Upstream has had no release since January 2025, so waiting for a fix isn't a plan.

## The fix

`pnpm patch` swaps the single line for `clientReady`:

```diff
-        this.client.on('ready', () => this.registerCommands(this.client, options));
+        // 'ready' is deprecated in discord.js v14 and gone in v15, taking command registration with it.
+        this.client.on('clientReady', () => this.registerCommands(this.client, options));
```

The floor on `discord.js` moves to `^14.22.0` because that is where `clientReady` exists. Without it, a resolution below that version would leave the patched listener bound to an event nothing emits — swapping a warning for a silent failure. The installed version is already `14.26.5` via Renovate, so nothing actually moves today; this is a guard, not an upgrade.

The lockfile diff is only the patch registration (`patch_hash` entries plus the `patchedDependencies` block) — it was regenerated from `main`'s lockfile so no unrelated dependency drift rides along.

## Validation

- The `DeprecationWarning` is **gone** from a local boot; it is present on `main`, quoted verbatim in #724.
- The app starts through all 20 modules.
- 377 tests across 33 suites, lint and typecheck clean.

Being straight about the limit: a local run **cannot** prove registration itself works, because `clientReady` only fires on a real gateway connection and there is no valid token locally. What this proves is that the registration hook is no longer bound to a deprecated event. That it still registers is only proven by the deploy — worth a glance at the slash commands after it lands.

## One thing to know for later

The patch is pinned to `@discord-nestjs/core@5.5.1`. Any bump to that package will **fail the install** until the patch is re-cut against the new version. That is the behaviour I want — the alternative is pnpm silently dropping the patch and the bug returning unnoticed — but it does mean a Renovate PR for that package will go red until someone regenerates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016e1HuqQq3L6nE5cKYcMpYh
