### PR TITLE
feat(albion): Add /albion-force-register for testing registrations

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -12,5 +12,6 @@
 - [Renovate freezes PRs under minimumReleaseAge](renovate-freezes-prs-under-minimum-release-age.md) — forced PRs never rebase, and the rebase checkbox can't unstick them
 - [Local-midnight date keys are wrong here](local-midnight-date-keys-are-wrong.md) — forceUtcTimezone means setHours(0,0,0,0) splits a day across BST; use utcMidnight()
 - [A nullable unique key enforces one open row](nullable-unique-key-enforces-one-open-row.md) — beats a read-before-write check, which races
+- [Queue status flips collide with history](queue-status-unique-key-collides-with-history.md) — the unique key is on (guild, member, status), so an old succeeded row blocks the new one
 
 Note: this memory lives in the repo at `.claude/memory/` (wired via `autoMemoryDirectory` in `.claude/settings.json`) so it's shared via git across machines and collaborators. See README "Claude Code memory".

--- a/.claude/memory/queue-status-unique-key-collides-with-history.md
+++ b/.claude/memory/queue-status-unique-key-collides-with-history.md
@@ -1,0 +1,31 @@
+---
+name: queue-status-unique-key-collides-with-history
+description: "Flipping an albion_registration_queue row's status can collide with an older row holding the target status"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 2229b546-6ab4-4ca6-b8b8-72c155b3b6af
+  modified: 2026-08-02T19:34:44.047Z
+---
+
+`AlbionRegistrationQueueEntity` is unique on `(guildId, discordId, status)`, so a member may hold
+one row per status at once — one `pending`, one `succeeded`, one `failed`, one `expired`. That means
+writing `attempt.status = SUCCEEDED` on a pending row throws a duplicate-key error whenever that
+member already has a succeeded row from an earlier registration, which is exactly what a
+register → deregister → re-register cycle leaves behind. Delete the row already holding the target
+status first.
+
+**Why:** the collision only appears once a member has history, so it never shows up in development
+or in mocked tests — the repository mock accepts any status assignment. It surfaced in review, not
+in the suite. The consequence is worse than the error itself: the status flip happens *after* the
+registration row and the Discord roles are committed, so an uncaught throw reports failure to staff
+for a member who is in fact fully registered, and leaves the pending row for the retry cron to keep
+picking up.
+
+**How to apply:** treat any `status` assignment on this entity as a write that can collide, not a
+field update. Clear the target status first, and wrap the whole step so a failure downgrades to a
+warning rather than failing an operation that already succeeded. `AlbionForceRegistrationService`
+does both; the retry cron's own `PENDING → SUCCEEDED` flip in
+`albion.registration.retry.cron.service.ts` still carries the same exposure. See
+[[nullable-unique-key-enforces-one-open-row]] for the case where this constraint shape is the
+feature rather than the trap.

--- a/src/albion/albion.module.ts
+++ b/src/albion/albion.module.ts
@@ -14,6 +14,8 @@ import { AlbionDeregisterCommand } from './commands/deregistration.command';
 import { AlbionDeregistrationService } from './services/albion.deregistration.service';
 import { AlbionRegistrationRetryCronService } from './services/albion.registration.retry.cron.service';
 import { AlbionForceRetryCommand } from './commands/force-retry.command';
+import { AlbionForceRegisterCommand } from './commands/force-register.command';
+import { AlbionForceRegistrationService } from './services/albion.force.registration.service';
 import { AlbionRegisterQueueCommand } from './commands/register-queue.command';
 import { AlbionRegistrationQueueService } from './services/albion.registration.queue.service';
 import { AlbionRankUpCommand } from './commands/rank-up.command';
@@ -30,6 +32,8 @@ import { GeneralModule } from '../general/general.module';
     AlbionCronService,
     AlbionDeregisterCommand,
     AlbionDeregistrationService,
+    AlbionForceRegisterCommand,
+    AlbionForceRegistrationService,
     AlbionLogCommand,
     AlbionRankProgressService,
     AlbionRankUpCommand,

