### PR TITLE
feat(commands): Log every slash command invocation at info level

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -3,5 +3,8 @@
 - [Albion registration is a critical pillar](albion-registration-critical-pillar.md) — daily cron strips roles for ex-guild members; must be very robust
 - [Local dev/test environment](local-dev-test-environment.md) — nvm use 24.12.0 first (strict engines pin), pnpm test ~107s / 362 tests; test:wsl only needed on WSL
 - [Commit messages drive the version bump](commit-messages-drive-version-bump.md) — substring match on main: "feat" anywhere in a message forces a minor bump
+- [necord's @Options() drops DTO defaults](necord-options-drops-dto-defaults.md) — field initialisers are ignored; omitted options arrive as null, so default at the read site
+- [MariaDB upgrades need MARIADB_AUTO_UPGRADE](mariadb-upgrades-need-auto-upgrade-env.md) — a tag bump alone leaves system tables un-upgraded; the DB container drifts behind the repo
+- [The deploy webhook reports false failures](deploy-webhook-reports-false-failure.md) — send-webhook goes red on deploys that worked; check /root/deploy.log instead
 
 Note: this memory lives in the repo at `.claude/memory/` (wired via `autoMemoryDirectory` in `.claude/settings.json`) so it's shared via git across machines and collaborators. See README "Claude Code memory".

--- a/.claude/memory/deploy-webhook-reports-false-failure.md
+++ b/.claude/memory/deploy-webhook-reports-false-failure.md
@@ -1,0 +1,15 @@
+---
+name: deploy-webhook-reports-false-failure
+description: "ci.yml's send-webhook step goes red on deploys that actually succeeded — check /root/deploy.log on the host, not the Actions result"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 98e6e913-c748-4676-92ad-94d3e2352e1b
+  modified: 2026-07-29T01:37:43.327Z
+---
+
+The `Trigger deployment / send-webhook` job in `ci.yml` reports failure while the deploy itself succeeds. It errors with `timeout of 120000ms exceeded` after only **~5 seconds**, so it is a connection/response-handling problem mislabelled as a timeout. Confirmed on both `e33a1c8` (2.27.12) and `46abe1e` (2.27.13): `/root/deploy.log` on the host shows the deploy fired and recreated the container each time.
+
+**Why:** a pipeline that shows red on every successful deploy trains everyone to stop reading it, so the day it fails for real nothing stands out. There is also no watchtower container on that host despite `watchtower.enable` labels on both compose services — the webhook is the only deploy path, with nothing quietly covering for it.
+
+**How to apply:** treat a red `send-webhook` as unproven, not failed. Verify against `/root/deploy.log` and the container's `StartedAt` before assuming a deploy did not land. Note the repo's `server-update.sh` is **not** the script that actually runs — the host's real one pulls and recreates by changed image and logs different text. Related: [[mariadb-upgrades-need-auto-upgrade-env]].

--- a/.claude/memory/mariadb-upgrades-need-auto-upgrade-env.md
+++ b/.claude/memory/mariadb-upgrades-need-auto-upgrade-env.md
@@ -1,0 +1,15 @@
+---
+name: mariadb-upgrades-need-auto-upgrade-env
+description: Bumping the mariadb image tag does nothing to system tables unless MARIADB_AUTO_UPGRADE is set on the container
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 98e6e913-c748-4676-92ad-94d3e2352e1b
+  modified: 2026-07-29T01:37:36.272Z
+---
+
+The official mariadb image only runs `mariadb-upgrade` when **`MARIADB_AUTO_UPGRADE`** is set — it is the one environment variable that still has any effect on a container whose data directory is already populated. Without it, a tag bump starts new binaries against old system tables, which surfaces as `Incorrect definition of table mysql.*`. The DB container also carries `watchtower.enable=false`, so it never auto-updates and drifts behind the repo silently.
+
+**Why:** on 2026-07-29 the server was found running `mariadb:12.0.2` while the repo's compose had been bumped to `12.3.2` by Renovate — two release series of drift that nobody had noticed. In MariaDB's versioning the *second* digit is the major version, so 12.0 → 12.3 is three major steps, not a patch. Skipping intermediate majors is supported, and 12.1/12.2 list no backward-incompatible changes at all, so the whole breaking surface was 12.3's (reserved words `CONVERSION`/`ST_COLLECT`/`TO_DATE`, removed `big_tables`/`large_page_size`/`storage_engine`) — none of which this schema touches.
+
+**How to apply:** before rolling a mariadb bump, confirm `MARIADB_AUTO_UPGRADE=1` is on the service, take a timestamped `--all-databases` dump (via `docker exec ... sh -c` referencing `$MYSQL_ROOT_PASSWORD` **inside** the container, so the credential is never read out), and copy it off the host before bouncing. `scripts/backup.sh` is not suitable — it writes a fixed filename and overwrites the previous backup. The upgrade also writes its own `system_mysql_backup_<oldversion>.sql.zst` into the datadir.

--- a/.claude/memory/necord-options-drops-dto-defaults.md
+++ b/.claude/memory/necord-options-drops-dto-defaults.md
@@ -1,0 +1,15 @@
+---
+name: necord-options-drops-dto-defaults
+description: "necord's @Options() never constructs the DTO class, so field initialisers are silently ignored and omitted options arrive as null"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 98e6e913-c748-4676-92ad-94d3e2352e1b
+  modified: 2026-07-29T01:37:26.407Z
+---
+
+necord's `@Options()` param decorator reduces the resolved interaction options into a **plain object literal** — it calls `interaction.options.getBoolean(name, required)` etc. per field and never instantiates the DTO class. So a class field initialiser (`dryRun = true`) is silently ignored, and an omitted optional argument arrives as **`null`**, not the default.
+
+**Why:** `@discord-nestjs`' old `SlashCommandPipe` *did* fall back to the class default (`interactionOption?.value ?? dtoInstance[property]`), so the migration in #727 lost that behaviour invisibly. `DryRunDto` defaulted `dryRun` to `true`; ported as-is, `/thanos-snap` with no argument would have skipped the dry-run banner and kicked members for real. Nothing in the type system or the test suite caught it — the DTO still *looked* like it had a default.
+
+**How to apply:** never put a field initialiser on a command DTO; it is a lie. Apply the default where the value is read (`const dryRun = dto.dryRun ?? false`) and write a test that asserts the omitted-argument case. Same trap applies to any new optional option. Related: [[albion-registration-critical-pillar]].

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,9 @@ services:
     container_name: digletbot-db
     image: mariadb:12.3.2
     env_file: digletbot-db.env
+    # Without this the image leaves system tables at the old version on a tag bump.
+    environment:
+      - MARIADB_AUTO_UPGRADE=1
     restart: unless-stopped
     ports:
       - "3307:3306"

--- a/src/general/events/interaction.events.spec.ts
+++ b/src/general/events/interaction.events.spec.ts
@@ -1,0 +1,121 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { InteractionEvents } from './interaction.events';
+
+describe('InteractionEvents', () => {
+  let interactionEvents: InteractionEvents;
+  let logSpy: jest.SpyInstance;
+
+  const mockInteraction = (overrides: any = {}): any => ({
+    isChatInputCommand: () => true,
+    commandName: 'albion-scan',
+    channelId: '1155997486318620746',
+    user: { username: 'digletuser', id: '90078072660852736' },
+    options: { data: [] },
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [InteractionEvents],
+    }).compile();
+
+    interactionEvents = module.get<InteractionEvents>(InteractionEvents);
+    logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('onInteractionCreate', () => {
+    it('should ignore interactions that are not chat input commands', () => {
+      interactionEvents.onInteractionCreate([
+        mockInteraction({ isChatInputCommand: () => false }),
+      ]);
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('should log the command, caller and channel when there are no arguments', () => {
+      interactionEvents.onInteractionCreate([mockInteraction()]);
+      expect(logSpy).toHaveBeenCalledWith(
+        '/albion-scan by digletuser (90078072660852736) in channel 1155997486318620746 args: none',
+      );
+    });
+
+    it('should log scalar argument values', () => {
+      interactionEvents.onInteractionCreate([
+        mockInteraction({
+          options: { data: [{ name: 'character-name', value: 'Maelstromeous' }] },
+        }),
+      ]);
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('args: character-name=Maelstromeous'));
+    });
+
+    // A false boolean is the case a truthiness check would silently drop.
+    it('should log a false boolean argument rather than omitting it', () => {
+      interactionEvents.onInteractionCreate([
+        mockInteraction({ options: { data: [{ name: 'dry-run', value: false }] } }),
+      ]);
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('args: dry-run=false'));
+    });
+
+    it('should log a user argument as username and id, not the raw object', () => {
+      interactionEvents.onInteractionCreate([
+        mockInteraction({
+          options: {
+            data: [
+              {
+                name: 'discord-user',
+                value: '123456789',
+                user: { username: 'targetuser', id: '123456789' },
+              },
+            ],
+          },
+        }),
+      ]);
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('args: discord-user=@targetuser(123456789)'),
+      );
+      expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('[object Object]'));
+    });
+
+    it('should log channel and role arguments by id', () => {
+      interactionEvents.onInteractionCreate([
+        mockInteraction({
+          options: {
+            data: [
+              { name: 'target-channel', value: '111', channel: { id: '111' } },
+              { name: 'target-role', value: '222', role: { id: '222' } },
+            ],
+          },
+        }),
+      ]);
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('target-channel=#111 target-role=&222'));
+    });
+
+    it('should flatten nested subcommand options', () => {
+      interactionEvents.onInteractionCreate([
+        mockInteraction({
+          options: {
+            data: [{ name: 'add', options: [{ name: 'character-name', value: 'Foo' }] }],
+          },
+        }),
+      ]);
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('args: add(character-name=Foo)'));
+    });
+
+    it('should report a missing value as null', () => {
+      interactionEvents.onInteractionCreate([
+        mockInteraction({ options: { data: [{ name: 'dry-run', value: undefined }] } }),
+      ]);
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('args: dry-run=null'));
+    });
+
+    it('should describe a DM as such when there is no channel', () => {
+      interactionEvents.onInteractionCreate([mockInteraction({ channelId: null })]);
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('in DM args: none'));
+    });
+  });
+});

