### PR TITLE
docs: Correct CLAUDE.md after removal of the purge subsystem

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,9 @@ If `migration:up` fails with "MikroORM config file not found", run `pnpm build` 
 
 NestJS dependency-injection app bootstrapped in `src/main.ts` / `src/app.module.ts`. There is no HTTP server — the app's "controllers" are Discord slash commands and gateway events.
 
-- **Feature modules** — `src/general/` (core community features: activity tracking, purges, joiner/leaver stats, role metrics), `src/albion/`, `src/ps2/` (per-game registration/verification/scanning). Each follows the same internal layout:
+- **Feature modules** — `src/general/` (core community features: activity tracking and reports, joiner/leaver stats, role metrics, recruitment role pings, healthcheck), `src/albion/`, `src/ps2/` (per-game registration/verification/scanning). Each follows the same internal layout:
   - `commands/` — slash commands via `necord` decorators (`@SlashCommand` on the handler method, `@Context`/`@Options` on its params). Commands are thin; logic lives in services.
-  - `services/` — business logic. `*.cron.service.ts` files hold scheduled jobs (`@nestjs/schedule` `@Cron` decorators) that drive recurring scans/reports/purges.
+  - `services/` — business logic. `*.cron.service.ts` files hold scheduled jobs (`@nestjs/schedule` `@Cron` decorators) that drive recurring scans, reports and registration retries. A few `@Cron` jobs also sit in ordinary services (`healthcheck.service.ts`, `rec.role.ping.service.ts`).
   - `events/` (general only) — Discord gateway event handlers (guild member, message, voice state).
 - **`src/database/`** — MikroORM (MariaDB) entities and migrations. Entities extend `base.entity.ts`. Config is in root-level `mikro-orm.config.ts`. Migrations are non-transactional.
 - **`src/config/`** — `@nestjs/config` namespaced configs (`app`, `discord`, `albion`, `ps2`), including large Discord role/channel ID maps and PS2 rank→role mappings. Accessed via `ConfigService.get('discord.guildId')` etc.


### PR DESCRIPTION
#736 removed `/thanos-snap` and the purge subsystem, but `CLAUDE.md` was left describing it.

Two stale claims in the Architecture section:

- `src/general/` was listed as "activity tracking, purges, joiner/leaver stats, role metrics". It now reads "activity tracking and reports, joiner/leaver stats, role metrics, recruitment role pings, healthcheck", which matches what is actually in `src/general/services/` today.
- The `services/` bullet said cron services "drive recurring scans/reports/purges". It now says "scans, reports and registration retries", and notes that a couple of `@Cron` jobs live outside `*.cron.service.ts` (`healthcheck.service.ts`, `rec.role.ping.service.ts`).

I also grepped the rest of the repo for purge/thanos references in docs and config examples: `README.md` and `digletbot.env.example` are clean. The only other hit is a Claude memory file describing a past bug, which is a historical record and correct as-is.

Documentation only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)