--- a/src/albion/commands/force-register.command.spec.ts
+++ b/src/albion/commands/force-register.command.spec.ts
@@ -1,0 +1,181 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Test } from '@nestjs/testing';
+import { MessageFlags } from 'discord.js';
+import { AlbionForceRegisterCommand } from './force-register.command';
+import { AlbionForceRegistrationService } from '../services/albion.force.registration.service';
+import { AlbionUtilities } from '../utilities/albion.utilities';
+
+const discordMemberId = '90078072660852736';
+const characterName = 'Maelstromeous';
+
+const createInteraction = () => ({
+  guildId: 'discord-guild-id',
+  member: { id: 'staff-id', roles: { cache: new Map() } },
+  deferred: true,
+  replied: false,
+  deferReply: jest.fn().mockResolvedValue(undefined),
+  editReply: jest.fn().mockResolvedValue(undefined),
+  reply: jest.fn().mockResolvedValue(undefined),
+}) as any;
+
+describe('AlbionForceRegisterCommand', () => {
+  let command: AlbionForceRegisterCommand;
+  let forceRegistrationService: any;
+  let albionUtilities: any;
+  let interaction: any;
+
+  const dto: any = {
+    character: characterName,
+    discordMember: { id: discordMemberId },
+  };
+
+  beforeEach(async () => {
+    forceRegistrationService = {
+      forceRegister: jest.fn().mockResolvedValue({
+        characterName,
+        characterId: 'character-id-123',
+        discordMember: { id: discordMemberId },
+        queueResolved: false,
+      }),
+    };
+
+    albionUtilities = {
+      isElector: jest.fn().mockReturnValue(true),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        AlbionForceRegisterCommand,
+        {
+          provide: AlbionForceRegistrationService,
+          useValue: forceRegistrationService,
+        },
+        {
+          provide: AlbionUtilities,
+          useValue: albionUtilities,
+        },
+      ],
+    }).compile();
+
+    command = moduleRef.get(AlbionForceRegisterCommand);
+    interaction = createInteraction();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should refuse members below Eldritch Mage', async () => {
+    albionUtilities.isElector.mockReturnValue(false);
+
+    const result = await command.onAlbionForceRegisterCommand(dto, [interaction]);
+
+    expect(result).toContain('You do not have permission to run this command');
+    expect(forceRegistrationService.forceRegister).not.toHaveBeenCalled();
+  });
+
+  it('should keep the refusal private to whoever tried it', async () => {
+    albionUtilities.isElector.mockReturnValue(false);
+
+    await command.onAlbionForceRegisterCommand(dto, [interaction]);
+
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ flags: MessageFlags.Ephemeral }),
+    );
+    expect(interaction.deferReply).not.toHaveBeenCalled();
+  });
+
+  it('should fail closed when there is no guild member to check, such as in a DM', async () => {
+    interaction.member = null;
+
+    const result = await command.onAlbionForceRegisterCommand(dto, [interaction]);
+
+    expect(result).toContain('You do not have permission to run this command');
+    expect(albionUtilities.isElector).not.toHaveBeenCalled();
+    expect(forceRegistrationService.forceRegister).not.toHaveBeenCalled();
+  });
+
+  it('should fail closed when the member arrives without a resolved role cache', async () => {
+    // Discord hands back an APIInteractionGuildMember, whose roles are a plain ID array.
+    interaction.member = { id: 'staff-id', roles: ['1218115619732455474'] };
+
+    const result = await command.onAlbionForceRegisterCommand(dto, [interaction]);
+
+    expect(result).toContain('You do not have permission to run this command');
+    expect(forceRegistrationService.forceRegister).not.toHaveBeenCalled();
+  });
+
+  it('should check the permission against the member who ran it', async () => {
+    await command.onAlbionForceRegisterCommand(dto, [interaction]);
+
+    expect(albionUtilities.isElector).toHaveBeenCalledWith(interaction.member);
+  });
+
+  it('should defer the reply before doing any work', async () => {
+    await command.onAlbionForceRegisterCommand(dto, [interaction]);
+
+    expect(interaction.deferReply).toHaveBeenCalledTimes(1);
+  });
+
+  it('should force register the character for the supplied member', async () => {
+    const result = await command.onAlbionForceRegisterCommand(dto, [interaction]);
+
+    expect(forceRegistrationService.forceRegister).toHaveBeenCalledWith(
+      characterName,
+      discordMemberId,
+      'discord-guild-id',
+      interaction.member,
+    );
+    expect(result).toContain(`✅ **${characterName}** has been force registered to <@${discordMemberId}>`);
+    expect(result).toContain('@ALB/Disciple');
+  });
+
+  it('should warn that the scan will still remove them if they are not in the guild', async () => {
+    const result = await command.onAlbionForceRegisterCommand(dto, [interaction]);
+
+    expect(result).toContain('the next scan will strip them if they are not actually in the guild');
+  });
+
+  it('should say when a queued attempt was closed out', async () => {
+    forceRegistrationService.forceRegister.mockResolvedValue({
+      characterName,
+      characterId: 'character-id-123',
+      discordMember: { id: discordMemberId },
+      queueResolved: true,
+    });
+
+    const result = await command.onAlbionForceRegisterCommand(dto, [interaction]);
+
+    expect(result).toContain('queued registration attempt has been marked as succeeded');
+  });
+
+  it('should not mention the queue when nothing was queued', async () => {
+    const result = await command.onAlbionForceRegisterCommand(dto, [interaction]);
+
+    expect(result).not.toContain('queued registration attempt');
+  });
+
+  it('should warn rather than fail when the queue could not be closed out', async () => {
+    forceRegistrationService.forceRegister.mockResolvedValue({
+      characterName,
+      characterId: 'character-id-123',
+      discordMember: { id: discordMemberId },
+      queueResolved: false,
+      queueError: 'Duplicate entry',
+    });
+
+    const result = await command.onAlbionForceRegisterCommand(dto, [interaction]);
+
+    expect(result).toContain('has been force registered');
+    expect(result).toContain('queued registration attempt could not be closed out');
+    expect(result).toContain('Duplicate entry');
+  });
+
+  it('should report the error when registration fails', async () => {
+    forceRegistrationService.forceRegister.mockRejectedValue(new Error('already registered'));
+
+    const result = await command.onAlbionForceRegisterCommand(dto, [interaction]);
+
+    expect(result).toBe('⛔️ **ERROR:** already registered');
+  });
+});

