### PR TITLE
fix(ci): Call the deploy hook with curl instead of a marketplace action

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -5,7 +5,6 @@
 - [Commit messages drive the version bump](commit-messages-drive-version-bump.md) — substring match on main: "feat" anywhere in a message forces a minor bump
 - [necord's @Options() drops DTO defaults](necord-options-drops-dto-defaults.md) — field initialisers are ignored; omitted options arrive as null, so default at the read site
 - [MariaDB upgrades need MARIADB_AUTO_UPGRADE](mariadb-upgrades-need-auto-upgrade-env.md) — a tag bump alone leaves system tables un-upgraded; the DB container drifts behind the repo
-- [The deploy webhook reports false failures](deploy-webhook-reports-false-failure.md) — send-webhook goes red on deploys that worked; check /root/deploy.log instead
-- [allowBuilds breaks on dependency renames](pnpm-allowbuilds-breaks-on-renames.md) — an unlisted ignored build script fails pnpm install outright, killing CI before lint/test
+- [The deploy webhook reports false failures](deploy-webhook-reports-false-failure.md) — Node 19+ globalAgent kills the request at 5s, so Actions webhook wrappers are unusable; use curl
 
 Note: this memory lives in the repo at `.claude/memory/` (wired via `autoMemoryDirectory` in `.claude/settings.json`) so it's shared via git across machines and collaborators. See README "Claude Code memory".

--- a/.claude/memory/deploy-webhook-reports-false-failure.md
+++ b/.claude/memory/deploy-webhook-reports-false-failure.md
@@ -1,15 +1,29 @@
 ---
 name: deploy-webhook-reports-false-failure
-description: "ci.yml's send-webhook step goes red on deploys that actually succeeded — check /root/deploy.log on the host, not the Actions result"
+description: "Actions wrappers for the deploy webhook die at 5s on Node 19+ because https.globalAgent sets timeout:5000 — the configured timeout is unreachable, so call the hook with curl"
 metadata: 
   node_type: memory
   type: project
-  originSessionId: 98e6e913-c748-4676-92ad-94d3e2352e1b
-  modified: 2026-07-29T01:37:43.327Z
+  originSessionId: f59bd104-1a86-4613-a4d3-c718fae6dff4
+  modified: 2026-07-29T02:27:17.845Z
 ---
 
-The `Trigger deployment / send-webhook` job in `ci.yml` reports failure while the deploy itself succeeds. It errors with `timeout of 120000ms exceeded` after only **~5 seconds**, so it is a connection/response-handling problem mislabelled as a timeout. Confirmed on both `e33a1c8` (2.27.12) and `46abe1e` (2.27.13): `/root/deploy.log` on the host shows the deploy fired and recreated the container each time.
+`ramzzisudip/secure-github-webhook@0.3.0` — and any Actions wrapper that does not set its
+own HTTP agent — aborts the request after **~5 seconds** regardless of its `timeout` input,
+then reports `timeout of <configured>ms exceeded`, which is why the error looks like a
+timeout that has not happened. Since Node 19 `https.globalAgent` is
+`{keepAlive: true, timeout: 5000, …}`; that 5000 is a socket idle timeout, the socket is
+idle for the whole deploy, so it fires, the request emits `timeout`, and axios rejects with
+its own configured message. Reproduced off-infrastructure against `httpbin.org/delay/10`:
+`EXIT after 5373ms` with `timeout: 120000`. A request with a fresh agent waits properly.
 
-**Why:** a pipeline that shows red on every successful deploy trains everyone to stop reading it, so the day it fails for real nothing stands out. There is also no watchtower container on that host despite `watchtower.enable` labels on both compose services — the webhook is the only deploy path, with nothing quietly covering for it.
+**Why:** this only started showing on 2026-07-28, when the webhooks repo made deploy hooks
+synchronous (`include-command-output-in-response`), so responses went from instant to
+37–86s. Nothing changed in this repo, and raising the action's timeout 2000 → 120000 could
+never have helped — the input is unreachable. The deploys themselves all landed.
 
-**How to apply:** treat a red `send-webhook` as unproven, not failed. Verify against `/root/deploy.log` and the container's `StartedAt` before assuming a deploy did not land. Note the repo's `server-update.sh` is **not** the script that actually runs — the host's real one pulls and recreates by changed image and logs different text. Related: [[mariadb-upgrades-need-auto-upgrade-env]].
+**How to apply:** call the hook with `curl` and `--fail-with-body --max-time`, signing the
+body with `openssl dgst -sha256 -hmac` (verified byte-identical to the action's HMAC), as
+`.github/workflows/deploy.yml` now does. A red `send-webhook` is now a real deploy failure
+and its output is the deploy's own. Same fix applies to any other repo pointing at that
+host. Related: [[mariadb-upgrades-need-auto-upgrade-env]].

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,24 +9,29 @@ permissions:
 jobs:
   send-webhook:
     runs-on: ubuntu-latest
-    # Backstop only. The step below should resolve long before this.
+    # Backstop only. --max-time below should resolve first.
     timeout-minutes: 5
     steps:
-      # The receiving hook waits for the deployment to finish and answers 200 or 500,
-      # so this timeout has to cover a whole deploy rather than just the round trip.
-      # Measured deploys run 37-86s; the proxy in front of the hook gives up at ~100s
-      # and returns a 524 of its own. 120s sits above that deliberately: a deploy that
-      # overruns should surface as that 524 — which says the deploy was still running —
-      # rather than as a client-side timeout, which says nothing at all.
-      #
-      # It was 2000ms, which timed out on 2026-07-28 while the deploy underneath it ran
-      # to completion, reporting a failure that had not happened. The reverse was worse:
-      # at 2000ms this step returned before the hook could know the outcome, so a
-      # crashlooping bot came back green.
+      # curl rather than an action. Every Actions wrapper for this leaves Node's
+      # default agent in place, and since Node 19 https.globalAgent carries
+      # timeout: 5000 — so the socket is killed at 5s no matter what timeout the
+      # action was given, and the error still quotes the configured value. The
+      # hook waits for the whole deploy, so that fired on every single run.
       - name: Trigger webhook
-        uses: ramzzisudip/secure-github-webhook@0.3.0
-        with:
-          url: "${{ secrets.WEBHOOK_URL }}"
-          data: '{ "application": "digletbot" }'
-          timeout: 120000
-          hmacSecret: "${{ secrets.WEBHOOK_SECRET }}"
+        env:
+          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
+          WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
+        run: |
+          body='{"application":"digletbot"}'
+          signature=$(printf '%s' "$body" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" -r | cut -d' ' -f1)
+
+          # The hook answers 200 or 500 carrying the deploy's own output, so this
+          # step's result is the deploy's result. 180s clears the ~100s at which the
+          # proxy in front gives up — an overrun should surface as that 524, which
+          # at least says the deploy was still running.
+          curl --fail-with-body --silent --show-error --max-time 180 \
+            --header 'Content-Type: application/json' \
+            --header "X-Hub-Signature-256: sha256=$signature" \
+            --header "X-Hub-SHA: $GITHUB_SHA" \
+            --data "$body" \
+            "$WEBHOOK_URL"


### PR DESCRIPTION
## The problem

`Trigger deployment / send-webhook` has failed on every run since 2026-07-28. Every failure looks the same: `Error: timeout of 120000ms exceeded`, raised **~5 seconds** into the step.

The deploys were landing the whole time. Taking the last failure as the example, the hook logged `200` after `55.7s` having recreated the container, while Actions had already given up 4.6 seconds in.

## Why

`ramzzisudip/secure-github-webhook@0.3.0` never sets its own HTTP agent, so it inherits Node's default. Since Node 19 `https.globalAgent` is `{keepAlive: true, timeout: 5000, …}`, and that `timeout` is a socket idle timeout. While the hook is busy deploying, the socket is idle — so it fires at 5s, the request emits `timeout`, and axios rejects using its *configured* message. That's why the error quotes a duration that never elapsed.

The `timeout` input is therefore unreachable for anything over 5 seconds, and raising it from 2000 to 120000 in #725 could never have helped.

Reproduced with no involvement from our own infrastructure, running the action's own `dist/index.js` against `https://httpbin.org/delay/10`:

```
::error::Error: timeout of 120000ms exceeded
EXIT after 5373ms
```

The same request with a fresh agent returns `OK 200 after 11273ms`.

Nothing changed in this repo to cause it. The hooks became synchronous on 2026-07-28, so responses went from instant to 37–86s and crossed the 5s ceiling that had been there, unnoticed, since the runners moved off Node 16.

## The change

`openssl dgst -sha256 -hmac` for the signature, `curl` for the request. `--fail-with-body` is what makes this step meaningful — the hook answers `200` or `500` carrying the deploy script's own output, so a red run is now a real deploy failure with the reason attached. `--max-time 180` clears the ~100s at which the proxy in front gives up and returns its own `524`.

The same change is going into the other three repos that call these hooks, and the canonical snippet is documented in the webhooks repo.

## Validation

- The `openssl` digest is byte-identical to the action's node HMAC over the same body.
- `500` → step fails with the body printed. `200` → passes. **10-second delayed response → passes**, which is the case that was failing.
- The workflow file parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)