### PR TITLE
fix(albion): Fix eight faults in the rank-up ballot

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -13,5 +13,7 @@
 - [Local-midnight date keys are wrong here](local-midnight-date-keys-are-wrong.md) — forceUtcTimezone means setHours(0,0,0,0) splits a day across BST; use utcMidnight()
 - [A nullable unique key enforces one open row](nullable-unique-key-enforces-one-open-row.md) — beats a read-before-write check, which races
 - [Queue status flips collide with history](queue-status-unique-key-collides-with-history.md) — the unique key is on (guild, member, status), so an old succeeded row blocks the new one
+- [execute() needs 'run' for affectedRows](mikro-orm-execute-needs-run-mode.md) — the default returns rows, so every conditional-update election silently reads as lost
+- [A claimed row can strand](claimed-row-before-side-effect-can-strand.md) — anything fallible between the claim and the side effect locks the member behind a ballot nobody saw
 
 Note: this memory lives in the repo at `.claude/memory/` (wired via `autoMemoryDirectory` in `.claude/settings.json`) so it's shared via git across machines and collaborators. See README "Claude Code memory".

--- a/.claude/memory/claimed-row-before-side-effect-can-strand.md
+++ b/.claude/memory/claimed-row-before-side-effect-can-strand.md
@@ -1,0 +1,28 @@
+---
+name: claimed-row-before-side-effect-can-strand
+description: Claiming a row before an unrepeatable side effect strands the claim if anything between them fails
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 90fbe174-1646-4977-a103-bfdf7cf2ff8d
+  modified: 2026-08-02T20:16:33.889Z
+---
+
+`/albion-rank-up` inserts the ballot row (claiming `pendingKey`) before posting to Judgement Hall,
+because a Discord post cannot be rolled back. The trap is everything that sits *between* the claim
+and the post: the activity report was built there, so a failing rollup query left a pending row with
+no `messageId` — a ballot the member is locked behind that nobody ever saw. Nothing cleaned it up,
+and after five days the expiry cron closed it as a timeout, adding a week-long failed-vote lockout.
+
+**Why:** claim-then-act is the right ordering — the reverse leaves an untracked public ballot. But
+it only holds if the gap is empty. Two things make it safe: build everything fallible *before* the
+claim, and give the claim a reclaim path, since a crash between the two can always happen.
+`reclaimUnposted()` abandons pending rows with a null `messageId` older than a grace window, run
+first in the vote sweep so a stranded claim is cleared before expiry can time it out. The grace
+window matters — without it a concurrent request could reclaim a publish still in flight.
+
+**How to apply:** when a row claims a slot ahead of an irreversible side effect, check what can
+throw in between and move it earlier, then ask what clears the claim if the process dies there. Also
+classify the duplicate-key error rather than catching broadly: the original code reported *any*
+insert failure as "you already have a vote open", which is how a stranded row looked identical to a
+missing table. See [[nullable-unique-key-enforces-one-open-row]] for the constraint itself.

--- a/.claude/memory/mikro-orm-execute-needs-run-mode.md
+++ b/.claude/memory/mikro-orm-execute-needs-run-mode.md
@@ -1,0 +1,27 @@
+---
+name: mikro-orm-execute-needs-run-mode
+description: "connection.execute() returns rows by default, so affectedRows is undefined on every UPDATE unless you pass 'run'"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 90fbe174-1646-4977-a103-bfdf7cf2ff8d
+  modified: 2026-08-02T20:16:22.304Z
+---
+
+`em.getConnection().execute(sql, params)` defaults to `method: 'all'` and returns **rows**. For an
+`UPDATE` that means `[]`, so `result.affectedRows` is `undefined` and any `?? 0` fallback reads as
+zero. Pass `'run'` as the third argument to get `{ affectedRows, rows }` back.
+
+**Why:** it fails silently and in the safe-looking direction. Every conditional-update election in
+the Albion rank-up feature — resolving a vote, claiming the announcement, claiming the denial-notice
+throttle, reclaiming a stranded ballot — treats "affected 1 row" as winning. Reading 0 means every
+caller concludes somebody else won and returns without doing anything, so votes resolved in the
+database and never announced, and denial notices never reached Judgement Hall. Nothing throws and
+nothing logs. It shipped because the specs mock `execute` and assert on the SQL string, which is
+exactly the part that was right. See [[nullable-unique-key-enforces-one-open-row]] for why these
+elections exist at all.
+
+**How to apply:** any `execute()` whose return value you inspect needs `'run'`. Assert on the third
+argument in the spec (`expect(execute.mock.calls[0][2]).toBe('run')`) — a mocked connection returns
+whatever you told it to, so the mode is the one thing mocks can never catch. Where an election
+decides whether a side effect happens, prove it once against the real container.

