### PR TITLE
fix(ci): Allow the renamed Sentry cpu-profiler build script

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -6,5 +6,6 @@
 - [necord's @Options() drops DTO defaults](necord-options-drops-dto-defaults.md) — field initialisers are ignored; omitted options arrive as null, so default at the read site
 - [MariaDB upgrades need MARIADB_AUTO_UPGRADE](mariadb-upgrades-need-auto-upgrade-env.md) — a tag bump alone leaves system tables un-upgraded; the DB container drifts behind the repo
 - [The deploy webhook reports false failures](deploy-webhook-reports-false-failure.md) — send-webhook goes red on deploys that worked; check /root/deploy.log instead
+- [allowBuilds breaks on dependency renames](pnpm-allowbuilds-breaks-on-renames.md) — an unlisted ignored build script fails pnpm install outright, killing CI before lint/test
 
 Note: this memory lives in the repo at `.claude/memory/` (wired via `autoMemoryDirectory` in `.claude/settings.json`) so it's shared via git across machines and collaborators. See README "Claude Code memory".

--- a/.claude/memory/pnpm-allowbuilds-breaks-on-renames.md
+++ b/.claude/memory/pnpm-allowbuilds-breaks-on-renames.md
@@ -1,0 +1,28 @@
+---
+name: pnpm-allowbuilds-breaks-on-renames
+description: "An unlisted ignored build script fails pnpm install outright; allowBuilds keys are exact names, so a dependency rename breaks CI"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 7e253822-08af-4203-b398-60ba9dcec1da
+  modified: 2026-07-29T02:24:55.870Z
+---
+
+`allowBuilds` in `pnpm-workspace.yaml` matches on exact package names, and pnpm 11 treats an
+ignored build script that isn't listed there as a hard `ERR_PNPM_IGNORED_BUILDS` failure — not
+a warning. So when a dependency *renames* its native subpackage, every CI job dies at
+`pnpm install` before lint/build/test run. Hit on 2026-07-29: Sentry 10.65.0 renamed
+`@sentry-internal/node-cpu-profiler` to `@sentry/node-cpu-profiler`, failing PR #719 (fixed in
+#739). The failing install also appends a `': set this to true or false'` placeholder line to
+`pnpm-workspace.yaml`, so the file comes back dirty locally.
+
+**Why:** the error text points at `pnpm approve-builds` and names the package, but not the fact
+that a *previously handled* package changed name — it reads like a brand-new untrusted
+dependency, which sends you looking in the wrong place.
+
+**How to apply:** on any `ERR_PNPM_IGNORED_BUILDS`, diff the lockfile for a package dropping out
+as another appears before assuming it's new. Fix by adding the new name to `allowBuilds`
+(`false` for anything that only checks for a prebuilt binary — the Docker image installs with
+`--ignore-scripts` anyway). List both names while the bump is in flight, and land the change on
+`main` rather than the Renovate branch, since Renovate wipes non-Renovate commits when it
+rebases.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,12 @@
 # These packages' install scripts are deliberately not run: @nestjs/core's and necord's are
-# OpenCollective donation banners, and the other two only *check* that a prebuilt native binary is
+# OpenCollective donation banners, and the others only *check* that a prebuilt native binary is
 # present — the binaries ship in the published tarballs. The production image installs with
 # --ignore-scripts anyway, so allowing them here would only diverge CI from what actually ships.
+# Sentry renamed the profiler package in 10.65.0; both names are listed to cover either version.
 allowBuilds:
   '@nestjs/core': false
   '@sentry-internal/node-cpu-profiler': false
+  '@sentry/node-cpu-profiler': false
   necord: false
   unrs-resolver: false
 minimumReleaseAgeExclude:


### PR DESCRIPTION
## Problem

The Sentry bump in #719 fails at `pnpm install` before it gets anywhere near lint/build/test:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @sentry/node-cpu-profiler@2.4.2
```

Sentry 10.65.0 renames the native profiler package — the lockfile diff on that PR shows
`@sentry-internal/node-cpu-profiler@2.2.0` dropping out and `@sentry/node-cpu-profiler@2.4.2`
taking its place. Our `allowBuilds` map in `pnpm-workspace.yaml` only lists the old name, so
the new package's install script counts as an un-decided ignored build, and pnpm 11 treats
that as a hard error rather than a warning.

Any Sentry bump past 10.65.0 hits this, not just #719, which is why it lands here rather than
on the Renovate branch — Renovate wipes non-Renovate commits when it rebases.

## Fix

List the new name alongside the old one, with the same `false` value. That's consistent with
the existing policy for this package: its install script only *checks* that a prebuilt binary
is present, and the production image installs with `--ignore-scripts` anyway. Keeping both
names means installs pass either side of the bump; the `@sentry-internal/*` entry can be
dropped once the Sentry update merges.

## Validation

Reproduced the CI failure locally by checking out #719's head on Node 24.12.0 with pnpm
11.15.1 — `pnpm install --frozen-lockfile` fails with the error above. Adding this line makes
the same install exit 0. Confirmed pnpm tolerates the unmatched `@sentry-internal/*` key
without erroring or rewriting the file, and that install on `main` with this change still
exits 0.

Worth knowing: the failing install *appends* a placeholder line
(`'@sentry/node-cpu-profiler': set this to true or false`) to `pnpm-workspace.yaml`. Harmless
on a runner, but anyone who ran `pnpm install` on the Sentry branch will have a dirty file to
discard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)