### PR TITLE
ci: Type-check spec files

### DIFF
--- a/.github/workflows/build-and-test-main.yml
+++ b/.github/workflows/build-and-test-main.yml
@@ -50,6 +50,11 @@ jobs:
       - name: Check if app builds properly
         run: pnpm build
 
+      # pnpm build uses tsconfig.build.json, which excludes *.spec.ts, and ts-jest transpiles
+      # without type checking. Without this step nothing in CI type checks the tests.
+      - name: Check types, including tests
+        run: pnpm typecheck
+
       - name: Run tests with coverage
         run: pnpm test:ci
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,6 +47,11 @@ jobs:
       - name: Check if app builds properly
         run: pnpm build
 
+      # pnpm build uses tsconfig.build.json, which excludes *.spec.ts, and ts-jest transpiles
+      # without type checking. Without this step nothing in CI type checks the tests.
+      - name: Check types, including tests
+        run: pnpm typecheck
+
       - name: Run tests with coverage
         run: pnpm test:ci
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "mikro-orm migration:up && node dist/src/main",
     "test": "jest --coverage",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "test:wsl": "jest --coverage --maxWorkers=4",
     "test:ci": "jest --ci --coverage",
     "test:watch": "jest --watch",


### PR DESCRIPTION
Nothing in CI type-checks the tests. Adds a step that does.

## The gap

Three things each assume something else is checking, and nothing is:

- `pnpm build` compiles against `tsconfig.build.json`, which sets `"exclude": [..., "**/*spec.ts"]` — so it never looks at a test file
- `ts-jest` transpiles without checking types. Verified rather than assumed: a spec containing `const n: number = 'this is a string, not a number'` runs green, 1 passed
- ESLint doesn't type-check

So a spec can be arbitrarily wrong about types while `lint`, `build` and `test` all pass. That isn't hypothetical — eight such errors had accumulated behind a fully green pipeline before #727 happened to surface them.

## The change

- `typecheck` script running `tsc --noEmit -p tsconfig.json` — the root config, which unlike the build config does include specs
- The step wired into both `pr.yml` and `build-and-test-main.yml`, between build and test, so a type failure surfaces before the ~90s suite runs

Passes clean on current main, so it goes in green rather than needing a backlog of fixes first.