--- a/src/albion/commands/force-register.command.ts
+++ b/src/albion/commands/force-register.command.ts
@@ -1,0 +1,77 @@
+import { Context, Options, SlashCommand, SlashCommandContext } from 'necord';
+import { Injectable, Logger } from '@nestjs/common';
+import { GuildMember, MessageFlags } from 'discord.js';
+import { AlbionForceRegisterDto } from '../dto/albion.force.register.dto';
+import {
+  ALBION_FORCE_REGISTER_RANK,
+  AlbionForceRegistrationService,
+} from '../services/albion.force.registration.service';
+import { AlbionUtilities } from '../utilities/albion.utilities';
+import { replyTo } from '../../discord/discord.hacks';
+
+@Injectable()
+export class AlbionForceRegisterCommand {
+  private readonly logger = new Logger(AlbionForceRegisterCommand.name);
+
+  constructor(
+    private readonly albionForceRegistrationService: AlbionForceRegistrationService,
+    private readonly albionUtilities: AlbionUtilities,
+  ) {}
+
+  @SlashCommand({
+    name: 'albion-force-register',
+    description: 'Register a character to a member, skipping the guild membership check entirely.',
+  })
+  async onAlbionForceRegisterCommand(
+    @Options() dto: AlbionForceRegisterDto,
+    @Context() [interaction]: SlashCommandContext,
+  ): Promise<string> {
+    const performedBy = interaction.member as GuildMember;
+
+    // Gated to the same Eldritch Mage and above set that votes on rank ups. Checked before the
+    // defer so the refusal can stay private to whoever tried it. Outside a guild there is no
+    // member to check roles on, so fail closed rather than throw on the cast.
+    if (!performedBy?.roles?.cache || !this.albionUtilities.isElector(performedBy)) {
+      const denial = '⛔️ You do not have permission to run this command. It is restricted to `@ALB/EldritchMage` and above.';
+      await interaction.reply({
+        content: denial,
+        flags: MessageFlags.Ephemeral,
+      });
+      return denial;
+    }
+
+    this.logger.log(`Received Albion Force Register Command for "${dto.character}"`);
+
+    // Registration hits the Albion API and the database before replying, which blows Discord's 3s window.
+    await interaction.deferReply();
+
+    let result: Awaited<ReturnType<AlbionForceRegistrationService['forceRegister']>>;
+
+    try {
+      result = await this.albionForceRegistrationService.forceRegister(
+        dto.character,
+        dto.discordMember.id,
+        interaction.guildId,
+        performedBy,
+      );
+    }
+    catch (err) {
+      this.logger.error(err.message);
+      return replyTo(interaction, `⛔️ **ERROR:** ${err.message}`);
+    }
+
+    let queueNote = result.queueResolved
+      ? ' Their queued registration attempt has been marked as succeeded.'
+      : '';
+
+    // The registration itself is done at this point, so a queue failure is a warning, not an error.
+    if (result.queueError) {
+      queueNote = `\n\n⚠️ Their queued registration attempt could not be closed out, so the retry cron may still pick it up. Err: ${result.queueError}`;
+    }
+
+    return replyTo(
+      interaction,
+      `✅ **${result.characterName}** has been force registered to <@${result.discordMember.id}> with the \`${ALBION_FORCE_REGISTER_RANK}\` rank.${queueNote}\n\n⚠️ The guild membership check was skipped, so the next scan will strip them if they are not actually in the guild.`,
+    );
+  }
+}

--- a/src/albion/dto/albion.force.register.dto.ts
+++ b/src/albion/dto/albion.force.register.dto.ts
@@ -1,0 +1,22 @@
+import { StringOption, UserOption } from 'necord';
+import { User } from 'discord.js';
+
+export class AlbionForceRegisterDto {
+  @StringOption({
+    name: 'character-name',
+    description:
+      'Exact in-game Albion character name. Guild membership is not checked, so be careful!',
+    required: true,
+    min_length: 3,
+    max_length: 16,
+  })
+  character: string;
+
+  @UserOption({
+    name: 'discord-member',
+    description:
+      'Discord member the character belongs to.',
+    required: true,
+  })
+  discordMember: User;
+}