--- a/src/albion/services/albion.rank.up.service.spec.ts
+++ b/src/albion/services/albion.rank.up.service.spec.ts
@@ -2,6 +2,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { getRepositoryToken } from '@mikro-orm/nestjs';
+import { UniqueConstraintViolationException } from '@mikro-orm/core';
 import { AlbionRankUpService, RankUpRefusal } from './albion.rank.up.service';
 import { AlbionRegistrationsEntity } from '../../database/entities/albion.registrations.entity';
 import {
@@ -11,6 +12,7 @@ import {
 import { AlbionUtilities } from '../utilities/albion.utilities';
 import { DiscordService } from '../../discord/discord.service';
 import { MemberActivityRollupService } from '../../general/services/member.activity.rollup.service';
+import { AlbionRankUpVoteService } from './albion.rank.up.vote.service';
 import { TestBootstrapper } from '../../test.bootstrapper';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -21,11 +23,19 @@ describe('AlbionRankUpService', () => {
   let voteRepository: any;
   let albionUtilities: any;
   let rollupService: any;
+  let voteService: any;
+  let votePersist: jest.Mock;
+  let voteFlush: jest.Mock;
   let channelSend: jest.Mock;
   let registrationsExecute: jest.Mock;
   let ballotMessage: any;
 
   const daysAgo = (days: number) => new Date(Date.now() - days * DAY_MS);
+
+  // What MikroORM actually throws when the pendingKey index rejects a second open ballot
+  const duplicateKeyError = () => new UniqueConstraintViolationException(
+    new Error('Duplicate entry \'candidate\' for key \'albion_rank_up_vote_entity_pending_key_unique\''),
+  );
 
   const makeRegistration = (overrides: any = {}) => ({
     id: 1,
@@ -60,11 +70,14 @@ describe('AlbionRankUpService', () => {
       }),
     };
 
+    votePersist = jest.fn().mockReturnThis();
+    voteFlush = jest.fn().mockResolvedValue(true);
+
     voteRepository = {
       findOne: jest.fn().mockResolvedValue(null),
       getEntityManager: jest.fn().mockReturnValue({
-        persist: jest.fn().mockReturnThis(),
-        flush: jest.fn().mockResolvedValue(true),
+        persist: votePersist,
+        flush: voteFlush,
       }),
     };
 
@@ -80,6 +93,8 @@ describe('AlbionRankUpService', () => {
       getGameTotals: jest.fn().mockResolvedValue([]),
       getTrackingStartDate: jest.fn().mockResolvedValue(daysAgo(10)),
     };
+
+    voteService = { reclaimUnposted: jest.fn().mockResolvedValue(0) };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -97,6 +112,7 @@ describe('AlbionRankUpService', () => {
         },
         { provide: AlbionUtilities, useValue: albionUtilities },
         { provide: MemberActivityRollupService, useValue: rollupService },
+        { provide: AlbionRankUpVoteService, useValue: voteService },
         { provide: getRepositoryToken(AlbionRegistrationsEntity), useValue: registrationsRepository },
         { provide: getRepositoryToken(AlbionRankUpVoteEntity), useValue: voteRepository },
       ],
@@ -347,6 +363,16 @@ describe('AlbionRankUpService', () => {
       expect(channelSend).toHaveBeenCalledTimes(1);
     });
 
+    // Without 'run' the driver returns rows, so the UPDATE comes back as [] and the claim always
+    // reads as lost - no denial notice would ever reach Judgement Hall
+    it('asks for the affected row count', async () => {
+      registrationsRepository.findOne.mockResolvedValue(makeRegistration({ createdAt: daysAgo(2) }));
+
+      await service.handleRankUpRequest(member);
+
+      expect(registrationsExecute.mock.calls[0][2]).toBe('run');
+    });
+
     it('stays silent when the claim matches no rows', async () => {
       registrationsExecute.mockResolvedValue({ affectedRows: 0 });
       registrationsRepository.findOne.mockResolvedValue(makeRegistration({ createdAt: daysAgo(2) }));
@@ -417,14 +443,67 @@ describe('AlbionRankUpService', () => {
     });
 
     it('refuses when a ballot is already open', async () => {
-      voteRepository.getEntityManager.mockReturnValue({
-        persist: jest.fn().mockReturnThis(),
-        flush: jest.fn().mockRejectedValue(new Error('Duplicate entry for key pending_key')),
-      });
+      voteFlush.mockRejectedValue(duplicateKeyError());
 
       const outcome = await service.handleRankUpRequest(member);
 
       expect(outcome.reply).toContain('already have a rank up vote open');
+      expect(channelSend).not.toHaveBeenCalledWith(expect.objectContaining({
+        content: expect.stringContaining('wants to be ranked up'),
+      }));
+    });
+
+    // The bug this replaced: any insert failure was reported as an open ballot, so a missing
+    // table or a bad column read as "you already have a vote" with nothing in the table
+    it('does not claim a ballot is open when the insert failed for another reason', async () => {
+      voteFlush.mockRejectedValue(new Error('Table albion_rank_up_vote_entity does not exist'));
+
+      const outcome = await service.handleRankUpRequest(member);
+
+      expect(outcome.ok).toBe(false);
+      expect(outcome.reply).not.toContain('already have a rank up vote open');
+      expect(outcome.reply).toContain('Something went wrong');
+    });
+
+    it('does not post a ballot when the insert failed for another reason', async () => {
+      voteFlush.mockRejectedValue(new Error('Table albion_rank_up_vote_entity does not exist'));
+
+      await service.handleRankUpRequest(member);
+
+      expect(channelSend).not.toHaveBeenCalledWith(expect.objectContaining({
+        content: expect.stringContaining('wants to be ranked up'),
+      }));
+    });
+
+    // A claim left behind by an attempt that died before posting is ours to clear, not a
+    // reason to lock the member out of a ballot nobody ever saw
+    it('reclaims a ballot that was never posted and retries', async () => {
+      voteFlush.mockRejectedValueOnce(duplicateKeyError());
+      voteService.reclaimUnposted.mockResolvedValue(1);
+
+      const outcome = await service.handleRankUpRequest(member);
+
+      expect(voteService.reclaimUnposted).toHaveBeenCalledWith('candidate');
+      expect(outcome.ok).toBe(true);
+      expect(lastSentContent()).toContain('wants to be ranked up');
+    });
+
+    it('refuses when there was nothing stranded to reclaim', async () => {
+      voteFlush.mockRejectedValue(duplicateKeyError());
+      voteService.reclaimUnposted.mockResolvedValue(0);
+
+      const outcome = await service.handleRankUpRequest(member);
+
+      expect(outcome.reply).toContain('already have a rank up vote open');
+    });
+
+    // Anything failing after the row is claimed but before the send strands the member behind a
+    // ballot that was never posted, so the report has to be built first
+    it('does not claim a ballot when the activity report cannot be built', async () => {
+      rollupService.getRollup.mockRejectedValue(new Error('activity table is missing'));
+
+      await expect(service.handleRankUpRequest(member)).rejects.toThrow('activity table is missing');
+      expect(votePersist).not.toHaveBeenCalled();
     });
 
     it('adds all four reactions in order', async () => {

--- a/src/albion/services/albion.rank.up.service.spec.ts
+++ b/src/albion/services/albion.rank.up.service.spec.ts
@@ -600,10 +600,46 @@ describe('AlbionRankUpService', () => {
       });
     });
 
-    it('always shows Albion Online even at zero', async () => {
+    it('shows Albion Online at zero when the member has some game data', async () => {
+      rollupService.getGameTotals.mockResolvedValue([{ gameName: 'Foxhole', minutes: 60 }]);
+
       await service.handleRankUpRequest(member);
 
       expect(lastSentContent()).toContain('Albion Online: 0h 0m');
+    });
+
+    // "0h 0m" reads as "played none", which is a different claim from "we recorded nothing"
+    it('says nothing was recorded rather than showing zero hours', async () => {
+      rollupService.getRollup.mockResolvedValue([{ messagesSent: 3, reactionsAdded: 0, voiceMinutes: 0 }]);
+      rollupService.getGameTotals.mockResolvedValue([]);
+
+      await service.handleRankUpRequest(member);
+      const content = lastSentContent();
+
+      expect(content).toContain('No game activity recorded');
+      expect(content).not.toContain('Albion Online: 0h 0m');
+    });
+
+    // A brand new member has no rows at all. Zeroes plus a red band would read as a verdict.
+    it('states there is no data rather than reporting a member as inactive', async () => {
+      rollupService.getRollup.mockResolvedValue([]);
+      rollupService.getGameTotals.mockResolvedValue([]);
+
+      await service.handleRankUpRequest(member);
+      const content = lastSentContent();
+
+      expect(content).toContain('No activity data recorded for this member');
+      expect(content).not.toContain('🔴 Low');
+      expect(content).not.toContain('Messages:');
+    });
+
+    it('still names the character and registration date when there is no activity data', async () => {
+      rollupService.getRollup.mockResolvedValue([]);
+      rollupService.getGameTotals.mockResolvedValue([]);
+
+      await service.handleRankUpRequest(member);
+
+      expect(lastSentContent()).toContain('**Character:** Testy');
     });
 
     it('shows the top three other games and omits the line when there are none', async () => {

--- a/src/albion/services/albion.rank.up.service.spec.ts
+++ b/src/albion/services/albion.rank.up.service.spec.ts
@@ -26,6 +26,7 @@ describe('AlbionRankUpService', () => {
   let voteService: any;
   let votePersist: jest.Mock;
   let voteFlush: jest.Mock;
+  let voteExecute: jest.Mock;
   let channelSend: jest.Mock;
   let registrationsExecute: jest.Mock;
   let ballotMessage: any;
@@ -58,7 +59,11 @@ describe('AlbionRankUpService', () => {
 
   beforeEach(async () => {
     channelSend = jest.fn().mockImplementation(async () => ballotMessage);
-    ballotMessage = { id: 'msg-1', react: jest.fn().mockResolvedValue(true) };
+    ballotMessage = {
+      id: 'msg-1',
+      react: jest.fn().mockResolvedValue(true),
+      delete: jest.fn().mockResolvedValue(true),
+    };
     registrationsExecute = jest.fn().mockResolvedValue({ affectedRows: 1 });
 
     registrationsRepository = {
@@ -72,12 +77,14 @@ describe('AlbionRankUpService', () => {
 
     votePersist = jest.fn().mockReturnThis();
     voteFlush = jest.fn().mockResolvedValue(true);
+    voteExecute = jest.fn().mockResolvedValue({ affectedRows: 1 });
 
     voteRepository = {
       findOne: jest.fn().mockResolvedValue(null),
       getEntityManager: jest.fn().mockReturnValue({
         persist: votePersist,
         flush: voteFlush,
+        getConnection: jest.fn().mockReturnValue({ execute: voteExecute }),
       }),
     };
 
@@ -495,6 +502,36 @@ describe('AlbionRankUpService', () => {
       const outcome = await service.handleRankUpRequest(member);
 
       expect(outcome.reply).toContain('already have a rank up vote open');
+    });
+
+    it('records the message ID only while it still owns the claim', async () => {
+      await service.handleRankUpRequest(member);
+
+      const track = voteExecute.mock.calls.find((c: any[]) => c[0].includes('set message_id = ?'));
+      expect(track[0]).toContain('message_id is null');
+      expect(track[2]).toBe('run');
+    });
+
+    // The sweep can reclaim a claim while the send is in flight. The post is then an orphan
+    // nothing will ever resolve, so it has to come back down rather than collect votes.
+    it('removes a ballot that was reclaimed while it was being posted', async () => {
+      voteExecute.mockResolvedValue({ affectedRows: 0 });
+
+      const outcome = await service.handleRankUpRequest(member);
+
+      expect(ballotMessage.delete).toHaveBeenCalled();
+      expect(outcome.ok).toBe(false);
+      expect(outcome.reply).toContain('try again');
+    });
+
+    it('leaves the ballot up when it cannot tell whether it still owns it', async () => {
+      voteExecute.mockRejectedValue(new Error('db unreachable'));
+
+      const outcome = await service.handleRankUpRequest(member);
+
+      // Taking down a ballot leadership may already be voting on is the worse mistake
+      expect(ballotMessage.delete).not.toHaveBeenCalled();
+      expect(outcome.ok).toBe(true);
     });
 
     // Anything failing after the row is claimed but before the send strands the member behind a

--- a/src/albion/services/albion.rank.up.service.ts
+++ b/src/albion/services/albion.rank.up.service.ts
@@ -176,6 +176,7 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
     // Built before the row is claimed. Anything failing in here afterwards would strand a pending
     // ballot with no message, locking the member out of a vote nobody could ever see.
     const content = await this.buildBallot(member, registration, tier, anchor, electors.length, requiredScore, expiresAt);
+    const ping: LeadershipPing = this.config.get('albion.leadershipPing');
 
     const newBallot = () => new AlbionRankUpVoteEntity({
       channelId: this.judgementHall.id,
@@ -207,7 +208,6 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
       return await this.refuse(member, registration, tier, RankUpRefusal.VOTE_ALREADY_OPEN);
     }
 
-    const ping: LeadershipPing = this.config.get('albion.leadershipPing');
     let message: Awaited<ReturnType<TextChannel['send']>>;
 
     try {
@@ -217,23 +217,37 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
       });
     }
     catch (err) {
-      // Don't lock the member out behind a ballot that never went up
-      vote.status = 'abandoned' as AlbionRankUpVoteEntity['status'];
-      vote.pendingKey = null;
-      vote.resolutionNote = 'The ballot could not be posted';
-      await this.voteRepository.getEntityManager().persist(vote).flush();
-
       this.logger.error(`Failed to post rank up ballot for ${member.id}: ${err.message}`);
+
+      // Don't lock the member out behind a ballot that never went up. The cleanup gets its own
+      // guard because a failure here would escape and strand the claim it exists to release.
+      try {
+        vote.status = AlbionRankUpVoteStatus.ABANDONED;
+        vote.pendingKey = null;
+        vote.resolutionNote = 'The ballot could not be posted';
+        await this.voteRepository.getEntityManager().persist(vote).flush();
+      }
+      catch (cleanupErr) {
+        // The sweep will reclaim it, so this costs the member a wait rather than a lockout
+        this.logger.error(`Could not release the claim for ${member.id}: ${cleanupErr.message}`);
+      }
+
       return { ok: false, reply: '⛔ Could not post your rank up request. Please tell leadership.' };
     }
 
-    try {
-      vote.messageId = message.id;
-      await this.voteRepository.getEntityManager().persist(vote).flush();
-    }
-    catch (err) {
-      // The ballot is public and now untracked - the one case that needs a human
-      this.logger.error(`Rank up ballot ${message.id} is public but could not be tracked: ${err.message}`);
+    if (!await this.trackBallot(vote, message.id)) {
+      // The sweep reclaimed the claim while the send was in flight, so this ballot is an orphan
+      // nothing will ever resolve. Take it down rather than leave leadership voting on it.
+      this.logger.error(`Ballot ${message.id} for ${member.id} was reclaimed mid-post, removing it`);
+
+      try {
+        await message.delete();
+      }
+      catch (err) {
+        this.logger.error(`Could not remove orphaned ballot ${message.id}: ${err.message}`);
+      }
+
+      return { ok: false, reply: '⛔ Your rank up request could not be opened. Please try again.' };
     }
 
     for (const emoji of VOTE_REACTIONS) {
@@ -250,6 +264,36 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
       ok: true,
       reply: `✅ Your rank up request has been sent to <#${this.judgementHall.id}>. Leadership will vote on it, and voting closes ${discordTime(expiresAt, 'R')}.`,
     };
+  }
+
+  // Conditional, because the reclaim sweep can decide a ballot is never going to appear while the
+  // send is still in flight. Losing that race means our post is an orphan, so the caller has to
+  // know rather than write a message ID onto a row somebody else already abandoned.
+  private async trackBallot(vote: AlbionRankUpVoteEntity, messageId: string): Promise<boolean> {
+    try {
+      const result = await this.voteRepository.getEntityManager().getConnection().execute(
+        `update albion_rank_up_vote_entity set message_id = ?, updated_at = ?
+          where id = ? and status = ? and message_id is null`,
+        [messageId, new Date(), vote.id, AlbionRankUpVoteStatus.PENDING],
+        'run',
+      );
+
+      return this.affectedRows(result) === 1;
+    }
+    catch (err) {
+      // Can't tell whether we still own it, and taking down a ballot leadership may already be
+      // voting on is the worse mistake. Leave it up and shout.
+      this.logger.error(`Rank up ballot ${messageId} is public but could not be tracked: ${err.message}`);
+      return true;
+    }
+  }
+
+  private affectedRows(result: unknown): number {
+    if (typeof result === 'number') {
+      return result;
+    }
+
+    return (result as { affectedRows?: number })?.affectedRows ?? 0;
   }
 
   // A unique violation can mean a live ballot, or a stranded claim from an attempt that died
@@ -270,6 +314,8 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
         throw err;
       }
 
+      // Safe to reuse the entity manager: MikroORM drops the failed entity from the persist
+      // stack, so this flush inserts only the replacement. Verified against the container.
       const retry = newBallot();
       await this.voteRepository.getEntityManager().persist(retry).flush();
       return retry;
@@ -508,10 +554,6 @@ ${stats}`;
       'run',
     );
 
-    const affected = typeof result === 'number'
-      ? result
-      : (result as { affectedRows?: number })?.affectedRows ?? 0;
-
-    return affected === 1;
+    return this.affectedRows(result) === 1;
   }
 }

--- a/src/albion/services/albion.rank.up.service.ts
+++ b/src/albion/services/albion.rank.up.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@mikro-orm/nestjs';
-import { EntityRepository } from '@mikro-orm/core';
+import { EntityRepository, UniqueConstraintViolationException } from '@mikro-orm/core';
 import { GuildMember, TextChannel } from 'discord.js';
 import { AlbionRegistrationsEntity } from '../../database/entities/albion.registrations.entity';
 import {
@@ -11,7 +11,8 @@ import {
 import { AlbionUtilities } from '../utilities/albion.utilities';
 import { DiscordService } from '../../discord/discord.service';
 import { MemberActivityRollupService } from '../../general/services/member.activity.rollup.service';
-import { VOTE_REACTIONS } from './albion.rank.up.vote.service';
+import { LeadershipPing } from '../../config/albion.app.config';
+import { AlbionRankUpVoteService, VOTE_REACTIONS } from './albion.rank.up.vote.service';
 import { discordTime } from '../../helpers';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -70,6 +71,7 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
     private readonly discordService: DiscordService,
     private readonly albionUtilities: AlbionUtilities,
     private readonly rollupService: MemberActivityRollupService,
+    private readonly voteService: AlbionRankUpVoteService,
     @InjectRepository(AlbionRegistrationsEntity) private readonly registrationsRepository: EntityRepository<AlbionRegistrationsEntity>,
     @InjectRepository(AlbionRankUpVoteEntity) private readonly voteRepository: EntityRepository<AlbionRankUpVoteEntity>,
   ) {}
@@ -171,37 +173,47 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
     const expiresAt = new Date(Date.now() + VOTE_DURATION_DAYS * DAY_MS);
     const characterName = registration.characterName.slice(0, MAX_CHARACTER_NAME);
 
+    // Built before the row is claimed. Anything failing in here afterwards would strand a pending
+    // ballot with no message, locking the member out of a vote nobody could ever see.
+    const content = await this.buildBallot(member, registration, tier, anchor, electors.length, requiredScore, expiresAt);
+
+    const newBallot = () => new AlbionRankUpVoteEntity({
+      channelId: this.judgementHall.id,
+      discordId: member.id,
+      pendingKey: member.id, // Unique, so the database rejects a second open ballot
+      characterName,
+      fromRank: tier.from,
+      toRank: tier.to,
+      requiredScore,
+      electorateSize: electors.length,
+      expiresAt,
+    });
+
     // The row goes in before the Discord post. Posting first means a flush failure leaves a
     // public ballot nothing tracks and nothing will ever resolve.
     let vote: AlbionRankUpVoteEntity;
 
     try {
-      vote = new AlbionRankUpVoteEntity({
-        channelId: this.judgementHall.id,
-        discordId: member.id,
-        pendingKey: member.id, // Unique, so the database rejects a second open ballot
-        characterName,
-        fromRank: tier.from,
-        toRank: tier.to,
-        requiredScore,
-        electorateSize: electors.length,
-        expiresAt,
-      });
-      await this.voteRepository.getEntityManager().persist(vote).flush();
+      vote = await this.claimBallot(newBallot);
     }
     catch (err) {
+      if (!(err instanceof UniqueConstraintViolationException)) {
+        // Anything that isn't the duplicate guard is a fault, not a member doing something wrong
+        this.logger.error(`Could not open a rank up ballot for ${member.id}: ${err.message}`);
+        return { ok: false, reply: '⛔ Something went wrong opening your rank up request. Please tell leadership.' };
+      }
+
       this.logger.warn(`Refused a duplicate rank up ballot for ${member.id}: ${err.message}`);
       return await this.refuse(member, registration, tier, RankUpRefusal.VOTE_ALREADY_OPEN);
     }
 
-    const content = await this.buildBallot(member, registration, tier, anchor, electors.length, requiredScore, expiresAt);
-    const pingRole = this.config.get('albion.leadershipPingRole');
+    const ping: LeadershipPing = this.config.get('albion.leadershipPing');
     let message: Awaited<ReturnType<TextChannel['send']>>;
 
     try {
       message = await this.judgementHall.send({
         content,
-        allowedMentions: { roles: [pingRole], users: [member.id] },
+        allowedMentions: { roles: ping.roles, users: [...ping.users, member.id] },
       });
     }
     catch (err) {
@@ -240,6 +252,30 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
     };
   }
 
+  // A unique violation can mean a live ballot, or a stranded claim from an attempt that died
+  // before it posted. Clearing the latter is the difference between a retry and a lockout.
+  private async claimBallot(newBallot: () => AlbionRankUpVoteEntity): Promise<AlbionRankUpVoteEntity> {
+    const ballot = newBallot();
+
+    try {
+      await this.voteRepository.getEntityManager().persist(ballot).flush();
+      return ballot;
+    }
+    catch (err) {
+      if (!(err instanceof UniqueConstraintViolationException)) {
+        throw err;
+      }
+
+      if (await this.voteService.reclaimUnposted(ballot.discordId) === 0) {
+        throw err;
+      }
+
+      const retry = newBallot();
+      await this.voteRepository.getEntityManager().persist(retry).flush();
+      return retry;
+    }
+  }
+
   private async buildBallot(
     member: GuildMember,
     registration: AlbionRegistrationsEntity,
@@ -249,10 +285,10 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
     requiredScore: number,
     expiresAt: Date,
   ): Promise<string> {
-    const pingRole = this.config.get('albion.leadershipPingRole');
+    const ping: LeadershipPing = this.config.get('albion.leadershipPing');
     const stats = await this.buildActivityBlock(member.id, anchor, registration, tier);
 
-    return `<@&${pingRole}>
+    return `${ping.mention}
 
 Guildmember <@${member.id}> wants to be ranked up from **${this.friendlyRank(tier.from)}** to **${this.friendlyRank(tier.to)}**.
 Please react with the following:
@@ -459,6 +495,8 @@ ${stats}`;
 
   // Claimed before sending, so two simultaneous refusals can't both post. A failed send then
   // costs at most one suppressed notice, which is the right way round for a rate limit.
+  // 'run' is required: execute() otherwise returns rows, so an UPDATE comes back as [] and this
+  // would always read as "somebody else claimed it" and never post a notice at all.
   private async claimDenialNotice(registration: AlbionRegistrationsEntity): Promise<boolean> {
     const threshold = new Date(Date.now() - DENIAL_NOTICE_THROTTLE_HOURS * 60 * 60 * 1000);
     const connection = this.registrationsRepository.getEntityManager().getConnection();
@@ -467,6 +505,7 @@ ${stats}`;
       `update albion_registrations_entity set last_denial_notice_at = ?, updated_at = ?
         where id = ? and (last_denial_notice_at is null or last_denial_notice_at < ?)`,
       [new Date(), new Date(), registration.id, threshold],
+      'run',
     );
 
     const affected = typeof result === 'number'

--- a/src/albion/services/albion.rank.up.service.ts
+++ b/src/albion/services/albion.rank.up.service.ts
@@ -395,24 +395,37 @@ ${stats}`;
       lines.push(`**Graduate since:** ${discordTime(registration.graduateSince, 'D')} — ${graduateDays} days ago`);
     }
 
-    lines.push(`- ⚔️ **${albionName}: ${this.friendlyDuration(albionMinutes)}**`);
-
-    if (otherGames.length > 0) {
-      lines.push(`- 🎮 Other games: ${otherGames.join(', ')}`);
+    // No rows at all is not the same as a member who did nothing. Rendering zeroes and a red band
+    // would read as a damning report when it usually means they predate tracking.
+    if (rollup.length === 0 && gameTotals.length === 0) {
+      lines.push(
+        '',
+        '📭 **No activity data recorded for this member.**',
+        'That may mean they were inactive, or simply that nothing has been tracked for them yet — leadership will need to judge this one on what they know.',
+      );
     }
+    else {
+      lines.push(gameTotals.length > 0
+        ? `- ⚔️ **${albionName}: ${this.friendlyDuration(albionMinutes)}**`
+        : '- ⚔️ No game activity recorded');
 
-    lines.push(
-      `- 🎙️ Voice: **${this.friendlyDuration(voiceMinutes)}**`,
-      `- 💬 Messages: **${messages}** (${(messages / trackedDays).toFixed(1)}/day)`,
-      `- ⭐ Reactions: **${reactions}**`,
-      `- 📊 Active on **${activeDays}** of **${trackedDays}** days (${((activeDays / trackedDays) * 100).toFixed(0)}%) — ${this.activityBand(activeDays, trackedDays)}`,
-    );
+      if (otherGames.length > 0) {
+        lines.push(`- 🎮 Other games: ${otherGames.join(', ')}`);
+      }
+
+      lines.push(
+        `- 🎙️ Voice: **${this.friendlyDuration(voiceMinutes)}**`,
+        `- 💬 Messages: **${messages}** (${(messages / trackedDays).toFixed(1)}/day)`,
+        `- ⭐ Reactions: **${reactions}**`,
+        `- 📊 Active on **${activeDays}** of **${trackedDays}** days (${((activeDays / trackedDays) * 100).toFixed(0)}%) — ${this.activityBand(activeDays, trackedDays)}`,
+      );
+    }
 
     if (trackingStart) {
       lines.push(`\n-# Activity tracking began ${discordTime(trackingStart, 'D')}. Figures cover the ${trackedDays} days since.`);
     }
     else {
-      lines.push('\n-# No activity has been recorded yet, so these figures are all zero.');
+      lines.push('\n-# Activity tracking has not recorded anything yet, for anyone.');
     }
 
     lines.push('-# Game time is sampled from Discord presence — it only counts when the member has Discord open with game activity sharing enabled, so a low figure may reflect settings rather than inactivity.');

--- a/src/albion/services/albion.rank.up.vote.cron.service.spec.ts
+++ b/src/albion/services/albion.rank.up.vote.cron.service.spec.ts
@@ -33,6 +33,7 @@ describe('AlbionRankUpVoteCronService', () => {
     };
 
     voteService = {
+      reclaimUnposted: jest.fn().mockResolvedValue(0),
       evaluate: jest.fn().mockResolvedValue(undefined),
       resolve: jest.fn().mockResolvedValue(true),
       announce: jest.fn().mockResolvedValue(undefined),
@@ -149,6 +150,25 @@ describe('AlbionRankUpVoteCronService', () => {
         2,
         expect.stringContaining('elapsed'),
       );
+    });
+  });
+
+  describe('sweep', () => {
+    // Before expireOverdue, or a ballot that was never posted gets timed out instead of
+    // reclaimed - which would also lock the member out for the failed vote period
+    it('reclaims unposted ballots before anything else', async () => {
+      const order: string[] = [];
+      voteService.reclaimUnposted.mockImplementation(async () => {
+        order.push('reclaim');
+        return 0;
+      });
+      jest.spyOn(service, 'expireOverdue').mockImplementation(async () => {
+        order.push('expire');
+      });
+
+      await service.sweep();
+
+      expect(order).toEqual(['reclaim', 'expire']);
     });
   });
 

--- a/src/albion/services/albion.rank.up.vote.cron.service.ts
+++ b/src/albion/services/albion.rank.up.vote.cron.service.ts
@@ -40,6 +40,8 @@ export class AlbionRankUpVoteCronService implements OnApplicationBootstrap {
   }
 
   async sweep(): Promise<void> {
+    // First, so a stranded claim is cleared before expireOverdue can time it out
+    await this.voteService.reclaimUnposted();
     await this.reconcileUnannounced();
     await this.commitElapsedHolds();
     await this.expireOverdue();

--- a/src/albion/services/albion.rank.up.vote.service.spec.ts
+++ b/src/albion/services/albion.rank.up.vote.service.spec.ts
@@ -6,6 +6,7 @@ import { Collection } from 'discord.js';
 import {
   AlbionRankUpVoteService,
   PROVISIONAL_HOLD_MS,
+  UNPOSTED_GRACE_MS,
   VOTE_APPROVE,
   VOTE_DISAPPROVE,
   VOTE_SHRUG,
@@ -348,6 +349,65 @@ describe('AlbionRankUpVoteService', () => {
       await service.resolve(makeVote(), AlbionRankUpVoteStatus.FAILED, 1);
 
       expect(execute.mock.calls[0][0]).toContain('pending_key = null');
+    });
+
+    // Without 'run' the driver returns rows, so an UPDATE comes back as [] and every election
+    // reads as lost - votes would resolve in the database and never announce
+    it('asks for the affected row count', async () => {
+      await service.resolve(makeVote(), AlbionRankUpVoteStatus.PASSED, 4);
+
+      for (const call of execute.mock.calls) {
+        expect(call[2]).toBe('run');
+      }
+    });
+  });
+
+  describe('reclaimUnposted', () => {
+    it('only touches pending rows that never got a message', async () => {
+      await service.reclaimUnposted();
+
+      expect(execute.mock.calls[0][0]).toContain('message_id is null');
+      expect(execute.mock.calls[0][0]).toContain('status = ?');
+      expect(execute.mock.calls[0][1]).toContain(AlbionRankUpVoteStatus.ABANDONED);
+    });
+
+    it('frees the pending key so the member can ask again', async () => {
+      await service.reclaimUnposted();
+
+      expect(execute.mock.calls[0][0]).toContain('pending_key = null');
+    });
+
+    // Otherwise the reconcile sweep would try to post an outcome for a ballot nobody ever saw
+    it('marks the row announced so nothing tries to post an outcome', async () => {
+      await service.reclaimUnposted();
+
+      expect(execute.mock.calls[0][0]).toContain('announced_at = ?');
+    });
+
+    it('leaves a publish still in flight alone', async () => {
+      await service.reclaimUnposted();
+
+      const cutoff: Date = execute.mock.calls[0][1].at(-1);
+      expect(Date.now() - cutoff.getTime()).toBeGreaterThanOrEqual(UNPOSTED_GRACE_MS);
+    });
+
+    it('narrows to one member when given a discord ID', async () => {
+      await service.reclaimUnposted('candidate');
+
+      expect(execute.mock.calls[0][0]).toContain('and discord_id = ?');
+      expect(execute.mock.calls[0][1].at(-1)).toBe('candidate');
+    });
+
+    it('reports how many it reclaimed', async () => {
+      execute.mockResolvedValue({ affectedRows: 2 });
+
+      expect(await service.reclaimUnposted()).toBe(2);
+    });
+
+    it('asks for the affected row count', async () => {
+      await service.reclaimUnposted();
+
+      expect(execute.mock.calls[0][2]).toBe('run');
     });
   });
 

--- a/src/albion/services/albion.rank.up.vote.service.spec.ts
+++ b/src/albion/services/albion.rank.up.vote.service.spec.ts
@@ -384,7 +384,9 @@ describe('AlbionRankUpVoteService', () => {
       expect(execute.mock.calls[0][0]).toContain('announced_at = ?');
     });
 
-    it('leaves a publish still in flight alone', async () => {
+    // Only bounds how recent a claim can be and still be reclaimed. It does not prove a
+    // concurrent publish is safe - trackBallot()'s conditional write is what does that.
+    it('only considers claims older than the grace window', async () => {
       await service.reclaimUnposted();
 
       const cutoff: Date = execute.mock.calls[0][1].at(-1);
@@ -408,6 +410,61 @@ describe('AlbionRankUpVoteService', () => {
       await service.reclaimUnposted();
 
       expect(execute.mock.calls[0][2]).toBe('run');
+    });
+  });
+
+  describe('announcement recovery', () => {
+    const passed = () => makeVote({ status: AlbionRankUpVoteStatus.PASSED, toRank: '@ALB/Adept' });
+    const releaseCall = () => execute.mock.calls.find((c: any[]) => c[0].includes('announced_at = null'));
+
+    const withBallot = (content = 'Current score: **4** / 4') => {
+      discordService.getTextChannel = jest.fn().mockResolvedValue({
+        id: 'chan-1',
+        send: channelSend,
+        messages: { fetch: jest.fn().mockResolvedValue(makeMessage({}, content)) },
+      });
+    };
+
+    beforeEach(() => withBallot());
+
+    // The claim is stamped before the Discord work. Without handing it back, a transient failure
+    // suppresses the outcome forever - reconcileUnannounced only looks for announcedAt null
+    it('hands the claim back when announcing fails', async () => {
+      channelSend.mockRejectedValue(new Error('discord is down'));
+
+      await service.announce(passed());
+
+      expect(releaseCall()).toBeDefined();
+      expect(releaseCall()[2]).toBe('run');
+    });
+
+    it('keeps the claim when announcing succeeds', async () => {
+      await service.announce(passed());
+
+      expect(releaseCall()).toBeUndefined();
+    });
+
+    it('does nothing when another caller already claimed the announcement', async () => {
+      execute.mockResolvedValue({ affectedRows: 0 });
+
+      await service.announce(passed());
+
+      expect(channelSend).not.toHaveBeenCalled();
+    });
+
+    // A retried announcement must not stack a second outcome header on the ballot
+    it('does not re-prepend a header the ballot already carries', async () => {
+      withBallot('# ✅ PASSED — score 4 / 4\n\nCurrent score: **4** / 4');
+
+      await service.announce(passed());
+
+      expect(messageEdit).not.toHaveBeenCalled();
+    });
+
+    it('prepends the header when the ballot does not have one', async () => {
+      await service.announce(passed());
+
+      expect(messageEdit).toHaveBeenCalledWith(expect.stringContaining('# ✅ PASSED'));
     });
   });
 

--- a/src/albion/services/albion.rank.up.vote.service.ts
+++ b/src/albion/services/albion.rank.up.vote.service.ts
@@ -41,9 +41,11 @@ const SCORE_LINE = /^Current score:.*(?:\n⏳.*)?$/m;
 // Discord rate limits message edits, and a busy ballot recounts on every reaction
 const SCORE_EDIT_THROTTLE_MS = 5000;
 
-// How long a claimed but unposted ballot is left alone before it is treated as dead. Long enough
-// that a publish still in flight is never reclaimed out from under itself.
-export const UNPOSTED_GRACE_MS = 60 * 1000;
+// How long a claimed but unposted ballot is left alone before it is treated as dead. A send can
+// stall far longer than it looks - discord.js queues behind rate limits - so this is a long way
+// past a normal post rather than a tight bound. It is not the only guard: trackBallot() writes the
+// message ID conditionally, so a publish that loses this race takes its own orphan back down.
+export const UNPOSTED_GRACE_MS = 5 * 60 * 1000;
 
 export interface VoteTally {
   score: number;
@@ -372,6 +374,23 @@ export class AlbionRankUpVoteService {
     }
     catch (err) {
       this.logger.error(`Failed to announce outcome for vote ${vote.id}: ${err.message}`);
+      await this.releaseAnnouncement(vote);
+    }
+  }
+
+  // Hands the claim back so reconcileUnannounced retries. Without this a Discord outage during
+  // the announcement suppresses it permanently - the sweep looks for announcedAt null and the
+  // claim has already been stamped. Both steps it retries are idempotent.
+  private async releaseAnnouncement(vote: AlbionRankUpVoteEntity): Promise<void> {
+    try {
+      await this.voteRepository.getEntityManager().getConnection().execute(
+        'update albion_rank_up_vote_entity set announced_at = null, updated_at = ? where id = ?',
+        [new Date(), vote.id],
+        'run',
+      );
+    }
+    catch (err) {
+      this.logger.error(`Could not release the announcement claim on vote ${vote.id}: ${err.message}`);
     }
   }
 
@@ -423,8 +442,14 @@ export class AlbionRankUpVoteService {
 
     try {
       const message = await this.fetchBallot(vote);
-      const header = this.outcomeHeader(vote);
-      await message.edit(`${header}\n\n${message.content}`);
+
+      // A retried announcement must not stack a second header. A ballot body never starts
+      // with a heading, so one already there is ours.
+      if (message.content.startsWith('# ')) {
+        return;
+      }
+
+      await message.edit(`${this.outcomeHeader(vote)}\n\n${message.content}`);
     }
     catch (err) {
       // An over long edit or a deleted ballot must not lose the outcome - postOutcome still runs

--- a/src/albion/services/albion.rank.up.vote.service.ts
+++ b/src/albion/services/albion.rank.up.vote.service.ts
@@ -9,7 +9,7 @@ import {
   AlbionRankUpVoteStatus,
 } from '../../database/entities/albion.rank.up.vote.entity';
 import { AlbionUtilities } from '../utilities/albion.utilities';
-import { AlbionRoleMapInterface } from '../../config/albion.app.config';
+import { AlbionRoleMapInterface, LeadershipPing } from '../../config/albion.app.config';
 import { DiscordService } from '../../discord/discord.service';
 import { resolvePartialReaction } from '../../discord/discord.hacks';
 import { discordTime } from '../../helpers';
@@ -40,6 +40,10 @@ const SCORE_LINE = /^Current score:.*(?:\n⏳.*)?$/m;
 
 // Discord rate limits message edits, and a busy ballot recounts on every reaction
 const SCORE_EDIT_THROTTLE_MS = 5000;
+
+// How long a claimed but unposted ballot is left alone before it is treated as dead. Long enough
+// that a publish still in flight is never reclaimed out from under itself.
+export const UNPOSTED_GRACE_MS = 60 * 1000;
 
 export interface VoteTally {
   score: number;
@@ -276,6 +280,40 @@ export class AlbionRankUpVoteService {
     return await channel.messages.fetch(vote.messageId);
   }
 
+  // A pending row with no messageId is a ballot that was never posted: the insert claimed the
+  // member's slot and something failed before the send. Nothing else ever clears it, so the member
+  // stays locked out and is eventually timed out for a vote nobody could see.
+  // announcedAt is stamped alongside resolvedAt so the reconcile sweep doesn't try to post an
+  // outcome for a message that never existed.
+  async reclaimUnposted(discordId?: string): Promise<number> {
+    const connection = this.voteRepository.getEntityManager().getConnection();
+    const now = new Date();
+    const cutoff = new Date(Date.now() - UNPOSTED_GRACE_MS);
+
+    const result = await connection.execute(
+      `update albion_rank_up_vote_entity
+          set status = ?, pending_key = null, resolved_at = ?, announced_at = ?,
+              resolution_note = ?, updated_at = ?
+        where status = ? and message_id is null and created_at <= ?
+          ${discordId ? 'and discord_id = ?' : ''}`,
+      [
+        AlbionRankUpVoteStatus.ABANDONED, now, now,
+        'The ballot was never posted', now,
+        AlbionRankUpVoteStatus.PENDING, cutoff,
+        ...(discordId ? [discordId] : []),
+      ],
+      'run',
+    );
+
+    const reclaimed = this.affectedRows(result);
+
+    if (reclaimed > 0) {
+      this.logger.warn(`Reclaimed ${reclaimed} rank up ballot(s) that were never posted`);
+    }
+
+    return reclaimed;
+  }
+
   // Elects a single winner in the database. Re-reading the row and checking it is still pending
   // is itself a race - two reactions landing together would both resolve and both announce.
   async resolve(
@@ -292,6 +330,7 @@ export class AlbionRankUpVoteService {
               provisional_status = null, provisional_since = null, provisional_note = null, updated_at = ?
         where id = ? and status = ?`,
       [status, score, new Date(), note ?? null, new Date(), vote.id, AlbionRankUpVoteStatus.PENDING],
+      'run',
     );
 
     if (this.affectedRows(result) !== 1) {
@@ -315,6 +354,7 @@ export class AlbionRankUpVoteService {
       `update albion_rank_up_vote_entity set announced_at = ?, updated_at = ?
         where id = ? and announced_at is null`,
       [new Date(), new Date(), vote.id],
+      'run',
     );
 
     if (this.affectedRows(claim) !== 1) {
@@ -414,16 +454,16 @@ export class AlbionRankUpVoteService {
     const link = `https://discord.com/channels/${this.config.get('discord.guildId')}/${vote.channelId}/${vote.messageId}`;
 
     if (vote.status === AlbionRankUpVoteStatus.PASSED) {
-      const pingRole = this.config.get('albion.leadershipPingRole');
+      const ping: LeadershipPing = this.config.get('albion.leadershipPing');
 
       await channel.send({
         content: [
-          `<@&${pingRole}> Rank up vote **passed** for <@${vote.discordId}> (${vote.characterName}) — **${this.friendlyRank(vote.fromRank)} → ${this.friendlyRank(vote.toRank)}**, score ${vote.score}/${vote.requiredScore}.`,
+          `${ping.mention} Rank up vote **passed** for <@${vote.discordId}> (${vote.characterName}) — **${this.friendlyRank(vote.fromRank)} → ${this.friendlyRank(vote.toRank)}**, score ${vote.score}/${vote.requiredScore}.`,
           '',
           this.whatIsLeftToDo(vote, granted),
           link,
         ].join('\n'),
-        allowedMentions: { roles: [pingRole], users: [vote.discordId] },
+        allowedMentions: { roles: ping.roles, users: [...ping.users, vote.discordId] },
       });
       return;
     }
@@ -454,6 +494,8 @@ export class AlbionRankUpVoteService {
     return roleName.replace('@ALB/', '');
   }
 
+  // Every caller must pass 'run' to execute(). The default returns rows, so an UPDATE comes back
+  // as [] and every election here would silently read as "somebody else won".
   private affectedRows(result: unknown): number {
     if (typeof result === 'number') {
       return result;

--- a/src/config/albion.app.config.ts
+++ b/src/config/albion.app.config.ts
@@ -1,3 +1,10 @@
+// The mention string plus what allowedMentions has to permit for it to actually notify anyone
+export interface LeadershipPing {
+  mention: string;
+  roles: string[];
+  users: string[];
+}
+
 export interface AlbionRoleMapInterface {
   name: string,
   discordRoleId: string;
@@ -98,11 +105,15 @@ const roleMap = isProduction ? rolesToRankProduction : rolesToRankDevelopment;
 const findRole = (roleName: string) => roleMap.filter((role) => role.name === roleName)[0];
 const pingLeaderRoles = [findRole('@ALB/Archmage').discordRoleId, findRole('@ALB/Magister').discordRoleId];
 
-// The rank up ballot pings this role. No dev equivalent exists yet, so dev falls back to
-// Archmage so the mention still resolves locally.
-const leadershipPingRole = isProduction
-  ? '1421034165356331070'
-  : findRole('@ALB/Archmage').discordRoleId;
+// Who the rank up ballot pings. Dev has no leadership role, and pinging dev Archmage would
+// ping real people during testing, so it pings the dev user instead.
+const leadershipPing = isProduction
+  ? { mention: '<@&1421034165356331070>', roles: ['1421034165356331070'], users: [] }
+  : {
+    mention: `<@${process.env.DISCORD_DEVUSER_ID}>`,
+    roles: [],
+    users: [process.env.DISCORD_DEVUSER_ID],
+  };
 
 // Everyone who may vote on a rank up: Eldritch Mage and above, per the guild ranks wiki.
 // Filtered on priority rather than name because production spells tier 3 "EldritchMager".
@@ -112,7 +123,7 @@ export default () => ({
   guildId: '0_zTfLfASD2Wtw6Tc-yckA',
   roleMap,
   pingLeaderRoles,
-  leadershipPingRole,
+  leadershipPing,
   electorMaxPriority: ELECTOR_MAX_PRIORITY,
   // Ranks the bot grants itself once a vote passes. Adept is deliberately absent: it is
   // soft-leadership, so a human makes that call even after a successful vote.

--- a/src/test.bootstrapper.ts
+++ b/src/test.bootstrapper.ts
@@ -440,7 +440,11 @@ export class TestBootstrapper {
           keep: false,
         },
       ],
-      leadershipPingRole: '1421034165356331070',
+      leadershipPing: {
+        mention: '<@&1421034165356331070>',
+        roles: ['1421034165356331070'],
+        users: [],
+      },
       electorMaxPriority: 3,
       autoAssignRanks: ['@ALB/Graduate'],
       gameActivityName: 'Albion Online',


### PR DESCRIPTION
> [!IMPORTANT]
> ## ⚠️ THIS NEEDS A MANUAL STEP BEFORE IT DEPLOYS
>
> **Rename one environment variable, everywhere the bot runs:**
>
> ```
> CHANNEL_JUDGEMENT_HALL   ->   CHANNEL_ALBION_JUDGEMENT_HALL
> ```
>
> Same value, new name — it now matches the other `CHANNEL_*` entries. Set it to the Albion
> Judgement Hall channel ID for **that environment** (prod and dev are different channels).
>
> **Until it is set, `/albion-rank-up` is dead:** the service throws at bootstrap, Nest logs it and
> carries on booting, and every request is refused. Nothing else in the bot is affected, so the
> deploy itself is safe — the command simply does not work.
>
> It is currently **unset in the running container**, which is one of the two faults this PR fixes.
> Renaming it in the environment is the half a merge cannot do.

Testing registrations with the newly merged `/albion-force-register` immediately surfaced five
faults in the rank-up ballot. Three came out of the original symptom; the adversarial review of the
fix found two more; a sixth fixes how the report reads for a member with no activity data. Testing
the fix against a live bot then exposed two more that killed every ballot outright.

## The symptom

Force-registering a test account and running `/albion-rank-up` produced **"You already have a rank
up vote open"** when no ballot had ever been posted.

### 1. The error message was lying

The catch around the ballot insert treated *any* flush failure as the duplicate-key guard:

```ts
catch (err) {
  return await this.refuse(..., RankUpRefusal.VOTE_ALREADY_OPEN);
}
```

A missing table, a bad column, a connection drop — all reported as an open vote that did not exist.
It now only says that for a `UniqueConstraintViolationException`, which was confirmed against the
database as the class MikroORM actually throws for a `pendingKey` collision (anything else arrives
as a plain `DriverException`, so `instanceof` discriminates cleanly). Everything else logs the real
error and says something went wrong.

### 2. A ballot could be stranded, locking the member out permanently

The row was inserted — claiming `pendingKey` — and *then* the activity report was built, outside any
try/catch. Any failure in those rollup queries threw after the claim, leaving a pending row with no
`messageId`: a vote the member is locked behind that was never posted. Nothing cleaned it up, and
after five days the expiry cron would have closed it as a timeout and added a week-long failed-vote
lockout on top.

Three changes: the report is built **before** the row is claimed, `reclaimUnposted()` abandons
pending rows with no `messageId` past a grace window (swept first, so expiry cannot time one out),
and a duplicate that clears a stranded claim retries once rather than refusing.

### 3. Every affected-row check in the feature was broken

Found while verifying the reclaim SQL against the database — the row was visibly updated but the
count came back zero:

```ts
await connection.execute(sql, params)          // → []          (defaults to returning rows)
await connection.execute(sql, params, 'run')   // → { affectedRows: 1, rows: [] }
```

Four call sites inspect that result, and in `2.32.0` as deployed:

- `resolve()` always returned false → **a vote could pass and never announce or grant the role**
- `announce()` always bailed → nothing posted
- `claimDenialNotice()` always returned false → **no denial notice ever reached Judgement Hall**

Nothing throws and nothing logs. It shipped because the specs mock `execute` and assert on the SQL
string, which was the part that was correct. The specs now assert the mode as well, since a mocked
connection is the one thing that can never catch it.

### 4. An announcement failure suppressed the outcome forever

Raised by the review. The announcement claim is stamped *before* granting the rank, editing the
ballot and posting the outcome — and failures were caught and logged. But `reconcileUnannounced()`
looks for a null `announcedAt`, which the claim had already filled in. So a transient Discord
failure meant the vote resolved in the database and the outcome was never posted **and never
retried**. The comment above it asserted the opposite of what the code did.

The claim is now handed back on failure so the sweep retries, and `editBallot` skips a ballot that
already carries a header, so a retry cannot stack a second one.

### 5. The reclaim sweep could abandon a publish in flight

Also from the review, and a fault in the fix for #2. The original grace window was one minute,
asserted to be safely longer than a post. It is not — a `send()` can queue behind rate limits for
much longer. If it did: the sweep abandons the row, a second request posts another ballot, and the
first writes its message ID onto an abandoned row, leaving a public ballot nothing will ever resolve.

The message ID is now written **conditionally on still owning the claim**, and a publisher that
loses the race takes its own orphan back down. The grace window went to five minutes as defence in
depth rather than as the guarantee.

### 6. Missing activity data was reported as inactivity

A member with no rollup rows rendered as zero hours, zero messages and "active on **0** of **60**
days (0%) — 🔴 Low". That reads as a verdict on the candidate when it is a statement about what has
been recorded, and it is usually the opposite: they predate tracking, or have Discord activity
sharing turned off. On a real ballot that would push leadership toward voting someone down for the
bot's lack of history.

No rows at all now replaces the figures with a plain note that nothing was recorded and that
leadership will have to judge on what they know. The character name and registration dates stay,
since those are real. Where there are counters but no game rows, the Albion line says nothing was
recorded rather than claiming zero hours played.

### 7. `findOne({})` threw on every single ballot

The root cause of the original report, found by running it against a live bot.
`getTrackingStartDate()` did this:

```ts
const earliest = await this.activityRepository.findOne({}, { orderBy: { date: 'ASC' } });
```

MikroORM rejects an empty `where` outright rather than treating it as "match anything":

```
You cannot call 'EntityManager.findOne()' with empty 'where' parameter
```

So it threw on **every** rank-up that got past the gates, regardless of what was in the table. And
under the original ordering that throw landed *after* the row had claimed `pendingKey` — which is
exactly how the phantom "you already have a vote open" was produced. Now `findAll` with a limit,
which has no such restriction. Verified against the container: null on an empty table, the earliest
date on a populated one, and the old form reproducing the throw.

### 8. Judgement Hall was resolved from an unset variable

Bootstrap failed with `Value "undefined" is not snowflake` — a Discord error for what is really
missing configuration. Two changes: the variable is checked by name before the fetch, so the error
names the thing to fix; and because a failed bootstrap only logs and lets Nest carry on booting, a
request arriving without a resolved channel is now refused with a clear message instead of dying on
a TypeError deep inside `publish()`.

## Also

The ballot ping now targets the dev user outside production instead of falling back to the dev
Archmage role, so testing stops mentioning real people. This closes the open item left by the
original rank-up PR, which had no dev-guild leadership role to point at.

## Known limitation

A crash in the window between Discord accepting the post and the message ID being written still
leaves a live untracked ballot that the sweep will later treat as never posted. That window is now
sub-millisecond and cannot be closed without message IDs being assigned before the send. Likewise,
`send()` rejecting does not strictly prove Discord did not accept the message.

## Validation

- `pnpm lint` clean, **620 tests across 47 suites passing**.
- Three mechanics proven against a real MariaDB container rather than mocks, since these are exactly
  the behaviours mocks assert away:
  - `execute(..., 'run')` returns `affectedRows` 1 then 0 across a conditional update; the default
    returns `[]`.
  - The conditional message-ID write returns 1 for the owning publisher and 0 for one whose claim was
    reclaimed underneath it, after which the member can open a new ballot.
  - MikroORM drops a failed entity from the persist stack, so the retry-after-duplicate path inserts
    only the replacement row.
  - `getTrackingStartDate()` returns null on an empty table and the earliest date on a populated one,
    where the previous `findOne({})` throws.

The fix was put through an adversarial review, which returned RETHINK; findings 4 and 5 above are
its two substantive catches, both fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qt1VkMfrJd8ArmWZnw3iHa
