### PR TITLE
fix(commands): Defer replies on commands that work before responding

### DIFF
--- a/src/albion/commands/deregistration.command.ts
+++ b/src/albion/commands/deregistration.command.ts
@@ -2,6 +2,7 @@ import { Context, Options, SlashCommand, SlashCommandContext } from 'necord';
 import { Injectable, Logger } from '@nestjs/common';
 import { AlbionDeregistrationService } from '../services/albion.deregistration.service';
 import { AlbionDeregisterDto } from '../dto/albion.deregister.dto';
+import { replyTo } from '../../discord/discord.hacks';
 
 @Injectable()
 export class AlbionDeregisterCommand {
@@ -21,9 +22,12 @@ export class AlbionDeregisterCommand {
   ): Promise<void> {
     this.logger.log('Received Albion Deregister Command', dto);
 
+    // Deregistration hits the database before replying, which blows Discord's 3s window.
+    await interaction.deferReply();
+
     // If neither character nor discordMember is provided, throw
     if (!dto.character && !dto.discordMember) {
-      await interaction.reply('❌ You must provide either a character name or a Discord member to deregister.');
+      await replyTo(interaction, '❌ You must provide either a character name or a Discord member to deregister.');
       return;
     }
 
@@ -31,6 +35,8 @@ export class AlbionDeregisterCommand {
 
     // Create placeholder message
     const message = await interaction.channel.send(`Deregistration process for ${name} started. Please wait...`);
+
+    let outcome = `Deregistration process for ${name} complete.`;
 
     try {
       await this.albionDeregistrationService.deregister(
@@ -40,10 +46,14 @@ export class AlbionDeregisterCommand {
     }
     catch (err) {
       this.logger.error('Error during deregistration process', err);
-      await message.channel.send(`❌ An error occurred during the deregistration process for ${name}. Error: ${err.message}`);
+      outcome = `❌ An error occurred during the deregistration process for ${name}. Error: ${err.message}`;
+      await message.channel.send(outcome);
     }
 
     // Delete placeholder
     await message.delete();
+
+    // Without this the deferred "thinking..." state never resolves.
+    await replyTo(interaction, outcome);
   }
 }

--- a/src/albion/commands/log.command.ts
+++ b/src/albion/commands/log.command.ts
@@ -1,6 +1,7 @@
 import { Context, SlashCommand, SlashCommandContext } from 'necord';
 import { Injectable, Logger } from '@nestjs/common';
 import { randomInt } from 'node:crypto';
+import { replyTo } from '../../discord/discord.hacks';
 
 @Injectable()
 export class AlbionLogCommand {
@@ -14,6 +15,9 @@ export class AlbionLogCommand {
     @Context() [interaction]: SlashCommandContext,
   ): Promise<void> {
     this.logger.debug('Received Albion Log Command');
+
+    // Both messages are sent to the channel, so the interaction itself was never acknowledged.
+    await interaction.deferReply();
 
     const images = [
       'https://cdn.discordapp.com/attachments/1039269706605002912/1159810488088154122/image.png?ex=653b9b30&is=65292630&hm=bd8a57e7667948ffad446b27f32a1b6e64733f4aa7929417e3afd78e1e53e993&',
@@ -31,5 +35,8 @@ The log is girthy, the log is big.
 The log will log our logs with speed.`);
     // crypto rather than Math.random purely to keep the SAST scanner quiet — see rule S2245.
     (await interaction.channel.send(images[randomInt(images.length)])).react('🪵');
+
+    // Without this the deferred "thinking..." state never resolves.
+    await replyTo(interaction, 'ALL HAIL THE LOG 🪵');
   }
 }

--- a/src/albion/commands/register.command.ts
+++ b/src/albion/commands/register.command.ts
@@ -25,6 +25,9 @@ export class AlbionRegisterCommand {
     @Options() dto: AlbionRegisterDto,
     @Context() [interaction]: SlashCommandContext,
   ): Promise<string> {
+    // The placeholder message is sent before the first reply, which blows Discord's 3s window.
+    await interaction.deferReply();
+
     // Check if the command came from the correct channel ID
     const registrationChannelId = this.config.get('discord.channels.albionRegistration');
 

--- a/src/albion/commands/scan.command.ts
+++ b/src/albion/commands/scan.command.ts
@@ -23,6 +23,8 @@ export class AlbionScanCommand {
     @Context() [interaction]: SlashCommandContext,
   ): Promise<string> {
     this.logger.debug('Received Albion Scan Command');
+    // API and database work happens before the first reply, which blows Discord's 3s window.
+    await interaction.deferReply();
     const dryRun = dto.dryRun ?? false;
 
     // Check if the command came from the correct channel ID

--- a/src/discord/discord.hacks.spec.ts
+++ b/src/discord/discord.hacks.spec.ts
@@ -1,0 +1,44 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { replyTo } from './discord.hacks';
+
+describe('discord.hacks', () => {
+  const mockInteraction = (overrides: any = {}): any => ({
+    deferred: false,
+    replied: false,
+    reply: jest.fn(),
+    editReply: jest.fn(),
+    ...overrides,
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('replyTo', () => {
+    it('should reply directly when the interaction has not been deferred', async () => {
+      const interaction = mockInteraction();
+      await replyTo(interaction, 'hello');
+      expect(interaction.reply).toHaveBeenCalledWith('hello');
+      expect(interaction.editReply).not.toHaveBeenCalled();
+    });
+
+    // Replying to a deferred interaction throws, so it has to be edited instead.
+    it('should edit the reply when the interaction was deferred', async () => {
+      const interaction = mockInteraction({ deferred: true });
+      await replyTo(interaction, 'hello');
+      expect(interaction.editReply).toHaveBeenCalledWith('hello');
+      expect(interaction.reply).not.toHaveBeenCalled();
+    });
+
+    it('should edit the reply when the interaction was already replied to', async () => {
+      const interaction = mockInteraction({ replied: true });
+      await replyTo(interaction, 'hello');
+      expect(interaction.editReply).toHaveBeenCalledWith('hello');
+      expect(interaction.reply).not.toHaveBeenCalled();
+    });
+
+    it('should return the content it sent', async () => {
+      expect(await replyTo(mockInteraction(), 'echoed')).toBe('echoed');
+    });
+  });
+});

--- a/src/discord/discord.hacks.ts
+++ b/src/discord/discord.hacks.ts
@@ -7,10 +7,16 @@ export const getChannel = (message: Message): GuildTextBasedChannel => {
 
 // necord discards whatever a command handler returns, so every reply has to be explicit.
 // Handing the content back keeps handlers readable as `return replyTo(...)`.
+// Deferred interactions must be edited rather than replied to, or discord.js throws.
 export const replyTo = async (
   interaction: ChatInputCommandInteraction,
   content: string,
 ): Promise<string> => {
-  await interaction.reply(content);
+  if (interaction.deferred || interaction.replied) {
+    await interaction.editReply(content);
+  }
+  else {
+    await interaction.reply(content);
+  }
   return content;
 };

--- a/src/general/commands/hello.there.command.spec.ts
+++ b/src/general/commands/hello.there.command.spec.ts
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Test, TestingModule } from '@nestjs/testing';
+import { HelloThereCommand } from './hello.there.command';
+import { TestBootstrapper } from '../../test.bootstrapper';
+
+describe('HelloThereCommand', () => {
+  let command: HelloThereCommand;
+  let mockInteraction: any;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [HelloThereCommand],
+    }).compile();
+
+    command = module.get<HelloThereCommand>(HelloThereCommand);
+    // Don't actually wait 5 seconds in the suite.
+    command['delay'] = jest.fn().mockResolvedValue(undefined);
+
+    mockInteraction = TestBootstrapper.getMockDiscordInteraction(
+      '1234',
+      TestBootstrapper.getMockDiscordUser(),
+    )[0];
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('onHelloThereCommand', () => {
+    it('should defer before doing the slow work', async () => {
+      await command.onHelloThereCommand([mockInteraction]);
+      expect(mockInteraction.deferReply).toHaveBeenCalled();
+    });
+
+    it('should reply with the expected greeting', async () => {
+      await command.onHelloThereCommand([mockInteraction]);
+      expect(mockInteraction.reply).toHaveBeenCalledWith('General Kenobi!');
+    });
+
+    // The whole point of the command: the wait must exceed Discord's 3s window.
+    it('should wait longer than the interaction acknowledgement window', async () => {
+      await command.onHelloThereCommand([mockInteraction]);
+      const waited = (command['delay'] as jest.Mock).mock.calls[0][0];
+      expect(waited).toBeGreaterThan(3000);
+    });
+
+    it('should defer before waiting, not after', async () => {
+      const order: string[] = [];
+      mockInteraction.deferReply = jest.fn(() => { order.push('defer'); });
+      command['delay'] = jest.fn(() => {
+        order.push('wait');
+        return Promise.resolve();
+      });
+
+      await command.onHelloThereCommand([mockInteraction]);
+      expect(order).toEqual(['defer', 'wait']);
+    });
+  });
+});

--- a/src/general/commands/hello.there.command.ts
+++ b/src/general/commands/hello.there.command.ts
@@ -1,0 +1,30 @@
+import { Context, SlashCommand, SlashCommandContext } from 'necord';
+import { Injectable, Logger } from '@nestjs/common';
+import { replyTo } from '../../discord/discord.hacks';
+
+@Injectable()
+export class HelloThereCommand {
+  private readonly logger = new Logger(HelloThereCommand.name);
+
+  // Deliberately longer than Discord's 3 second acknowledgement window. Without the deferral
+  // below this command would always fail with "The application did not respond".
+  private static readonly DELAY_MS = 5000;
+
+  @SlashCommand({
+    name: 'hello-there',
+    description: 'General Kenobi',
+  })
+  async onHelloThereCommand(
+    @Context() [interaction]: SlashCommandContext,
+  ): Promise<void> {
+    this.logger.debug('Received Hello There Command');
+
+    await interaction.deferReply();
+    await this.delay(HelloThereCommand.DELAY_MS);
+    await replyTo(interaction, 'General Kenobi!');
+  }
+
+  protected delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/src/general/general.module.ts
+++ b/src/general/general.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { PingCommand } from './commands/ping.command';
+import { HelloThereCommand } from './commands/hello.there.command';
 import { ConfigModule } from '../config/config.module';
 import { DiscordService } from '../discord/discord.service';
 import { MessageEvents } from './events/message.events';
@@ -34,6 +35,7 @@ import { HealthcheckService } from './services/healthcheck.service';
 
     // Commands
     ActivityReportCommand,
+    HelloThereCommand,
     PingCommand,
 
     // Events

--- a/src/ps2/commands/scan.command.ts
+++ b/src/ps2/commands/scan.command.ts
@@ -23,6 +23,8 @@ export class PS2ScanCommand {
     @Context() [interaction]: SlashCommandContext,
   ): Promise<string> {
     this.logger.debug('Received PS2ScanCommand');
+    // API and database work happens before the first reply, which blows Discord's 3s window.
+    await interaction.deferReply();
     const dryRun = dto.dryRun ?? false;
 
     // Check if the command came from the correct channel ID

--- a/src/ps2/commands/verify.command.ts
+++ b/src/ps2/commands/verify.command.ts
@@ -26,6 +26,8 @@ export class PS2VerifyCommand {
     @Context() [interaction]: SlashCommandContext,
   ): Promise<string> {
     this.logger.debug(`Received PS2VerifyCommand with character ${dto.character}`);
+    // API and database work happens before the first reply, which blows Discord's 3s window.
+    await interaction.deferReply();
     // Check if the command came from the correct channel ID
     const verifyChannelId = this.config.get('discord.channels.ps2Verify');
 

--- a/src/ps2/commands/verify.manual.command.ts
+++ b/src/ps2/commands/verify.manual.command.ts
@@ -26,6 +26,8 @@ export class PS2VerifyManualCommand {
     @Context() [interaction]: SlashCommandContext,
   ): Promise<string> {
     this.logger.debug(`Received onPS2VerifyManualCommand with character ${dto.character}`);
+    // API and database work happens before the first reply, which blows Discord's 3s window.
+    await interaction.deferReply();
     // Check if the command came from the correct channel ID
     const verifyChannelId = this.config.get('discord.channels.ps2Verify');
 

--- a/src/test.bootstrapper.ts
+++ b/src/test.bootstrapper.ts
@@ -250,6 +250,10 @@ export class TestBootstrapper {
           send: jest.fn().mockReturnValue(TestBootstrapper.getMockDiscordMessage()),
         },
         reply: jest.fn(),
+        deferReply: jest.fn(),
+        editReply: jest.fn(),
+        deferred: false,
+        replied: false,
       },
     ];
   }


### PR DESCRIPTION
Discord closes the interaction acknowledgement window after **3 seconds**. Seven commands did API, database or channel work before their first reply, so a slow dependency meant the reply fired against a dead token and the user saw "The application did not respond".

## What was wrong

| Command | Work before first reply |
|---|---|
| `/ps2-verify` | Census lookup, member fetch, validation |
| `/ps2-verify-manual` | 2 member fetches, Census lookup, add/remove |
| `/albion-register` | placeholder `channel.send` |
| `/albion-scan`, `/ps2-scan` | placeholder `channel.send` |
| `/albion-deregister` | `channel.send` + database deregistration |
| `/the-log-is-life` | 2 × `channel.send` |

`/albion-force-retry` already replies first and then edits, which is the correct pattern — it's unchanged and was the model for this.

**`/ps2-verify` was the worst case.** `census.api.service.ts` retries 10 times with a 3s delay and a 10s timeout, so `getCharacter` can run for roughly **130 seconds**. Its `catch` block then tried to report the failure — meaning when Census was down, exactly when someone needed telling why, the error path could never reply at all.

**`/albion-deregister` and `/the-log-is-life` never acknowledged the interaction on their happy paths at all**, regardless of timing, so both showed that message every single time. Flagged as pre-existing in #727 and left alone then; deferring fixes them, but only if they also resolve, so both now finish with an outcome message.

## The change

- `await interaction.deferReply()` at the top of the seven affected handlers. The user sees "*DigletBot is thinking…*" and the window becomes 15 minutes.
- `replyTo` edits rather than replies once an interaction is deferred, since replying twice throws. No-op for handlers that don't defer, so the four commands still using it directly are unaffected.
- `/albion-deregister` reports success or the caught error; `/the-log-is-life` closes with a short acknowledgement.

## `/hello-there`

Added deliberately as a live check: defers, waits 5 seconds, answers "General Kenobi!". Five seconds is comfortably past the 3s window, so if the deferral ever regresses this command fails visibly and immediately rather than only under load. Its spec asserts the wait exceeds 3s and that the defer happens *before* the wait, not after.

## Verification

`pnpm lint`, `pnpm build`, `pnpm test` and `npx tsc --noEmit` all clean on Node 24.12.0 — **371 tests across 35 suites**, up from 367/34. New specs cover both `replyTo` branches and the `/hello-there` ordering.

Not yet exercised against live Discord — `/hello-there` exists precisely so that's a five second manual check after deploy.