### PR TITLE
docs(claude): Record the Renovate/pnpm minimum release age findings

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -6,5 +6,8 @@
 - [necord's @Options() drops DTO defaults](necord-options-drops-dto-defaults.md) — field initialisers are ignored; omitted options arrive as null, so default at the read site
 - [MariaDB upgrades need MARIADB_AUTO_UPGRADE](mariadb-upgrades-need-auto-upgrade-env.md) — a tag bump alone leaves system tables un-upgraded; the DB container drifts behind the repo
 - [The deploy webhook reports false failures](deploy-webhook-reports-false-failure.md) — Node 19+ globalAgent kills the request at 5s, so Actions webhook wrappers are unusable; use curl
+- [allowBuilds breaks on dependency renames](pnpm-allowbuilds-breaks-on-renames.md) — an unlisted ignored build script fails pnpm install outright, killing CI before lint/test
+- [Lock file maintenance bypasses Renovate's age gate](lockfile-maintenance-bypasses-renovate-age-gate.md) — the 14-day wait doesn't cover it; pnpm's own minimumReleaseAge is the only guard
+- [Renovate freezes PRs under minimumReleaseAge](renovate-freezes-prs-under-minimum-release-age.md) — forced PRs never rebase, and the rebase checkbox can't unstick them
 
 Note: this memory lives in the repo at `.claude/memory/` (wired via `autoMemoryDirectory` in `.claude/settings.json`) so it's shared via git across machines and collaborators. See README "Claude Code memory".

--- a/.claude/memory/lockfile-maintenance-bypasses-renovate-age-gate.md
+++ b/.claude/memory/lockfile-maintenance-bypasses-renovate-age-gate.md
@@ -1,0 +1,26 @@
+---
+name: lockfile-maintenance-bypasses-renovate-age-gate
+description: Renovate's 14-day minimumReleaseAge does not apply to lock file maintenance; pnpm's own setting is the only guard on that path
+metadata:
+  type: project
+---
+
+`renovate.json` sets `minimumReleaseAge: 14 days`, but Renovate's `isMinimumReleaseAgeApplicable()`
+excludes the `lockFileMaintenance` update type — resolution is delegated to the package manager, so
+Renovate never sees candidate releases to age-filter. The weekly job deletes `pnpm-lock.yaml` and
+re-runs `pnpm install --lockfile-only`, re-resolving every caret in `package.json` against pnpm's
+policy alone. This repo is the only one of mine with `lockFileMaintenance` enabled; Renovate's
+default is `enabled: false`.
+
+**Why:** the 14-day wait reads like a repo-wide guarantee and isn't one. On 2026-07-29 `main`'s
+lockfile held `@sentry/node@10.68.0` five days after publication, plus `minimatch@10.2.6` at two
+days — all arriving under `^` ranges while the PR proposing a *reviewed* Sentry bump sat frozen.
+
+**How to apply:** the guard on that path is `minimumReleaseAge` in `pnpm-workspace.yaml` (minutes;
+pnpm 11 defaults to 1440 = 1 day), raised to 10080 = 7 days in PR #744. Not 14, because
+`vulnerabilityAlerts` deliberately bypasses the Renovate wait and a 14-day pnpm gate would block a
+CVE fix from installing at all. Raising it needs the lockfile regenerated in the same commit —
+`trustLockfile` defaults false, so every install re-checks existing entries and a stricter value
+fails `--frozen-lockfile` until they age out. Exact pins can make a value unreachable entirely:
+14 days was impossible while `@typescript-eslint` was pinned at 8.65.0. See
+[[pnpm-allowbuilds-breaks-on-renames]] for the other pnpm-policy trap.

--- a/.claude/memory/renovate-freezes-prs-under-minimum-release-age.md
+++ b/.claude/memory/renovate-freezes-prs-under-minimum-release-age.md
@@ -1,0 +1,25 @@
+---
+name: renovate-freezes-prs-under-minimum-release-age
+description: A Renovate PR forced from the dashboard before minimumReleaseAge is frozen — no rebases, no bumps — and the rebase checkbox cannot unstick it
+metadata:
+  type: project
+---
+
+Forcing a PR from the Dependency Dashboard while the release is younger than `minimumReleaseAge`
+gets the branch created, and nothing more. `internalChecksFilter` defaults to `strict`, which sets
+`pendingChecks`, and the branch worker then returns early on every later run: *"Branch updating is
+skipped because internalChecksFilter was not met"*. No rebase, no version bump, no PR body refresh
+until the age is met. Measured 2026-07-29: PR #729 sat 17 commits behind `main` for a day while
+#719, identical config but a green check, rebased and automerged the moment `main` moved.
+
+**Why:** it looks like Renovate has silently broken or lost the webhook, and the obvious remedy —
+ticking the rebase/retry checkbox — appears to do nothing. It does work (#729 force-pushed 135
+seconds after ticking), but `renovate/stability-days` is rewritten from release age alone on the
+new head, so the PR comes straight back to pending and looks untouched. Rebasing can never make a
+pending PR mergeable.
+
+**How to apply:** to actually land one early, merge it by hand — `main` is not branch-protected, so
+the pending check blocks only Renovate's own automerge. To stop forced PRs going stale in the first
+place, set `internalChecksFilter: flexible`: branches are then created and kept rebased, with the
+pending check still holding automerge back. Don't reach for
+`statusCheckWhen.minimumReleaseAge: never` — it removes the signal and keeps the freeze.


### PR DESCRIPTION
Follow-up to #744 — the reasoning behind it, written down so the next session doesn't re-derive it.

Two memories:

- **`lockfile-maintenance-bypasses-renovate-age-gate`** — why `minimumReleaseAge: 14 days` in
  `renovate.json` isn't a repo-wide guarantee, and why the pnpm-side value is what actually guards
  the weekly regeneration. Includes the two traps found while raising it: the lockfile must be
  regenerated in the same commit (`trustLockfile` defaults false, so existing entries are
  re-checked), and exact pins can make a value unreachable outright.
- **`renovate-freezes-prs-under-minimum-release-age`** — a PR forced from the dashboard before the
  age is met never rebases again, and the rebase checkbox can't fix it. Ticking it does work
  (#729 force-pushed 135 seconds later) but the status check is rewritten from release age on the
  new head, so the PR is no more mergeable than before.

Also restores the `pnpm-allowbuilds-breaks-on-renames` index line, which was dropped when
`MEMORY.md` was rewritten in #742 — the memory file itself was never lost, only its pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)