### PR TITLE
feat(albion): Keep force-queued registrations retrying through failures

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,6 +1,7 @@
 # Memory Index
 
 - [Albion registration is a critical pillar](albion-registration-critical-pillar.md) — daily cron strips roles for ex-guild members; must be very robust
+- [Albion search lags the guild member list](albion-api-search-lags-guild-members.md) — /search 404s characters /guilds/{id}/members already lists, so retries hard-fail on a lag
 - [Local dev/test environment](local-dev-test-environment.md) — nvm use 24.12.0 first (strict engines pin), pnpm test ~107s / 362 tests; test:wsl only needed on WSL
 - [Commit messages drive the version bump](commit-messages-drive-version-bump.md) — substring match on main: "feat" anywhere in a message forces a minor bump
 - [necord's @Options() drops DTO defaults](necord-options-drops-dto-defaults.md) — field initialisers are ignored; omitted options arrive as null, so default at the read site

--- a/.claude/memory/albion-api-search-lags-guild-members.md
+++ b/.claude/memory/albion-api-search-lags-guild-members.md
@@ -1,0 +1,26 @@
+---
+name: albion-api-search-lags-guild-members
+description: "The Albion /search endpoint can 404 a character that /guilds/{id}/members already lists, so registration hard-fails even when the membership check passes"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 2fa9c4b0-11e5-4ad5-af3f-7d94dee65519
+  modified: 2026-07-30T20:37:08.236Z
+---
+
+The Albion API's two sources disagree. `checkCharacterGuildMembership` is happy if *either*
+`/search?q=<name>` or `/guilds/<id>/members` confirms the character, but `handleRegistration` then
+calls `getCharacter()`, which only uses `/search`. For a freshly created or freshly joined
+character the guild member list is populated while search still returns nothing, so the retry
+passes the membership check and then dies with "Character X does not seem to exist on the Europe
+server".
+
+**Why:** this is what `/albion-register-queue` exists for — staff can see the member in-game, so the
+API is wrong rather than the member. It's also why a force-queued attempt must not be marked FAILED
+on a hard error: the failure is expected and self-resolving, so it stays PENDING until it succeeds
+or the 72h TTL expires (`forceQueued` on the queue entity).
+
+**How to apply:** treat "does not seem to exist" during a *retry* as a lag symptom, not a bad
+character name. If a member reports it right after registering, the fix is force-queueing them and
+waiting, not asking them to re-check their spelling. See
+[[albion-registration-critical-pillar]].

--- a/src/albion/services/albion.registration.queue.service.spec.ts
+++ b/src/albion/services/albion.registration.queue.service.spec.ts
@@ -96,6 +96,32 @@ describe('AlbionRegistrationQueueService', () => {
     expect(result.characterName).toBe(characterName);
   });
 
+  it('should flag a new attempt as force queued so the retry cron rides out failures', async () => {
+    await service.forceQueue(characterName, discordMemberId, discordGuildId);
+
+    expect(queueRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ forceQueued: true }),
+    );
+  });
+
+  it('should flag an existing attempt as force queued when re-queued', async () => {
+    const existing = {
+      discordId: discordMemberId,
+      characterName: 'OldName',
+      attemptCount: 12,
+      expiresAt: new Date(0),
+      forceQueued: false,
+    } as any;
+
+    queueRepo.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(existing);
+
+    await service.forceQueue(characterName, discordMemberId, discordGuildId);
+
+    expect(existing.forceQueued).toBe(true);
+  });
+
   it('should expire the queued attempt 72 hours from now', async () => {
     const before = Date.now();
 

--- a/src/albion/services/albion.registration.queue.service.ts
+++ b/src/albion/services/albion.registration.queue.service.ts
@@ -65,6 +65,7 @@ export class AlbionRegistrationQueueService {
       existing.attemptCount = 0;
       existing.expiresAt = expiresAt;
       existing.lastError = 'Force queued by staff.';
+      existing.forceQueued = true;
 
       // v7 no longer change-tracks scalar properties automatically, so persist explicitly.
       await this.albionRegistrationQueueRepository.getEntityManager().persist(existing).flush();
@@ -92,6 +93,7 @@ export class AlbionRegistrationQueueService {
       expiresAt,
       status: AlbionRegistrationQueueStatus.PENDING,
       lastError: 'Force queued by staff.',
+      forceQueued: true,
     });
     await this.albionRegistrationQueueRepository.upsert(entity);
 

--- a/src/albion/services/albion.registration.retry.cron.service.spec.ts
+++ b/src/albion/services/albion.registration.retry.cron.service.spec.ts
@@ -394,6 +394,117 @@ describe('AlbionRegistrationRetryCronService', () => {
     );
   });
 
+  describe('force queued attempts', () => {
+    const hardFailure = 'Registration failed for character "Char"!\nReason: Character **Char** does not seem to exist on the Europe server.';
+
+    const buildForceQueuedAttempt = (expiresAt = new Date(Date.now() + 1000 * 60 * 60)) => new AlbionRegistrationQueueEntity({
+      guildId: 'g1',
+      discordGuildId: 'dg1',
+      discordChannelId: 'dc1',
+      discordId: 'u1',
+      characterName: 'Char',
+      expiresAt,
+      forceQueued: true,
+    });
+
+    it('should keep the attempt pending when registration hard fails', async () => {
+      const attempt = buildForceQueuedAttempt();
+
+      queueRepo.find.mockResolvedValue([attempt]);
+      albionApiService.checkCharacterGuildMembership.mockResolvedValue(true);
+      albionRegistrationService.handleRegistration.mockRejectedValue(new Error(hardFailure));
+
+      await service.retryAlbionRegistrations();
+
+      expect(attempt.status).toBe(AlbionRegistrationQueueStatus.PENDING);
+      expect(attempt.lastError).toBe(hardFailure);
+      expect(registrationQueueChannel.send).toHaveBeenCalledWith(
+        `🔁 Force-queued attempt for **Char** failed, retrying until <t:${Math.floor(attempt.expiresAt.getTime() / 1000)}:f>.\n\nReason: ${hardFailure}`,
+      );
+      // The member must not be pinged with the same failure every hour.
+      expect(registrationChannel.send).not.toHaveBeenCalled();
+    });
+
+    it('should retry on subsequent runs after a hard failure, and succeed', async () => {
+      const attempt = buildForceQueuedAttempt();
+
+      queueRepo.find.mockResolvedValue([attempt]);
+      albionApiService.checkCharacterGuildMembership.mockResolvedValue(true);
+      albionRegistrationService.handleRegistration
+        .mockRejectedValueOnce(new Error(hardFailure))
+        .mockResolvedValueOnce(undefined);
+
+      await service.retryAlbionRegistrations();
+      expect(attempt.status).toBe(AlbionRegistrationQueueStatus.PENDING);
+
+      await service.retryAlbionRegistrations();
+
+      expect(albionRegistrationService.handleRegistration).toHaveBeenCalledTimes(2);
+      expect(attempt.status).toBe(AlbionRegistrationQueueStatus.SUCCEEDED);
+      expect(attempt.lastError).toBeNull();
+      expect(registrationQueueChannel.send).toHaveBeenCalledWith('✅ Registration successful for **Char**!');
+    });
+
+    it('should keep the attempt pending when the Discord member cannot be fetched', async () => {
+      const attempt = buildForceQueuedAttempt();
+
+      queueRepo.find.mockResolvedValue([attempt]);
+      discordService.getGuildMember = jest.fn().mockRejectedValue(new Error('Member not found'));
+
+      await service.retryAlbionRegistrations();
+
+      expect(attempt.status).toBe(AlbionRegistrationQueueStatus.PENDING);
+      expect(attempt.lastError).toBe('User is not currently in the Discord guild.');
+      expect(registrationQueueChannel.send).not.toHaveBeenCalledWith(
+        'Registration attempt for character **Char** has failed because the Discord member has left the server.',
+      );
+    });
+
+    it('should keep the attempt pending when the guild membership check throws', async () => {
+      const attempt = buildForceQueuedAttempt();
+
+      queueRepo.find.mockResolvedValue([attempt]);
+      albionApiService.checkCharacterGuildMembership.mockRejectedValue(new Error('bad response'));
+
+      await service.retryAlbionRegistrations();
+
+      expect(attempt.status).toBe(AlbionRegistrationQueueStatus.PENDING);
+      expect(attempt.attemptCount).toBe(1);
+      expect(attempt.lastError).toContain('Failed to fetch guild members');
+      expect(registrationChannel.send).not.toHaveBeenCalled();
+    });
+
+    it('should still expire, reporting the last error to the queue channel', async () => {
+      const attempt = buildForceQueuedAttempt(new Date(Date.now() - 1000));
+      attempt.lastError = hardFailure;
+
+      queueRepo.find.mockResolvedValue([attempt]);
+
+      await service.retryAlbionRegistrations();
+
+      expect(attempt.status).toBe(AlbionRegistrationQueueStatus.EXPIRED);
+      expect(registrationQueueChannel.send).toHaveBeenCalledWith(
+        `⏰ Force-queued attempt for **Char** has expired.\n\nLast error: ${hardFailure}`,
+      );
+      expect(registrationChannel.send).toHaveBeenCalledWith(
+        expect.stringContaining('<@u1> your registration attempt timed out'),
+      );
+    });
+
+    it('should mark force queued attempts in the retry summary', async () => {
+      const attempt = buildForceQueuedAttempt();
+
+      queueRepo.find.mockResolvedValue([attempt]);
+      albionApiService.checkCharacterGuildMembership.mockResolvedValue(false);
+
+      await service.retryAlbionRegistrations();
+
+      expect(registrationQueueChannel.send).toHaveBeenCalledWith(
+        `Albion registration queue retry attempt: checking 1 character(s):\n\n- **Char** (force queued, expires <t:${Math.floor(attempt.expiresAt.getTime() / 1000)}:f>)`,
+      );
+    });
+  });
+
   it('should log an error when retry summary cannot be sent', async () => {
     const attempt = new AlbionRegistrationQueueEntity({
       guildId: 'g1',

--- a/src/albion/services/albion.registration.retry.cron.service.ts
+++ b/src/albion/services/albion.registration.retry.cron.service.ts
@@ -96,6 +96,12 @@ export class AlbionRegistrationRetryCronService implements OnApplicationBootstra
     catch (err) {
       // Member not found - they've left the server
       this.logger.error(`Failed to get guild member for Discord ID ${attempt.discordId} during registration retry for character ${attempt.characterName}: ${err?.message ?? String(err)}`);
+
+      if (attempt.forceQueued) {
+        await this.retainForceQueued(attempt, 'User is not currently in the Discord guild.');
+        return;
+      }
+
       attempt.status = AlbionRegistrationQueueStatus.FAILED;
       attempt.lastError = 'User is no longer in the Discord guild.';
       // v7 no longer change-tracks scalar properties automatically, hence the explicit persist on every flush below.
@@ -161,6 +167,12 @@ export class AlbionRegistrationRetryCronService implements OnApplicationBootstra
         return;
       }
 
+      // Staff force-queued this precisely because the API is lagging, so a hard failure isn't final.
+      if (attempt.forceQueued) {
+        await this.retainForceQueued(attempt, message);
+        return;
+      }
+
       attempt.status = AlbionRegistrationQueueStatus.FAILED;
       await this.albionRegistrationQueueRepository.getEntityManager().persist(attempt).flush();
 
@@ -170,12 +182,25 @@ export class AlbionRegistrationRetryCronService implements OnApplicationBootstra
     }
   }
 
+  // Keeps a force-queued attempt alive after a failure the normal flow would give up on. Reported in
+  // the queue channel only, so the member isn't pinged with the same failure every hour.
+  private async retainForceQueued(attempt: AlbionRegistrationQueueEntity, message: string): Promise<void> {
+    attempt.status = AlbionRegistrationQueueStatus.PENDING;
+    attempt.lastError = message;
+    await this.albionRegistrationQueueRepository.getEntityManager().persist(attempt).flush();
+
+    this.logger.warn(`Force-queued attempt for ${attempt.characterName} failed but will be retried: ${message}`);
+
+    await this.registrationQueueSend(
+      `🔁 Force-queued attempt for **${attempt.characterName}** failed, retrying until ${this.discordTime(attempt.expiresAt)}.\n\nReason: ${message}`,
+    );
+  }
+
   private async postRetrySummary(attempts: AlbionRegistrationQueueEntity[]): Promise<void> {
     const characters = attempts
       .map((a) => {
-        const unixSeconds = Math.floor(a.expiresAt.getTime() / 1000);
-        const discordTime = `<t:${unixSeconds}:f>`;
-        return `- **${a.characterName}** (expires ${discordTime})`;
+        const forced = a.forceQueued ? 'force queued, ' : '';
+        return `- **${a.characterName}** (${forced}expires ${this.discordTime(a.expiresAt)})`;
       })
       .join('\n');
 
@@ -189,9 +214,20 @@ export class AlbionRegistrationRetryCronService implements OnApplicationBootstra
     attempt.status = AlbionRegistrationQueueStatus.EXPIRED;
     await this.albionRegistrationQueueRepository.getEntityManager().persist(attempt).flush();
 
+    // Force-queued attempts swallow their failures, so surface the last one to staff on the way out.
+    if (attempt.forceQueued) {
+      await this.registrationQueueSend(
+        `⏰ Force-queued attempt for **${attempt.characterName}** has expired.\n\nLast error: ${attempt.lastError ?? 'None recorded.'}`,
+      );
+    }
+
     await this.registrationSend(
       `⏰ <@${attempt.discordId}> your registration attempt timed out. You are either truly not in the guild, or there is another problem. If you are in the guild, you are recommended to play the game for at least 1 hour, then retry registration. If you are not in the guild, then... why are you trying? :P`,
     );
+  }
+
+  private discordTime(date: Date): string {
+    return `<t:${Math.floor(date.getTime() / 1000)}:f>`;
   }
 
   private async registrationSend(content: string): Promise<void> {

--- a/src/database/entities/albion.registration.queue.entity.ts
+++ b/src/database/entities/albion.registration.queue.entity.ts
@@ -18,6 +18,7 @@ export interface AlbionRegistrationQueueEntityInterface {
   expiresAt: Date
   status?: AlbionRegistrationQueueStatus
   lastError?: string | null
+  forceQueued?: boolean
 }
 
 @Entity()
@@ -58,6 +59,10 @@ export class AlbionRegistrationQueueEntity extends BaseEntity {
 
   @Property({ nullable: true, default: null, length: 2000 })
   lastError: null | string = null;
+
+  // Staff forced this attempt in, so hard failures are retried instead of ending the attempt.
+  @Property({ nullable: false, default: false })
+  forceQueued = false;
 
   constructor(options: AlbionRegistrationQueueEntityInterface) {
     super();

--- a/src/database/migrations/.snapshot-digletbot.json
+++ b/src/database/migrations/.snapshot-digletbot.json
@@ -508,6 +508,23 @@
           "enumItems": [],
           "mappedType": "datetime"
         },
+        "force_queued": {
+          "name": "force_queued",
+          "type": "tinyint(1)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 3,
+          "scale": 0,
+          "default": "false",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
         "guild_id": {
           "name": "guild_id",
           "type": "varchar(255)",

--- a/src/database/migrations/Migration20260730193000.ts
+++ b/src/database/migrations/Migration20260730193000.ts
@@ -1,0 +1,15 @@
+import { Migration } from '@mikro-orm/migrations';
+
+// Hand-written for the same reason as Migration20260728012034 — the snapshot is behind the
+// entities, so `migration:create` emits a full `create table` for this one.
+export class Migration20260730193000 extends Migration {
+
+  override up(): void | Promise<void> {
+    this.addSql('alter table `albion_registration_queue_entity` add `force_queued` tinyint(1) not null default false;');
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql('alter table `albion_registration_queue_entity` drop column `force_queued`;');
+  }
+
+}


### PR DESCRIPTION
Follow-up to #747, rebased onto it — this PR is now just the one commit.

## Why

`/albion-register-queue` exists because the Albion API disagrees with itself: `checkCharacterGuildMembership` is satisfied if *either* `/search?q=<name>` or `/guilds/<id>/members` confirms the character, but `handleRegistration` then calls `getCharacter()`, which only uses `/search`. For a character that has just joined the guild, the member list is populated while search still returns nothing.

So a forced attempt hits the retry cron, passes the membership check, and then dies with "Character X does not seem to exist on the Europe server" — at which point the cron marks it `FAILED` and pings the member. That ends the attempt at exactly the moment it should be waiting the lag out, which defeats the point of forcing it in.

## Changes

* New `forceQueued` flag on `AlbionRegistrationQueueEntity`, set by `/albion-register-queue` on both the create and re-queue paths. Migration `Migration20260730193000`, hand-written for the same reason as the previous one — the snapshot is behind, so `migration:create` emits a full `create table`.
* Attempts carrying the flag stay `PENDING` on a hard registration failure or a missing Discord member, rather than going `FAILED`. They keep retrying until they succeed or the 72h TTL expires.
* Those failures report to the registration **queue** channel instead of the registration channel, so the member isn't pinged with the same error every hour. Staff still see each reason, and the last error is surfaced when the attempt finally expires.
* Retry summaries mark forced entries as `(force queued, expires …)`.

Failures stay terminal for ordinary queued attempts — nothing about the normal path changes.

## Validation

* `pnpm test` — 396 passed, including 8 new cases: the flag being set on both queue paths, and each failure path staying pending, retrying on the next run, and expiring cleanly.
* `pnpm lint` clean.
* Migration applied and reverted against a local MariaDB: `up` adds `force_queued tinyint(1) not null default 0`, `down` removes it, `up` again is clean.

## Note for deploy

Anyone who already hit this and was marked `FAILED` won't be picked up by the cron. Re-run `/albion-register-queue` for them once this is live — that path clears the failed row and creates a fresh forced one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