--- a/src/albion/services/albion.force.registration.service.spec.ts
+++ b/src/albion/services/albion.force.registration.service.spec.ts
@@ -1,0 +1,342 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import _ from 'lodash';
+import { getRepositoryToken } from '@mikro-orm/nestjs';
+import { AlbionForceRegistrationService } from './albion.force.registration.service';
+import { AlbionApiService } from './albion.api.service';
+import { DiscordService } from '../../discord/discord.service';
+import { AlbionRegistrationsEntity } from '../../database/entities/albion.registrations.entity';
+import {
+  AlbionRegistrationQueueEntity,
+  AlbionRegistrationQueueStatus,
+} from '../../database/entities/albion.registration.queue.entity';
+import { TestBootstrapper } from '../../test.bootstrapper';
+
+const albionGuildId = TestBootstrapper.mockConfig.albion.guildId;
+const registrationChannelId = TestBootstrapper.mockConfig.discord.channels.albionRegistration;
+const discipleRoleId = TestBootstrapper.mockConfig.albion.roleMap.find((role) => role.name === '@ALB/Disciple').discordRoleId;
+const discordGuildId = 'discord-guild-id';
+const discordMemberId = '90078072660852736';
+const characterName = 'Maelstromeous';
+const characterId = 'character-id-123';
+
+describe('AlbionForceRegistrationService', () => {
+  let service: AlbionForceRegistrationService;
+  let registrationsRepo: any;
+  let queueRepo: any;
+  let entityManager: any;
+  let discordService: any;
+  let albionApiService: any;
+  let discordMember: any;
+  let performedBy: any;
+  let registrationChannel: any;
+  let moduleRef: TestingModule;
+
+  beforeEach(async () => {
+    entityManager = TestBootstrapper.getMockEntityManager();
+
+    registrationsRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      create: jest.fn().mockImplementation((data) => data),
+      nativeDelete: jest.fn().mockResolvedValue(1),
+      getEntityManager: jest.fn().mockReturnValue(entityManager),
+    };
+
+    queueRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      nativeDelete: jest.fn().mockResolvedValue(0),
+      getEntityManager: jest.fn().mockReturnValue(entityManager),
+    };
+
+    discordMember = {
+      ...TestBootstrapper.getMockDiscordUser(),
+      id: discordMemberId,
+      roles: { add: jest.fn().mockResolvedValue(undefined) },
+      setNickname: jest.fn().mockResolvedValue(undefined),
+    };
+
+    performedBy = {
+      ...TestBootstrapper.getMockDiscordUser(),
+      id: 'staff-id',
+      nickname: 'StaffPerson',
+    };
+
+    registrationChannel = {
+      ...TestBootstrapper.getMockDiscordTextChannel(),
+      send: jest.fn().mockResolvedValue(undefined),
+    };
+
+    discordService = {
+      getGuildMember: jest.fn().mockResolvedValue(discordMember),
+      getRoleViaMember: jest.fn().mockImplementation((_member, roleId) => Promise.resolve({ id: roleId })),
+      getTextChannel: jest.fn().mockResolvedValue(registrationChannel),
+    };
+
+    albionApiService = {
+      getCharacter: jest.fn().mockResolvedValue({
+        Id: characterId,
+        Name: characterName,
+        GuildId: 'some-other-guild',
+      }),
+    };
+
+    moduleRef = await Test.createTestingModule({
+      providers: [
+        AlbionForceRegistrationService,
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn() },
+        },
+        {
+          provide: DiscordService,
+          useValue: discordService,
+        },
+        {
+          provide: AlbionApiService,
+          useValue: albionApiService,
+        },
+        {
+          provide: getRepositoryToken(AlbionRegistrationsEntity),
+          useValue: registrationsRepo,
+        },
+        {
+          provide: getRepositoryToken(AlbionRegistrationQueueEntity),
+          useValue: queueRepo,
+        },
+      ],
+    }).compile();
+
+    TestBootstrapper.setupConfig(moduleRef);
+
+    service = moduleRef.get(AlbionForceRegistrationService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should register a character that is not in the guild', async () => {
+    const result = await service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy);
+
+    expect(registrationsRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        discordId: discordMemberId,
+        characterId,
+        characterName,
+        guildId: albionGuildId,
+      }),
+    );
+    expect(entityManager.flush).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(expect.objectContaining({ characterName, characterId }));
+  });
+
+  it('should never consult the character guild when deciding to register', async () => {
+    albionApiService.getCharacter.mockResolvedValue({
+      Id: characterId,
+      Name: characterName,
+      GuildId: null,
+    });
+
+    await expect(
+      service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy),
+    ).resolves.toEqual(expect.objectContaining({ characterName }));
+  });
+
+  it('should store the real character ID so the scan can still read the member back', async () => {
+    await service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy);
+
+    expect(albionApiService.getCharacter).toHaveBeenCalledWith(characterName);
+    expect(registrationsRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ characterId }),
+    );
+  });
+
+  it('should record who forced the registration', async () => {
+    await service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy);
+
+    expect(registrationsRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        manual: true,
+        manualCreatedByDiscordId: 'staff-id',
+        manualCreatedByDiscordName: 'StaffPerson',
+      }),
+    );
+  });
+
+  it('should apply the Disciple rank alongside the standard registration roles', async () => {
+    await service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy);
+
+    const appliedRoleIds = discordMember.roles.add.mock.calls.map(([role]) => role.id);
+
+    expect(appliedRoleIds).toEqual([
+      TestBootstrapper.mockConfig.discord.roles.albionMember,
+      TestBootstrapper.mockConfig.discord.roles.albionRegistered,
+      TestBootstrapper.mockConfig.discord.roles.albionAnnouncements,
+      discipleRoleId,
+    ]);
+  });
+
+  it('should set the member nickname to the character name', async () => {
+    await service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy);
+
+    expect(discordMember.setNickname).toHaveBeenCalledWith(characterName);
+  });
+
+  it('should not fail the registration when the nickname cannot be set', async () => {
+    discordMember.setNickname.mockRejectedValue(new Error('Missing permissions'));
+
+    await expect(
+      service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy),
+    ).resolves.toEqual(expect.objectContaining({ characterName }));
+  });
+
+  it('should mark a pending queue attempt as succeeded', async () => {
+    const queued = {
+      discordId: discordMemberId,
+      characterName,
+      status: AlbionRegistrationQueueStatus.PENDING,
+      lastError: 'Character not detected in guild yet.',
+    } as any;
+    queueRepo.findOne.mockResolvedValue(queued);
+
+    const result = await service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy);
+
+    expect(queued.status).toBe(AlbionRegistrationQueueStatus.SUCCEEDED);
+    expect(queued.lastError).toBeNull();
+    expect(entityManager.persist).toHaveBeenCalledWith(queued);
+    expect(result.queueResolved).toBe(true);
+  });
+
+  it('should clear an older succeeded attempt so the status unique key cannot collide', async () => {
+    queueRepo.findOne.mockResolvedValue({
+      discordId: discordMemberId,
+      status: AlbionRegistrationQueueStatus.PENDING,
+    } as any);
+
+    await service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy);
+
+    expect(queueRepo.nativeDelete).toHaveBeenCalledWith({
+      guildId: albionGuildId,
+      discordId: discordMemberId,
+      status: AlbionRegistrationQueueStatus.SUCCEEDED,
+    });
+  });
+
+  it('should not fail a committed registration when the queue cannot be closed out', async () => {
+    queueRepo.findOne.mockResolvedValue({
+      discordId: discordMemberId,
+      status: AlbionRegistrationQueueStatus.PENDING,
+    } as any);
+    queueRepo.nativeDelete.mockRejectedValue(new Error('Duplicate entry'));
+
+    const result = await service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy);
+
+    expect(result.queueResolved).toBe(false);
+    expect(result.queueError).toBe('Duplicate entry');
+  });
+
+  it('should report no queue resolution when nothing was queued', async () => {
+    const result = await service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy);
+
+    expect(result.queueResolved).toBe(false);
+    expect(result.queueError).toBeUndefined();
+    expect(queueRepo.nativeDelete).not.toHaveBeenCalled();
+  });
+
+  it('should announce the registration in the registration channel', async () => {
+    await service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy);
+
+    expect(discordService.getTextChannel).toHaveBeenCalledWith(registrationChannelId);
+    expect(registrationChannel.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining(`<@${discordMemberId}>, your character **${characterName}** has been registered!`),
+        allowedMentions: expect.objectContaining({ users: [discordMemberId] }),
+      }),
+    );
+  });
+
+  it('should still succeed when the announcement cannot be sent', async () => {
+    discordService.getTextChannel.mockRejectedValue(new Error('no channel'));
+
+    await expect(
+      service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy),
+    ).resolves.toEqual(expect.objectContaining({ characterName }));
+  });
+
+  it('should throw when the Discord member is not on the server', async () => {
+    discordService.getGuildMember.mockRejectedValue(new Error('Could not find member'));
+
+    await expect(
+      service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy),
+    ).rejects.toThrow(`Discord member <@${discordMemberId}> could not be found on the server. Err: Could not find member`);
+
+    expect(registrationsRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('should throw when the character cannot be looked up', async () => {
+    albionApiService.getCharacter.mockRejectedValue(new Error('does not seem to exist'));
+
+    await expect(
+      service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy),
+    ).rejects.toThrow(`Could not look up character **${characterName}**. Err: does not seem to exist`);
+
+    expect(registrationsRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('should throw when the Discord member is already registered', async () => {
+    registrationsRepo.findOne.mockResolvedValueOnce({ characterName: 'SomeoneElse' });
+
+    await expect(
+      service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy),
+    ).rejects.toThrow(`<@${discordMemberId}> is already registered as **SomeoneElse**.`);
+
+    expect(discordMember.roles.add).not.toHaveBeenCalled();
+    expect(registrationsRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('should throw when the character is already registered to someone else', async () => {
+    registrationsRepo.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ discordId: '111', characterName });
+
+    await expect(
+      service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy),
+    ).rejects.toThrow(`Character **${characterName}** is already registered to <@111>.`);
+
+    expect(registrationsRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('should throw when a role cannot be applied', async () => {
+    discordService.getRoleViaMember.mockRejectedValue(new Error('Role does not exist'));
+
+    await expect(
+      service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy),
+    ).rejects.toThrow('Unable to add roles to');
+  });
+
+  it('should roll the registration row back when the roles cannot be applied', async () => {
+    discordService.getRoleViaMember.mockRejectedValue(new Error('Role does not exist'));
+
+    await expect(
+      service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy),
+    ).rejects.toThrow('Unable to add roles to');
+
+    expect(registrationsRepo.nativeDelete).toHaveBeenCalledWith({
+      guildId: albionGuildId,
+      discordId: discordMemberId,
+    });
+  });
+
+  it('should throw when the Disciple rank is missing from the role map', async () => {
+    const config = _.cloneDeep(TestBootstrapper.mockConfig);
+    config.albion.roleMap = config.albion.roleMap.filter((role) => role.name !== '@ALB/Disciple');
+    TestBootstrapper.setupConfig(moduleRef, config);
+
+    await expect(
+      service.forceRegister(characterName, discordMemberId, discordGuildId, performedBy),
+    ).rejects.toThrow('Rank `@ALB/Disciple` is missing from the Albion role map!');
+
+    expect(registrationsRepo.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/albion/services/albion.force.registration.service.ts
+++ b/src/albion/services/albion.force.registration.service.ts
@@ -1,0 +1,300 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { EntityRepository } from '@mikro-orm/core';
+import { GuildMember, MessageFlags } from 'discord.js';
+import { DiscordService } from '../../discord/discord.service';
+import { AlbionApiService } from './albion.api.service';
+import { AlbionRegistrationsEntity } from '../../database/entities/albion.registrations.entity';
+import {
+  AlbionRegistrationQueueEntity,
+  AlbionRegistrationQueueStatus,
+} from '../../database/entities/albion.registration.queue.entity';
+import { ALBION_GUILD_EMOJI, AlbionPlayerInterface } from '../interfaces/albion.api.interfaces';
+import { AlbionRoleMapInterface } from '../../config/albion.app.config';
+
+// The rank a force-registered member starts on, same as anyone joining the guild fresh.
+export const ALBION_FORCE_REGISTER_RANK = '@ALB/Disciple';
+
+export interface ForceRegistrationResult {
+  characterName: string
+  characterId: string
+  discordMember: GuildMember
+  queueResolved: boolean
+  queueError?: string
+}
+
+@Injectable()
+export class AlbionForceRegistrationService {
+  private readonly logger = new Logger(AlbionForceRegistrationService.name);
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly discordService: DiscordService,
+    private readonly albionApiService: AlbionApiService,
+    @InjectRepository(AlbionRegistrationsEntity)
+    private readonly albionRegistrationsRepository: EntityRepository<AlbionRegistrationsEntity>,
+    @InjectRepository(AlbionRegistrationQueueEntity)
+    private readonly albionRegistrationQueueRepository: EntityRepository<AlbionRegistrationQueueEntity>,
+  ) {}
+
+  // Registers a character without ever asking whether it is in the guild. The character itself is
+  // still looked up, because the stored character ID is what the daily scan reads back.
+  async forceRegister(
+    characterName: string,
+    discordMemberId: string,
+    discordGuildId: string,
+    performedBy: GuildMember,
+  ): Promise<ForceRegistrationResult> {
+    const guildId = this.config.get('albion.guildId');
+
+    const discordMember = await this.getDiscordMember(discordGuildId, discordMemberId);
+    const character = await this.getCharacter(characterName);
+
+    // Resolved before anything is written, so a broken role map can't leave a half-done registration.
+    const roleIds = this.getRegistrationRoleIds();
+
+    await this.checkNotAlreadyRegistered(guildId, character, discordMember);
+
+    // The database row is the authoritative record, so it goes in first and is rolled back if the
+    // member never actually receives the roles.
+    await this.createRegistration(guildId, character, discordMember, performedBy);
+
+    try {
+      await this.applyRoles(discordMember, roleIds);
+    }
+    catch (err) {
+      await this.rollbackRegistration(guildId, discordMember.id);
+      throw err;
+    }
+
+    await this.setNickname(discordMember, character.Name);
+
+    const queue = await this.resolveQueuedAttempt(guildId, discordMember.id);
+
+    this.logger.log(
+      `Force registered "${character.Name}" (${character.Id}) to Discord ID ${discordMember.id} by ${performedBy.id}`,
+    );
+
+    await this.announce(character.Name, discordMember, performedBy);
+
+    return {
+      characterName: character.Name,
+      characterId: character.Id,
+      discordMember,
+      queueResolved: queue.resolved,
+      queueError: queue.error,
+    };
+  }
+
+  private async getDiscordMember(discordGuildId: string, discordMemberId: string): Promise<GuildMember> {
+    try {
+      return await this.discordService.getGuildMember(discordGuildId, discordMemberId);
+    }
+    catch (err) {
+      this.throwError(`Discord member <@${discordMemberId}> could not be found on the server. Err: ${err.message}`);
+    }
+  }
+
+  private async getCharacter(characterName: string): Promise<AlbionPlayerInterface> {
+    try {
+      return await this.albionApiService.getCharacter(characterName);
+    }
+    catch (err) {
+      this.throwError(`Could not look up character **${characterName}**. Err: ${err.message}`);
+    }
+  }
+
+  private async checkNotAlreadyRegistered(
+    guildId: string,
+    character: AlbionPlayerInterface,
+    discordMember: GuildMember,
+  ): Promise<void> {
+    const foundByDiscord = await this.albionRegistrationsRepository.findOne({
+      guildId,
+      discordId: String(discordMember.id),
+    });
+
+    if (foundByDiscord) {
+      this.throwError(
+        `<@${discordMember.id}> is already registered as **${foundByDiscord.characterName}**. Deregister them first if this needs changing.`,
+      );
+    }
+
+    const foundByCharacter = await this.albionRegistrationsRepository.findOne({
+      guildId,
+      characterId: character.Id,
+    });
+
+    if (foundByCharacter) {
+      this.throwError(
+        `Character **${character.Name}** is already registered to <@${foundByCharacter.discordId}>.`,
+      );
+    }
+  }
+
+  private getRegistrationRoleIds(): string[] {
+    return [
+      this.config.get('discord.roles.albionMember'),
+      this.config.get('discord.roles.albionRegistered'),
+      this.config.get('discord.roles.albionAnnouncements'),
+      this.getRankRoleId(ALBION_FORCE_REGISTER_RANK),
+    ];
+  }
+
+  private async applyRoles(discordMember: GuildMember, roleIds: string[]): Promise<void> {
+    try {
+      for (const roleId of roleIds) {
+        await discordMember.roles.add(
+          await this.discordService.getRoleViaMember(discordMember, roleId),
+        );
+      }
+    }
+    catch (err) {
+      this.throwError(
+        `Unable to add roles to "${discordMember.displayName}"! Pinging <@${this.config.get('discord.devUserId')}>! Err: ${err.message}`,
+      );
+    }
+  }
+
+  private getRankRoleId(rankName: string): string {
+    const roleMap: AlbionRoleMapInterface[] = this.config.get('albion.roleMap');
+    const role = roleMap.find((entry) => entry.name === rankName);
+
+    if (!role) {
+      this.throwError(
+        `Rank \`${rankName}\` is missing from the Albion role map! Pinging <@${this.config.get('discord.devUserId')}>!`,
+      );
+    }
+
+    return role.discordRoleId;
+  }
+
+  private async createRegistration(
+    guildId: string,
+    character: AlbionPlayerInterface,
+    discordMember: GuildMember,
+    performedBy: GuildMember,
+  ): Promise<void> {
+    try {
+      const entity = this.albionRegistrationsRepository.create({
+        discordId: discordMember.id,
+        characterId: character.Id,
+        characterName: character.Name,
+        guildId,
+        manual: true,
+        manualCreatedByDiscordId: performedBy.id,
+        manualCreatedByDiscordName: performedBy.nickname || performedBy.displayName,
+      });
+      // A plain insert, not an upsert: both unique keys must reject a clash outright rather than
+      // silently reassign whichever existing row they hit.
+      await this.albionRegistrationsRepository.getEntityManager().persist(entity).flush();
+    }
+    catch (err) {
+      this.throwError(
+        `Unable to add the registration to the database! Pinging <@${this.config.get('discord.devUserId')}>! Err: ${err.message}`,
+      );
+    }
+  }
+
+  private async rollbackRegistration(guildId: string, discordMemberId: string): Promise<void> {
+    try {
+      await this.albionRegistrationsRepository.nativeDelete({
+        guildId,
+        discordId: String(discordMemberId),
+      });
+    }
+    catch (err) {
+      this.logger.error(`Failed to roll back the registration for ${discordMemberId}: ${err.message}`);
+    }
+  }
+
+  private async setNickname(discordMember: GuildMember, characterName: string): Promise<void> {
+    try {
+      await discordMember.setNickname(characterName);
+    }
+    catch (err) {
+      // Staff outrank the bot, so this fails routinely and must not undo the registration.
+      this.logger.warn(`Unable to set nickname for "${discordMember.displayName}": ${err.message}`);
+    }
+  }
+
+  // Anything still queued for this member is now moot, so close it out rather than let the retry
+  // cron keep hammering a character that is already registered. Runs after the registration is
+  // committed, so a failure here is reported but never fails the command.
+  private async resolveQueuedAttempt(
+    guildId: string,
+    discordMemberId: string,
+  ): Promise<{ resolved: boolean, error?: string }> {
+    const existing = await this.albionRegistrationQueueRepository.findOne({
+      guildId,
+      discordId: String(discordMemberId),
+      status: AlbionRegistrationQueueStatus.PENDING,
+    });
+
+    if (!existing) {
+      return { resolved: false };
+    }
+
+    try {
+      // Only one row per guild/member/status may exist, so an earlier succeeded attempt has to go
+      // before this one can take that status.
+      await this.albionRegistrationQueueRepository.nativeDelete({
+        guildId,
+        discordId: String(discordMemberId),
+        status: AlbionRegistrationQueueStatus.SUCCEEDED,
+      });
+
+      existing.status = AlbionRegistrationQueueStatus.SUCCEEDED;
+      existing.lastError = null;
+
+      // v7 no longer change-tracks scalar properties automatically, so persist explicitly.
+      await this.albionRegistrationQueueRepository.getEntityManager().persist(existing).flush();
+
+      return { resolved: true };
+    }
+    catch (err) {
+      this.logger.error(`Failed to close out the queued attempt for ${discordMemberId}: ${err.message}`);
+      return { resolved: false, error: err.message };
+    }
+  }
+
+  private async announce(
+    characterName: string,
+    discordMember: GuildMember,
+    performedBy: GuildMember,
+  ): Promise<void> {
+    const registrationChannelId = this.config.get('discord.channels.albionRegistration');
+    const rolesChannel = this.config.get('discord.channels.albionRoles');
+    const announcementChannel = this.config.get('discord.channels.albionAnnouncements');
+    const pingRoles = this.config.get('albion.pingLeaderRoles');
+
+    const content = `# ✅ <@${discordMember.id}>, your character **${characterName}** has been registered! 🎉
+
+Leadership have manually registered you to the ${ALBION_GUILD_EMOJI} Dignity Of War guild, so you did not need to be detected by our data source.
+
+## 👉️👉️👉️️ NEXT STEP: <#${rolesChannel}>
+* ℹ️ Your Discord server nickname has been automatically changed to match your character name. You are free to change this back should you want to, but please make sure it resembles your in-game name.
+* 🔔 You have automatically been enrolled to our <#${announcementChannel}> announcements channel. If you wish to opt out, go to <#${rolesChannel}>, double tap the 🔔 icon.
+
+Force registered by <@${performedBy.id}>. CC <@&${pingRoles.join('>, <@&')}>`;
+
+    try {
+      const channel = await this.discordService.getTextChannel(registrationChannelId);
+      await channel.send({
+        content,
+        flags: MessageFlags.SuppressEmbeds,
+        // Staff-run command, so be explicit that the member really does get pinged.
+        allowedMentions: { users: [discordMember.id], roles: pingRoles },
+      });
+    }
+    catch (err) {
+      this.logger.error(`Failed to announce force registration: ${err.message}`);
+    }
+  }
+
+  private throwError(error: string): never {
+    this.logger.error(error);
+    throw new Error(error);
+  }
+}


### PR DESCRIPTION
## What

Adds `/albion-force-register <character-name> <discord-member>`, which registers a character to a Discord member **without checking guild membership at all**. This is for testing the registration pipeline, so a character in another guild — or in no guild — registers fine.

It applies `@ALB/Disciple` alongside the usual member/registered/announcements roles, writes the row to `albion_registrations_entity` marked `manual` with whoever ran it, sets the nickname, and marks any pending queue attempt for that member as succeeded so the retry cron stops chasing it.

## Access

Restricted to Eldritch Mage and above, reusing `AlbionUtilities.isElector()` rather than a second hardcoded role list — that check already handles production spelling the tier-3 role `@ALB/EldritchMager` against development's `@ALB/EldritchMage`. The refusal is ephemeral, and the command fails closed when there is no resolved guild member to check roles on, so a DM invocation is denied rather than throwing.

## The scan still applies

Deliberately, since this is a testing tool. The character ID stored is the real one from the API — only the *guild membership check* is skipped, not the character lookup — and nothing is added to `scanExcludedUsers`. A force-registered member is therefore read back by the daily scan like any other registration and stripped if they are not actually in the guild. The command's reply says so.

## Persistence details worth a look

- The registration row is written **before** the roles are applied, and rolled back if role application fails, so the command stays retryable instead of leaving a member holding roles with no row.
- The insert is a plain `persist().flush()` rather than an `upsert`. Both unique keys on the table are independent, and an upsert resolves a clash by updating whichever row it collided with — which could reassign an existing registration. An insert rejects it instead.
- `albion_registration_queue_entity` is unique on `(guildId, discordId, status)`, so flipping a pending row to succeeded collides with any succeeded row that member already has from an earlier registration. The older row is cleared first, and the whole step is wrapped: it runs after the registration is committed, so a failure there is reported as a warning rather than telling staff the registration failed when it did not. Recorded in `.claude/memory/` — the same exposure still exists in the retry cron's own status flip.

## Validation done

- 32 new tests across the command and service; full suite green at 593 tests / 47 suites.
- `pnpm lint` and `pnpm build` clean.
- The persistence points above came out of an adversarial review of the diff and are all fixed here. The unique-key collisions are asserted against mocks only — this repo has no database-backed test setup, and adding one was out of scope for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