--- a/src/general/events/interaction.events.ts
+++ b/src/general/events/interaction.events.ts
@@ -1,0 +1,38 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Context, ContextOf, On } from 'necord';
+import { CommandInteractionOption } from 'discord.js';
+
+@Injectable()
+export class InteractionEvents {
+  private readonly logger = new Logger(InteractionEvents.name);
+
+  // Single listener rather than a log line per command, so new commands are covered automatically.
+  @On('interactionCreate')
+  onInteractionCreate(
+    @Context() [interaction]: ContextOf<'interactionCreate'>,
+  ): void {
+    if (!interaction.isChatInputCommand()) return;
+
+    const args = interaction.options.data.map((option) => this.formatOption(option)).join(' ');
+    const location = interaction.channelId ? `channel ${interaction.channelId}` : 'DM';
+
+    this.logger.log(
+      `/${interaction.commandName} by ${interaction.user.username} (${interaction.user.id}) in ${location} args: ${args || 'none'}`,
+    );
+  }
+
+  private formatOption(option: CommandInteractionOption): string {
+    // Subcommands and groups carry their arguments in a nested options array.
+    if (option.options?.length) {
+      const nested = option.options.map((child) => this.formatOption(child)).join(' ');
+      return `${option.name}(${nested})`;
+    }
+
+    // Resolved entities arrive as objects, so log the identity rather than "[object Object]".
+    if (option.user) return `${option.name}=@${option.user.username}(${option.user.id})`;
+    if (option.channel) return `${option.name}=#${option.channel.id}`;
+    if (option.role) return `${option.name}=&${option.role.id}`;
+
+    return `${option.name}=${option.value ?? 'null'}`;
+  }
+}

