### PR TITLE
fix(logging): Log the channel name alongside its id

### DIFF
--- a/src/general/events/interaction.events.spec.ts
+++ b/src/general/events/interaction.events.spec.ts
@@ -11,6 +11,7 @@ describe('InteractionEvents', () => {
     isChatInputCommand: () => true,
     commandName: 'albion-scan',
     channelId: '1155997486318620746',
+    channel: { name: 'albion-scans' },
     user: { username: 'digletuser', id: '90078072660852736' },
     options: { data: [] },
     ...overrides,
@@ -40,7 +41,15 @@ describe('InteractionEvents', () => {
     it('should log the command, caller and channel when there are no arguments', () => {
       interactionEvents.onInteractionCreate([mockInteraction()]);
       expect(logSpy).toHaveBeenCalledWith(
-        '/albion-scan by digletuser (90078072660852736) in channel 1155997486318620746 args: none',
+        '/albion-scan by digletuser (90078072660852736) in #albion-scans (1155997486318620746) args: none',
+      );
+    });
+
+    // The channel can be uncached, and DM channels have no name at all.
+    it('should fall back to the bare channel id when the channel has no name', () => {
+      interactionEvents.onInteractionCreate([mockInteraction({ channel: null })]);
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('in channel 1155997486318620746'),
       );
     });
 

--- a/src/general/events/interaction.events.ts
+++ b/src/general/events/interaction.events.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Context, ContextOf, On } from 'necord';
-import { CommandInteractionOption } from 'discord.js';
+import { ChatInputCommandInteraction, CommandInteractionOption } from 'discord.js';
 
 @Injectable()
 export class InteractionEvents {
@@ -14,11 +14,21 @@ export class InteractionEvents {
     if (!interaction.isChatInputCommand()) return;
 
     const args = interaction.options.data.map((option) => this.formatOption(option)).join(' ');
-    const location = interaction.channelId ? `channel ${interaction.channelId}` : 'DM';
+    const location = this.formatLocation(interaction);
 
     this.logger.log(
       `/${interaction.commandName} by ${interaction.user.username} (${interaction.user.id}) in ${location} args: ${args || 'none'}`,
     );
+  }
+
+  private formatLocation(interaction: ChatInputCommandInteraction): string {
+    if (!interaction.channelId) return 'DM';
+
+    // DM channels have no name, and the channel can be uncached, so fall back to the bare ID.
+    const channel = interaction.channel;
+    const name = channel && 'name' in channel ? channel.name : null;
+
+    return name ? `#${name} (${interaction.channelId})` : `channel ${interaction.channelId}`;
   }
 
   private formatOption(option: CommandInteractionOption): string {


### PR DESCRIPTION
The command invocation log printed a bare channel snowflake, which means nothing without looking it up.

Before:
```
/albion-scan by someuser (90078072660852736) in channel 1155997486318620746 args: dry-run=false
```

After:
```
/albion-scan by someuser (90078072660852736) in #albion-scans (1155997486318620746) args: dry-run=false
```

The id is kept as well, since it's still what you need to actually go and look something up.

Two fallbacks, both covered by tests: the channel can be uncached, and DM channels have no `name` at all — either case logs the bare id rather than `#undefined`.

`pnpm lint`, `pnpm build`, `pnpm test` and `pnpm typecheck` clean — 372 tests across 35 suites.