--- a/src/general/general.module.ts
+++ b/src/general/general.module.ts
@@ -11,6 +11,7 @@ import { DatabaseService } from '../database/services/database.service';
 import { VoiceStateEvents } from './events/voice.state.events';
 import { ActivityService } from './services/activity.service';
 import { GuildMemberEvents } from './events/guild.member.events';
+import { InteractionEvents } from './events/interaction.events';
 import { PurgeCronService } from './services/purge.cron.service';
 import { ActivityReportCronService } from './services/activity.report.cron.service';
 import { ActivityReportCommand } from './commands/activity.report.command';
@@ -44,6 +45,7 @@ import { HealthcheckService } from './services/healthcheck.service';
     MessageEvents,
     VoiceStateEvents,
     GuildMemberEvents,
+    InteractionEvents,
 
     // Cron Services
     PurgeCronService,


### PR DESCRIPTION
Logs every slash command call at info level: what was run, who ran it, where, and with which arguments.

## Approach

One `@On('interactionCreate')` listener filtered to `isChatInputCommand()`, rather than a log line added to each of the eleven command classes. Commands added later are covered without anyone having to remember, and the format can't drift between handlers. `interaction.options.data` gives the resolved arguments, so nothing in the DTOs changes.

```
/albion-register by someuser (90078072660852736) in channel 1039269295735181413 args: character-name=Foo
/albion-scan by someuser (90078072660852736) in channel 1155997486318620746 args: dry-run=false
/ping by someuser (90078072660852736) in channel 1244019649222541402 args: none
```

One line per invocation so it greps cleanly.

Three details worth noting in review:

1. **Resolved entities are logged by identity.** `@UserOption` hands back a `User` object, not a snowflake, so a naive template would print `[object Object]`. User, channel and role options are formatted as `@name(id)`, `#id` and `&id` respectively. There's a test asserting `[object Object]` never appears.
2. **A `false` boolean is logged, not dropped.** `??` rather than a truthiness check, so `dry-run=false` appears — which is the argument you'd most want in the log when working out why a scan did or didn't execute.
3. **Subcommand arguments are flattened** (`add(character-name=Foo)`). Nothing uses subcommands today; this is three lines and stops the log going blank if anything does.

## Also in here

`MARIADB_AUTO_UPGRADE=1` on the db service in `docker-compose.yaml`. The official image only runs `mariadb-upgrade` when that variable is set — without it, bumping the image tag starts new binaries against system tables from the previous version, which surfaces as `Incorrect definition of table mysql.*`. This came up rolling out the 12.3.2 bump from #718: the running container had drifted well behind the committed tag, and the tag change alone would not have upgraded anything. Adding it here means the next Renovate mariadb PR is safe to roll out as-is.

## Memories

Three, all from tonight's work and all committed here per the usual convention: necord's `@Options()` silently dropping DTO field initialisers (the one that nearly caused a real purge in #727), the MariaDB requirement above, and the deploy webhook reporting failure on deployments that actually succeeded.

## Verification

`pnpm lint`, `pnpm build`, `pnpm test` and `npx tsc --noEmit` all clean on Node 24.12.0 — **406 tests across 36 suites**, up from 397/35, with every pre-existing test still passing.

Not yet observed against live Discord; the listener is exercised by unit tests only.

## Version bump

The `feat` type is deliberate — this adds new behaviour, so it takes a minor bump rather than a patch. Say if you'd rather it went out as a patch and I'll retype the commit.