### PR TITLE
feat(albion): Add /albion-ranks command for rank and content role numbers

### DIFF
--- a/src/albion/albion.module.ts
+++ b/src/albion/albion.module.ts
@@ -18,6 +18,8 @@ import { AlbionForceRegisterCommand } from './commands/force-register.command';
 import { AlbionForceRegistrationService } from './services/albion.force.registration.service';
 import { AlbionRegisterQueueCommand } from './commands/register-queue.command';
 import { AlbionRegistrationQueueService } from './services/albion.registration.queue.service';
+import { AlbionRankCountsCommand } from './commands/rank-counts.command';
+import { AlbionRankCountsService } from './services/albion.rank.counts.service';
 import { AlbionRankUpCommand } from './commands/rank-up.command';
 import { AlbionRankUpService } from './services/albion.rank.up.service';
 import { AlbionRankProgressService } from './services/albion.rank.progress.service';
@@ -35,6 +37,8 @@ import { GeneralModule } from '../general/general.module';
     AlbionForceRegisterCommand,
     AlbionForceRegistrationService,
     AlbionLogCommand,
+    AlbionRankCountsCommand,
+    AlbionRankCountsService,
     AlbionRankProgressService,
     AlbionRankUpCommand,
     AlbionRankUpService,

--- a/src/albion/commands/rank-counts.command.spec.ts
+++ b/src/albion/commands/rank-counts.command.spec.ts
@@ -9,10 +9,14 @@ import { TestBootstrapper } from '../../test.bootstrapper';
 const guildId = TestBootstrapper.mockConfig.discord.guildId;
 const counts = {
   ranks: [
-    { name: '@ALB/Archmage', discordRoleId: '1', priority: 1, count: 1 },
-    { name: '@ALB/Disciple', discordRoleId: '2', priority: 6, count: 42 },
+    { name: '@ALB/Archmage', discordRoleId: '1', count: 1 },
+    { name: '@ALB/Disciple', discordRoleId: '2', count: 42 },
+  ],
+  content: [
+    { name: 'ALB/Dungeons', discordRoleId: '3', count: 20 },
   ],
   anyRank: 43,
+  registered: 40,
 };
 
 const createInteraction = () => ({
@@ -22,6 +26,7 @@ const createInteraction = () => ({
   deferReply: jest.fn().mockResolvedValue(undefined),
   editReply: jest.fn().mockResolvedValue(undefined),
   reply: jest.fn().mockResolvedValue(undefined),
+  followUp: jest.fn().mockResolvedValue(undefined),
 }) as any;
 
 describe('AlbionRankCountsCommand', () => {
@@ -32,7 +37,8 @@ describe('AlbionRankCountsCommand', () => {
   beforeEach(async () => {
     rankCountsService = {
       getRankCounts: jest.fn().mockResolvedValue(counts),
-      formatReport: jest.fn().mockReturnValue('## 📊 Albion rank numbers'),
+      formatReport: jest.fn().mockReturnValue('## 📊 Albion role numbers'),
+      chunkReport: jest.fn().mockImplementation((report: string) => [report]),
     };
 
     const moduleRef = await Test.createTestingModule({
@@ -70,8 +76,26 @@ describe('AlbionRankCountsCommand', () => {
 
     expect(rankCountsService.getRankCounts).toHaveBeenCalledWith(guildId);
     expect(rankCountsService.formatReport).toHaveBeenCalledWith(counts);
-    expect(result).toBe('## 📊 Albion rank numbers');
-    expect(interaction.editReply).toHaveBeenCalledWith('## 📊 Albion rank numbers');
+    expect(result).toBe('## 📊 Albion role numbers');
+    expect(interaction.editReply).toHaveBeenCalledWith('## 📊 Albion role numbers');
+    expect(interaction.followUp).not.toHaveBeenCalled();
+  });
+
+  it('should follow up ephemerally with the rest of an oversized report', async () => {
+    rankCountsService.chunkReport.mockReturnValue(['first chunk', 'second chunk', 'third chunk']);
+
+    await command.onAlbionRankCountsCommand([interaction]);
+
+    expect(interaction.editReply).toHaveBeenCalledWith('first chunk');
+    expect(interaction.followUp).toHaveBeenCalledTimes(2);
+    expect(interaction.followUp).toHaveBeenNthCalledWith(1, {
+      content: 'second chunk',
+      flags: MessageFlags.Ephemeral,
+    });
+    expect(interaction.followUp).toHaveBeenNthCalledWith(2, {
+      content: 'third chunk',
+      flags: MessageFlags.Ephemeral,
+    });
   });
 
   it('should report the error when the counts cannot be gathered', async () => {

--- a/src/albion/commands/rank-counts.command.spec.ts
+++ b/src/albion/commands/rank-counts.command.spec.ts
@@ -1,0 +1,85 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { MessageFlags } from 'discord.js';
+import { AlbionRankCountsCommand } from './rank-counts.command';
+import { AlbionRankCountsService } from '../services/albion.rank.counts.service';
+import { TestBootstrapper } from '../../test.bootstrapper';
+
+const guildId = TestBootstrapper.mockConfig.discord.guildId;
+const counts = {
+  ranks: [
+    { name: '@ALB/Archmage', discordRoleId: '1', priority: 1, count: 1 },
+    { name: '@ALB/Disciple', discordRoleId: '2', priority: 6, count: 42 },
+  ],
+  anyRank: 43,
+};
+
+const createInteraction = () => ({
+  guildId: 'discord-guild-id',
+  deferred: true,
+  replied: false,
+  deferReply: jest.fn().mockResolvedValue(undefined),
+  editReply: jest.fn().mockResolvedValue(undefined),
+  reply: jest.fn().mockResolvedValue(undefined),
+}) as any;
+
+describe('AlbionRankCountsCommand', () => {
+  let command: AlbionRankCountsCommand;
+  let rankCountsService: any;
+  let interaction: any;
+
+  beforeEach(async () => {
+    rankCountsService = {
+      getRankCounts: jest.fn().mockResolvedValue(counts),
+      formatReport: jest.fn().mockReturnValue('## 📊 Albion rank numbers'),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        AlbionRankCountsCommand,
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn() },
+        },
+        {
+          provide: AlbionRankCountsService,
+          useValue: rankCountsService,
+        },
+      ],
+    }).compile();
+
+    TestBootstrapper.setupConfig(moduleRef);
+
+    command = moduleRef.get(AlbionRankCountsCommand);
+    interaction = createInteraction();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should defer the reply ephemerally before doing any work', async () => {
+    await command.onAlbionRankCountsCommand([interaction]);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+  });
+
+  it('should reply with the formatted report for the configured guild', async () => {
+    const result = await command.onAlbionRankCountsCommand([interaction]);
+
+    expect(rankCountsService.getRankCounts).toHaveBeenCalledWith(guildId);
+    expect(rankCountsService.formatReport).toHaveBeenCalledWith(counts);
+    expect(result).toBe('## 📊 Albion rank numbers');
+    expect(interaction.editReply).toHaveBeenCalledWith('## 📊 Albion rank numbers');
+  });
+
+  it('should report the error when the counts cannot be gathered', async () => {
+    rankCountsService.getRankCounts.mockRejectedValue(new Error('Could not find guild with ID 123'));
+
+    const result = await command.onAlbionRankCountsCommand([interaction]);
+
+    expect(result).toBe('⛔️ **ERROR:** Could not find guild with ID 123');
+    expect(rankCountsService.formatReport).not.toHaveBeenCalled();
+  });
+});

--- a/src/albion/commands/rank-counts.command.ts
+++ b/src/albion/commands/rank-counts.command.ts
@@ -16,7 +16,7 @@ export class AlbionRankCountsCommand {
 
   @SlashCommand({
     name: 'albion-ranks',
-    description: 'Show how many members hold each Albion rank role',
+    description: 'Show how many members hold each Albion rank and content role',
   })
   async onAlbionRankCountsCommand(
     @Context() [interaction]: SlashCommandContext,
@@ -29,7 +29,18 @@ export class AlbionRankCountsCommand {
 
     try {
       const counts = await this.albionRankCountsService.getRankCounts(this.config.get('discord.guildId'));
-      return replyTo(interaction, this.albionRankCountsService.formatReport(counts));
+      const report = this.albionRankCountsService.formatReport(counts);
+
+      // Enough content roles will outgrow Discord's message limit, so the report may arrive split
+      const [firstChunk, ...restChunks] = this.albionRankCountsService.chunkReport(report);
+
+      await replyTo(interaction, firstChunk);
+
+      for (const chunk of restChunks) {
+        await interaction.followUp({ content: chunk, flags: MessageFlags.Ephemeral });
+      }
+
+      return report;
     }
     catch (err) {
       this.logger.error(`Error getting Albion rank counts: ${err.message}`);

--- a/src/albion/commands/rank-counts.command.ts
+++ b/src/albion/commands/rank-counts.command.ts
@@ -1,0 +1,39 @@
+import { Context, SlashCommand, SlashCommandContext } from 'necord';
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { MessageFlags } from 'discord.js';
+import { AlbionRankCountsService } from '../services/albion.rank.counts.service';
+import { replyTo } from '../../discord/discord.hacks';
+
+@Injectable()
+export class AlbionRankCountsCommand {
+  private readonly logger = new Logger(AlbionRankCountsCommand.name);
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly albionRankCountsService: AlbionRankCountsService,
+  ) {}
+
+  @SlashCommand({
+    name: 'albion-ranks',
+    description: 'Show how many members hold each Albion rank role',
+  })
+  async onAlbionRankCountsCommand(
+    @Context() [interaction]: SlashCommandContext,
+  ): Promise<string> {
+    this.logger.debug('Received Albion Rank Counts Command');
+
+    // Fetching the full member list blows Discord's 3s window. Ephemeral so the numbers can be
+    // pulled from any channel without spamming it.
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    try {
+      const counts = await this.albionRankCountsService.getRankCounts(this.config.get('discord.guildId'));
+      return replyTo(interaction, this.albionRankCountsService.formatReport(counts));
+    }
+    catch (err) {
+      this.logger.error(`Error getting Albion rank counts: ${err.message}`);
+      return replyTo(interaction, `⛔️ **ERROR:** ${err.message}`);
+    }
+  }
+}

--- a/src/albion/services/albion.rank.counts.service.spec.ts
+++ b/src/albion/services/albion.rank.counts.service.spec.ts
@@ -1,0 +1,152 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { Collection } from 'discord.js';
+import { AlbionRankCountsService } from './albion.rank.counts.service';
+import { DiscordService } from '../../discord/discord.service';
+import { TestBootstrapper } from '../../test.bootstrapper';
+
+const guildId = TestBootstrapper.mockConfig.discord.guildId;
+const roleMap = TestBootstrapper.mockConfig.albion.roleMap;
+const archmage = roleMap[0].discordRoleId;
+const graduate = roleMap[4].discordRoleId;
+const disciple = roleMap[5].discordRoleId;
+
+const createMember = (id: string, roleIds: string[], isBot = false) => ({
+  id,
+  displayName: `member-${id}`,
+  user: { id, bot: isBot },
+  roles: {
+    cache: {
+      has: (roleId: string) => roleIds.includes(roleId),
+    },
+  },
+}) as any;
+
+describe('AlbionRankCountsService', () => {
+  let service: AlbionRankCountsService;
+  let discordService: any;
+  let members: Collection<string, any>;
+
+  beforeEach(async () => {
+    members = new Collection<string, any>();
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        AlbionRankCountsService,
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn() },
+        },
+        {
+          provide: DiscordService,
+          useValue: {
+            getGuild: jest.fn().mockImplementation(() => ({
+              id: guildId,
+              members: { fetch: jest.fn().mockImplementation(() => members) },
+            })),
+          },
+        },
+      ],
+    }).compile();
+
+    TestBootstrapper.setupConfig(moduleRef);
+
+    service = moduleRef.get(AlbionRankCountsService);
+    discordService = moduleRef.get(DiscordService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch every member of the configured guild', async () => {
+    await service.getRankCounts(guildId);
+
+    expect(discordService.getGuild).toHaveBeenCalledWith(guildId);
+  });
+
+  it('should return a count for every rank in the role map, ordered by priority', async () => {
+    const counts = await service.getRankCounts(guildId);
+
+    expect(counts.ranks.map((rank) => rank.name)).toEqual(roleMap.map((role) => role.name));
+    expect(counts.ranks.map((rank) => rank.priority)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it('should count the members holding each role', async () => {
+    members.set('1', createMember('1', [archmage, graduate]));
+    members.set('2', createMember('2', [graduate]));
+    members.set('3', createMember('3', [disciple]));
+    members.set('4', createMember('4', [disciple]));
+    members.set('5', createMember('5', []));
+
+    const counts = await service.getRankCounts(guildId);
+    const byName = Object.fromEntries(counts.ranks.map((rank) => [rank.name, rank.count]));
+
+    expect(byName['@ALB/Archmage']).toBe(1);
+    expect(byName['@ALB/Graduate']).toBe(2);
+    expect(byName['@ALB/Disciple']).toBe(2);
+    expect(byName['@ALB/Magister']).toBe(0);
+  });
+
+  it('should count each member holding any rank only once', async () => {
+    // Archmage keeps Graduate on promotion, so this member holds two rank roles
+    members.set('1', createMember('1', [archmage, graduate]));
+    members.set('2', createMember('2', [disciple]));
+    members.set('3', createMember('3', []));
+
+    const counts = await service.getRankCounts(guildId);
+
+    expect(counts.anyRank).toBe(2);
+  });
+
+  it('should exclude bots from the counts', async () => {
+    members.set('1', createMember('1', [disciple]));
+    members.set('2', createMember('2', [disciple], true));
+
+    const counts = await service.getRankCounts(guildId);
+    const discipleCount = counts.ranks.find((rank) => rank.name === '@ALB/Disciple').count;
+
+    expect(discipleCount).toBe(1);
+    expect(counts.anyRank).toBe(1);
+  });
+
+  it('should report zeroes when nobody holds a rank', async () => {
+    members.set('1', createMember('1', []));
+
+    const counts = await service.getRankCounts(guildId);
+
+    expect(counts.ranks.every((rank) => rank.count === 0)).toBe(true);
+    expect(counts.anyRank).toBe(0);
+  });
+
+  it('should throw if the guild cannot be fetched', async () => {
+    discordService.getGuild.mockRejectedValue(new Error('Could not find guild with ID 123'));
+
+    await expect(service.getRankCounts(guildId)).rejects.toThrow('Could not find guild with ID 123');
+  });
+
+  describe('formatReport', () => {
+    it('should render every rank and its count inside a code block', async () => {
+      members.set('1', createMember('1', [archmage, graduate]));
+      members.set('2', createMember('2', [disciple]));
+
+      const report = service.formatReport(await service.getRankCounts(guildId));
+
+      expect(report).toContain('## 📊 Albion rank numbers');
+      expect(report).toContain('```');
+      expect(report).toContain('@ALB/Archmage');
+      expect(report).toContain('@ALB/Disciple');
+      expect(report).toContain('Members holding **any** Albion rank: **2**');
+    });
+
+    it('should pad the rank names so the numbers line up', async () => {
+      const report = service.formatReport(await service.getRankCounts(guildId));
+      const lines = report.split('\n').filter((line) => line.startsWith('@ALB/'));
+      const numberPositions = lines.map((line) => line.search(/\d/));
+
+      expect(lines).toHaveLength(roleMap.length);
+      expect(new Set(numberPositions).size).toBe(1);
+    });
+  });
+});

--- a/src/albion/services/albion.rank.counts.service.spec.ts
+++ b/src/albion/services/albion.rank.counts.service.spec.ts
@@ -1,16 +1,22 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Test } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
-import { Collection } from 'discord.js';
+import { getRepositoryToken } from '@mikro-orm/nestjs';
+import { Collection, Role, Snowflake } from 'discord.js';
 import { AlbionRankCountsService } from './albion.rank.counts.service';
+import { AlbionRegistrationsEntity } from '../../database/entities/albion.registrations.entity';
 import { DiscordService } from '../../discord/discord.service';
 import { TestBootstrapper } from '../../test.bootstrapper';
 
 const guildId = TestBootstrapper.mockConfig.discord.guildId;
+const albionGuildId = TestBootstrapper.mockConfig.albion.guildId;
 const roleMap = TestBootstrapper.mockConfig.albion.roleMap;
 const archmage = roleMap[0].discordRoleId;
 const graduate = roleMap[4].discordRoleId;
 const disciple = roleMap[5].discordRoleId;
+
+const dungeonsRoleId = '900000000000000001';
+const factionWarfareRoleId = '900000000000000002';
 
 const createMember = (id: string, roleIds: string[], isBot = false) => ({
   id,
@@ -23,13 +29,34 @@ const createMember = (id: string, roleIds: string[], isBot = false) => ({
   },
 }) as any;
 
+const createRoles = (roles: Array<{ id: string, name: string }>) => {
+  const collection = new Collection<Snowflake, Role>();
+  roles.forEach((role) => collection.set(role.id, role as Role));
+  return collection;
+};
+
+const defaultRoles = () => createRoles([
+  { id: '000000000000000000', name: '@everyone' },
+  { id: archmage, name: '@ALB/Archmage' },
+  { id: disciple, name: '@ALB/Disciple' },
+  { id: dungeonsRoleId, name: 'ALB/Dungeons' },
+  { id: factionWarfareRoleId, name: 'ALB/FactionWarfare' },
+  { id: '900000000000000003', name: 'Rec/BestGameEver' },
+  { id: '900000000000000004', name: 'Albion Online' },
+]);
+
 describe('AlbionRankCountsService', () => {
   let service: AlbionRankCountsService;
   let discordService: any;
+  let registrationsRepository: any;
   let members: Collection<string, any>;
+  let roles: Collection<Snowflake, Role>;
 
   beforeEach(async () => {
     members = new Collection<string, any>();
+    roles = defaultRoles();
+    registrationsRepository = TestBootstrapper.getMockEntityRepo();
+    registrationsRepository.find.mockResolvedValue([]);
 
     const moduleRef = await Test.createTestingModule({
       providers: [
@@ -45,7 +72,12 @@ describe('AlbionRankCountsService', () => {
               id: guildId,
               members: { fetch: jest.fn().mockImplementation(() => members) },
             })),
+            getAllRolesFromGuild: jest.fn().mockImplementation(() => roles),
           },
+        },
+        {
+          provide: getRepositoryToken(AlbionRegistrationsEntity),
+          useValue: registrationsRepository,
         },
       ],
     }).compile();
@@ -60,64 +92,183 @@ describe('AlbionRankCountsService', () => {
     jest.clearAllMocks();
   });
 
-  it('should fetch every member of the configured guild', async () => {
-    await service.getRankCounts(guildId);
+  const registerMembers = (discordIds: string[]) => {
+    registrationsRepository.find.mockResolvedValue(
+      discordIds.map((discordId) => ({ discordId })),
+    );
+  };
 
-    expect(discordService.getGuild).toHaveBeenCalledWith(guildId);
+  describe('ranks', () => {
+    it('should fetch every member of the configured guild', async () => {
+      await service.getRankCounts(guildId);
+
+      expect(discordService.getGuild).toHaveBeenCalledWith(guildId);
+    });
+
+    it('should return a count for every rank in the role map, ordered by priority', async () => {
+      const counts = await service.getRankCounts(guildId);
+
+      expect(counts.ranks.map((rank) => rank.name)).toEqual(roleMap.map((role) => role.name));
+    });
+
+    it('should count the members holding each role', async () => {
+      members.set('1', createMember('1', [archmage, graduate]));
+      members.set('2', createMember('2', [graduate]));
+      members.set('3', createMember('3', [disciple]));
+      members.set('4', createMember('4', [disciple]));
+      members.set('5', createMember('5', []));
+
+      const counts = await service.getRankCounts(guildId);
+      const byName = Object.fromEntries(counts.ranks.map((rank) => [rank.name, rank.count]));
+
+      expect(byName['@ALB/Archmage']).toBe(1);
+      expect(byName['@ALB/Graduate']).toBe(2);
+      expect(byName['@ALB/Disciple']).toBe(2);
+      expect(byName['@ALB/Magister']).toBe(0);
+    });
+
+    it('should count ranks regardless of whether the member is registered', async () => {
+      members.set('1', createMember('1', [disciple]));
+      members.set('2', createMember('2', [disciple]));
+      registerMembers(['1']);
+
+      const counts = await service.getRankCounts(guildId);
+      const discipleCount = counts.ranks.find((rank) => rank.name === '@ALB/Disciple').count;
+
+      expect(discipleCount).toBe(2);
+    });
+
+    it('should count each member holding any rank only once', async () => {
+      // Archmage keeps Graduate on promotion, so this member holds two rank roles
+      members.set('1', createMember('1', [archmage, graduate]));
+      members.set('2', createMember('2', [disciple]));
+      members.set('3', createMember('3', []));
+
+      const counts = await service.getRankCounts(guildId);
+
+      expect(counts.anyRank).toBe(2);
+    });
+
+    it('should exclude bots from the counts', async () => {
+      members.set('1', createMember('1', [disciple]));
+      members.set('2', createMember('2', [disciple], true));
+
+      const counts = await service.getRankCounts(guildId);
+      const discipleCount = counts.ranks.find((rank) => rank.name === '@ALB/Disciple').count;
+
+      expect(discipleCount).toBe(1);
+      expect(counts.anyRank).toBe(1);
+    });
+
+    it('should report zeroes when nobody holds a rank', async () => {
+      members.set('1', createMember('1', []));
+
+      const counts = await service.getRankCounts(guildId);
+
+      expect(counts.ranks.every((rank) => rank.count === 0)).toBe(true);
+      expect(counts.anyRank).toBe(0);
+    });
   });
 
-  it('should return a count for every rank in the role map, ordered by priority', async () => {
-    const counts = await service.getRankCounts(guildId);
+  describe('content roles', () => {
+    it('should fetch the roles before the members, so member role caches are populated', async () => {
+      const guild = { id: guildId, members: { fetch: jest.fn().mockResolvedValue(members) } };
+      discordService.getGuild.mockResolvedValue(guild);
 
-    expect(counts.ranks.map((rank) => rank.name)).toEqual(roleMap.map((role) => role.name));
-    expect(counts.ranks.map((rank) => rank.priority)).toEqual([1, 2, 3, 4, 5, 6]);
-  });
+      await service.getRankCounts(guildId);
 
-  it('should count the members holding each role', async () => {
-    members.set('1', createMember('1', [archmage, graduate]));
-    members.set('2', createMember('2', [graduate]));
-    members.set('3', createMember('3', [disciple]));
-    members.set('4', createMember('4', [disciple]));
-    members.set('5', createMember('5', []));
+      expect(discordService.getAllRolesFromGuild).toHaveBeenCalledWith(guild);
+      expect(discordService.getAllRolesFromGuild.mock.invocationCallOrder[0])
+        .toBeLessThan(guild.members.fetch.mock.invocationCallOrder[0]);
+    });
 
-    const counts = await service.getRankCounts(guildId);
-    const byName = Object.fromEntries(counts.ranks.map((rank) => [rank.name, rank.count]));
+    it('should find ALB roles that are not ranks', async () => {
+      const counts = await service.getRankCounts(guildId);
 
-    expect(byName['@ALB/Archmage']).toBe(1);
-    expect(byName['@ALB/Graduate']).toBe(2);
-    expect(byName['@ALB/Disciple']).toBe(2);
-    expect(byName['@ALB/Magister']).toBe(0);
-  });
+      expect(counts.content.map((role) => role.name).sort()).toEqual([
+        'ALB/Dungeons',
+        'ALB/FactionWarfare',
+      ]);
+    });
 
-  it('should count each member holding any rank only once', async () => {
-    // Archmage keeps Graduate on promotion, so this member holds two rank roles
-    members.set('1', createMember('1', [archmage, graduate]));
-    members.set('2', createMember('2', [disciple]));
-    members.set('3', createMember('3', []));
+    it('should not treat rank roles or other prefixes as content roles', async () => {
+      const contentNames = (await service.getRankCounts(guildId)).content.map((role) => role.name);
 
-    const counts = await service.getRankCounts(guildId);
+      expect(contentNames).not.toContain('@ALB/Archmage');
+      expect(contentNames).not.toContain('@ALB/Disciple');
+      expect(contentNames).not.toContain('Rec/BestGameEver');
+      expect(contentNames).not.toContain('Albion Online');
+      expect(contentNames).not.toContain('@everyone');
+    });
 
-    expect(counts.anyRank).toBe(2);
-  });
+    it('should treat an ALB role named with the mention prefix as content', async () => {
+      roles = createRoles([{ id: dungeonsRoleId, name: '@ALB/Dungeons' }]);
 
-  it('should exclude bots from the counts', async () => {
-    members.set('1', createMember('1', [disciple]));
-    members.set('2', createMember('2', [disciple], true));
+      const counts = await service.getRankCounts(guildId);
 
-    const counts = await service.getRankCounts(guildId);
-    const discipleCount = counts.ranks.find((rank) => rank.name === '@ALB/Disciple').count;
+      expect(counts.content.map((role) => role.name)).toEqual(['@ALB/Dungeons']);
+    });
 
-    expect(discipleCount).toBe(1);
-    expect(counts.anyRank).toBe(1);
-  });
+    it('should only count members who hold the role AND have a registration', async () => {
+      members.set('1', createMember('1', [dungeonsRoleId]));
+      members.set('2', createMember('2', [dungeonsRoleId]));
+      members.set('3', createMember('3', [dungeonsRoleId]));
+      registerMembers(['1', '3', '999']); // 999 has since left the server
 
-  it('should report zeroes when nobody holds a rank', async () => {
-    members.set('1', createMember('1', []));
+      const counts = await service.getRankCounts(guildId);
+      const dungeons = counts.content.find((role) => role.name === 'ALB/Dungeons');
 
-    const counts = await service.getRankCounts(guildId);
+      expect(dungeons.count).toBe(2);
+    });
 
-    expect(counts.ranks.every((rank) => rank.count === 0)).toBe(true);
-    expect(counts.anyRank).toBe(0);
+    it('should look up registrations for the configured Albion guild', async () => {
+      await service.getRankCounts(guildId);
+
+      expect(registrationsRepository.find).toHaveBeenCalledWith({ guildId: albionGuildId });
+    });
+
+    it('should exclude registered bots from content counts', async () => {
+      members.set('1', createMember('1', [dungeonsRoleId], true));
+      registerMembers(['1']);
+
+      const counts = await service.getRankCounts(guildId);
+      const dungeons = counts.content.find((role) => role.name === 'ALB/Dungeons');
+
+      expect(dungeons.count).toBe(0);
+    });
+
+    it('should sort content roles by count, then name', async () => {
+      members.set('1', createMember('1', [factionWarfareRoleId]));
+      members.set('2', createMember('2', [factionWarfareRoleId]));
+      members.set('3', createMember('3', [dungeonsRoleId]));
+      registerMembers(['1', '2', '3']);
+
+      const counts = await service.getRankCounts(guildId);
+
+      expect(counts.content.map((role) => role.name)).toEqual([
+        'ALB/FactionWarfare',
+        'ALB/Dungeons',
+      ]);
+    });
+
+    it('should count the registered members still in the server', async () => {
+      members.set('1', createMember('1', []));
+      members.set('2', createMember('2', []));
+      members.set('3', createMember('3', [], true));
+      registerMembers(['1', '2', '3', '999']);
+
+      const counts = await service.getRankCounts(guildId);
+
+      expect(counts.registered).toBe(2);
+    });
+
+    it('should cope with a guild that has no content roles', async () => {
+      roles = createRoles([{ id: archmage, name: '@ALB/Archmage' }]);
+
+      const counts = await service.getRankCounts(guildId);
+
+      expect(counts.content).toEqual([]);
+    });
   });
 
   it('should throw if the guild cannot be fetched', async () => {
@@ -127,26 +278,56 @@ describe('AlbionRankCountsService', () => {
   });
 
   describe('formatReport', () => {
-    it('should render every rank and its count inside a code block', async () => {
+    it('should render both sections with their counts inside code blocks', async () => {
       members.set('1', createMember('1', [archmage, graduate]));
-      members.set('2', createMember('2', [disciple]));
+      members.set('2', createMember('2', [disciple, dungeonsRoleId]));
+      registerMembers(['2']);
 
       const report = service.formatReport(await service.getRankCounts(guildId));
 
-      expect(report).toContain('## 📊 Albion rank numbers');
-      expect(report).toContain('```');
+      expect(report).toContain('## 📊 Albion role numbers');
+      expect(report).toContain('### Ranks');
       expect(report).toContain('@ALB/Archmage');
-      expect(report).toContain('@ALB/Disciple');
       expect(report).toContain('Members holding **any** Albion rank: **2**');
+      expect(report).toContain('### Content roles');
+      expect(report).toContain('ALB/Dungeons');
+      expect(report).toContain('Registered members in the server: **1**');
     });
 
-    it('should pad the rank names so the numbers line up', async () => {
-      const report = service.formatReport(await service.getRankCounts(guildId));
-      const lines = report.split('\n').filter((line) => line.startsWith('@ALB/'));
-      const numberPositions = lines.map((line) => line.search(/\d/));
+    it('should say so when there are no content roles', async () => {
+      roles = createRoles([{ id: archmage, name: '@ALB/Archmage' }]);
 
-      expect(lines).toHaveLength(roleMap.length);
-      expect(new Set(numberPositions).size).toBe(1);
+      const report = service.formatReport(await service.getRankCounts(guildId));
+
+      expect(report).toContain('_No ALB content roles found._');
+    });
+
+    it('should pad the role names so the numbers line up', async () => {
+      const report = service.formatReport(await service.getRankCounts(guildId));
+      const rankLines = report.split('\n').filter((line) => line.startsWith('@ALB/'));
+      const contentLines = report.split('\n').filter((line) => line.startsWith('ALB/'));
+
+      expect(rankLines).toHaveLength(roleMap.length);
+      expect(new Set(rankLines.map((line) => line.search(/\d/))).size).toBe(1);
+      expect(contentLines).toHaveLength(2);
+      expect(new Set(contentLines.map((line) => line.search(/\d/))).size).toBe(1);
+    });
+  });
+
+  describe('chunkReport', () => {
+    it('should leave a report that fits in one message alone', () => {
+      expect(service.chunkReport('a short report')).toEqual(['a short report']);
+    });
+
+    it('should split an oversized report on line boundaries', () => {
+      const line = 'ALB/SomeVeryLongContentRoleName    12';
+      const report = Array.from({ length: 200 }, () => line).join('\n');
+
+      const chunks = service.chunkReport(report);
+
+      expect(chunks.length).toBeGreaterThan(1);
+      chunks.forEach((chunk) => expect(chunk.length).toBeLessThanOrEqual(2000));
+      expect(chunks.join('\n')).toBe(report);
     });
   });
 });

--- a/src/albion/services/albion.rank.counts.service.ts
+++ b/src/albion/services/albion.rank.counts.service.ts
@@ -1,46 +1,86 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { GuildMember } from 'discord.js';
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { EntityRepository } from '@mikro-orm/core';
+import { GuildMember, Role } from 'discord.js';
 import { AlbionRoleMapInterface } from '../../config/albion.app.config';
+import { AlbionRegistrationsEntity } from '../../database/entities/albion.registrations.entity';
 import { DiscordService } from '../../discord/discord.service';
 
-export interface AlbionRankCountInterface {
+export interface AlbionRoleCountInterface {
   name: string;
   discordRoleId: string;
-  priority: number;
   count: number;
 }
 
 export interface AlbionRankCountsInterface {
-  ranks: AlbionRankCountInterface[];
+  ranks: AlbionRoleCountInterface[];
+  content: AlbionRoleCountInterface[];
   anyRank: number;
+  registered: number;
 }
+
+// Discord's hard cap on a single message
+const MESSAGE_LIMIT = 2000;
 
 @Injectable()
 export class AlbionRankCountsService {
   private readonly logger = new Logger(AlbionRankCountsService.name);
 
+  // Content roles aren't configured anywhere - they're added and retired in the Discord UI as
+  // the guild's interests change - so they're found by name instead. Rank roles share the
+  // prefix and are excluded by ID.
+  private readonly albionRolePrefix = 'ALB/';
+
   constructor(
     private readonly config: ConfigService,
     private readonly discordService: DiscordService,
+    @InjectRepository(AlbionRegistrationsEntity) private readonly registrationsRepository: EntityRepository<AlbionRegistrationsEntity>,
   ) {}
 
   async getRankCounts(guildId: string): Promise<AlbionRankCountsInterface> {
     const roleMap: AlbionRoleMapInterface[] = this.config.get('albion.roleMap');
     const guild = await this.discordService.getGuild(guildId);
 
+    // Roles first: a member's role cache is derived from the guild's role cache, and fetching
+    // roles busts that cache, so counting before this point would come back empty.
+    const roles = await this.discordService.getAllRolesFromGuild(guild);
+
     // Counting needs every member, not whatever the gateway happens to have cached
     const members = await guild.members.fetch();
     const humans = [...members.values()].filter((member: GuildMember) => !member.user?.bot);
+
+    // Content roles are self-assigned from a reaction role message, so anyone in the server can
+    // pick one up. Cross-referencing the registrations makes the content numbers guild members
+    // only, rather than a headcount of everyone who ever clicked an emoji.
+    const registrations = await this.registrationsRepository.find({
+      guildId: this.config.get('albion.guildId'),
+    });
+    const registeredDiscordIds = new Set(registrations.map((registration) => registration.discordId));
+
+    const countHolders = (roleId: string) => humans.filter((member) => member.roles.cache.has(roleId)).length;
+    const countRegisteredHolders = (roleId: string) => humans.filter(
+      (member) => member.roles.cache.has(roleId) && registeredDiscordIds.has(member.id),
+    ).length;
 
     const ranks = [...roleMap]
       .sort((a, b) => a.priority - b.priority)
       .map((role) => ({
         name: role.name,
         discordRoleId: role.discordRoleId,
-        priority: role.priority,
-        count: humans.filter((member) => member.roles.cache.has(role.discordRoleId)).length,
+        count: countHolders(role.discordRoleId),
       }));
+
+    const rankRoleIds = new Set(roleMap.map((role) => role.discordRoleId));
+    const content = [...(roles?.values() ?? [])]
+      .filter((role: Role) => this.isContentRole(role, rankRoleIds))
+      .map((role: Role) => ({
+        name: role.name,
+        discordRoleId: role.id,
+        count: countRegisteredHolders(role.id),
+      }))
+      // Most popular content first, since that's the point of the numbers
+      .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
 
     // Ranks overlap by design - the "keep" ranks stay on a member when they're promoted - so
     // summing the counts would double count people. This is the real headcount.
@@ -48,23 +88,76 @@ export class AlbionRankCountsService {
       (member) => roleMap.some((role) => member.roles.cache.has(role.discordRoleId)),
     ).length;
 
-    this.logger.log(`Counted ${ranks.length} Albion rank roles across ${humans.length} members`);
+    // The denominator for the content numbers: registrations belonging to someone still here
+    const registered = humans.filter((member) => registeredDiscordIds.has(member.id)).length;
 
-    return { ranks, anyRank };
+    this.logger.log(`Counted ${ranks.length} Albion rank roles and ${content.length} content roles across ${humans.length} members`);
+
+    return { ranks, content, anyRank, registered };
   }
 
-  // A code block so the numbers can be copy-pasted straight into a spreadsheet or report
-  formatReport(counts: AlbionRankCountsInterface): string {
-    const nameWidth = Math.max(...counts.ranks.map((rank) => rank.name.length));
-    const lines = counts.ranks.map(
-      (rank) => `${rank.name.padEnd(nameWidth)}  ${String(rank.count).padStart(5)}`,
-    );
+  private isContentRole(role: Role, rankRoleIds: Set<string>): boolean {
+    if (rankRoleIds.has(role.id)) {
+      return false;
+    }
 
-    return `## 📊 Albion rank numbers
+    // Role names are stored with the mention '@' in config but not on Discord, so tolerate both
+    return this.stripMention(role.name).startsWith(this.albionRolePrefix);
+  }
+
+  private stripMention(name: string): string {
+    return name.startsWith('@') ? name.slice(1) : name;
+  }
+
+  // Code blocks so the numbers can be copy-pasted straight into a spreadsheet or report
+  formatReport(counts: AlbionRankCountsInterface): string {
+    const contentSection = counts.content.length > 0
+      ? `\`\`\`\n${this.formatTable(counts.content)}\n\`\`\``
+      : '_No ALB content roles found._';
+
+    return `## 📊 Albion role numbers
+### Ranks
 \`\`\`
-${lines.join('\n')}
+${this.formatTable(counts.ranks)}
 \`\`\`
 Members holding **any** Albion rank: **${counts.anyRank}**
--# Counts are members currently holding each role, as Discord's role list shows them. Bots are excluded. Ranks overlap, so the individual counts don't add up to the total above.`;
+### Content roles
+${contentSection}
+Registered members in the server: **${counts.registered}**
+-# Rank counts are members currently holding each role, as Discord's role list shows them. Content counts only include members who are **also** registered with the guild, so self-assigned roles picked up by non-members aren't counted. Bots are excluded throughout. Roles overlap, so the individual counts don't add up to the totals.`;
+  }
+
+  private formatTable(roles: AlbionRoleCountInterface[]): string {
+    const nameWidth = Math.max(...roles.map((role) => role.name.length));
+
+    return roles
+      .map((role) => `${role.name.padEnd(nameWidth)}  ${String(role.count).padStart(5)}`)
+      .join('\n');
+  }
+
+  // The guild can add content roles indefinitely, so the report can outgrow a single message
+  chunkReport(report: string): string[] {
+    if (report.length <= MESSAGE_LIMIT) {
+      return [report];
+    }
+
+    const chunks: string[] = [];
+    let chunk = '';
+
+    for (const line of report.split('\n')) {
+      // +1 for the newline that rejoins it
+      if (chunk.length + line.length + 1 > MESSAGE_LIMIT) {
+        chunks.push(chunk);
+        chunk = '';
+      }
+
+      chunk += chunk.length > 0 ? `\n${line}` : line;
+    }
+
+    if (chunk.length > 0) {
+      chunks.push(chunk);
+    }
+
+    return chunks;
   }
 }

--- a/src/albion/services/albion.rank.counts.service.ts
+++ b/src/albion/services/albion.rank.counts.service.ts
@@ -1,0 +1,70 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { GuildMember } from 'discord.js';
+import { AlbionRoleMapInterface } from '../../config/albion.app.config';
+import { DiscordService } from '../../discord/discord.service';
+
+export interface AlbionRankCountInterface {
+  name: string;
+  discordRoleId: string;
+  priority: number;
+  count: number;
+}
+
+export interface AlbionRankCountsInterface {
+  ranks: AlbionRankCountInterface[];
+  anyRank: number;
+}
+
+@Injectable()
+export class AlbionRankCountsService {
+  private readonly logger = new Logger(AlbionRankCountsService.name);
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly discordService: DiscordService,
+  ) {}
+
+  async getRankCounts(guildId: string): Promise<AlbionRankCountsInterface> {
+    const roleMap: AlbionRoleMapInterface[] = this.config.get('albion.roleMap');
+    const guild = await this.discordService.getGuild(guildId);
+
+    // Counting needs every member, not whatever the gateway happens to have cached
+    const members = await guild.members.fetch();
+    const humans = [...members.values()].filter((member: GuildMember) => !member.user?.bot);
+
+    const ranks = [...roleMap]
+      .sort((a, b) => a.priority - b.priority)
+      .map((role) => ({
+        name: role.name,
+        discordRoleId: role.discordRoleId,
+        priority: role.priority,
+        count: humans.filter((member) => member.roles.cache.has(role.discordRoleId)).length,
+      }));
+
+    // Ranks overlap by design - the "keep" ranks stay on a member when they're promoted - so
+    // summing the counts would double count people. This is the real headcount.
+    const anyRank = humans.filter(
+      (member) => roleMap.some((role) => member.roles.cache.has(role.discordRoleId)),
+    ).length;
+
+    this.logger.log(`Counted ${ranks.length} Albion rank roles across ${humans.length} members`);
+
+    return { ranks, anyRank };
+  }
+
+  // A code block so the numbers can be copy-pasted straight into a spreadsheet or report
+  formatReport(counts: AlbionRankCountsInterface): string {
+    const nameWidth = Math.max(...counts.ranks.map((rank) => rank.name.length));
+    const lines = counts.ranks.map(
+      (rank) => `${rank.name.padEnd(nameWidth)}  ${String(rank.count).padStart(5)}`,
+    );
+
+    return `## 📊 Albion rank numbers
+\`\`\`
+${lines.join('\n')}
+\`\`\`
+Members holding **any** Albion rank: **${counts.anyRank}**
+-# Counts are members currently holding each role, as Discord's role list shows them. Bots are excluded. Ranks overlap, so the individual counts don't add up to the total above.`;
+  }
+}


### PR DESCRIPTION
Closes #680

Getting the Albion role numbers (notably `@ALB/Disciple` and `@ALB/Registered`) meant counting them by hand in the Discord UI. This adds a slash command that spits them out, along with the content role numbers.

## What it does

`/albion-ranks` replies with two sections — the ranks from `albion.roleMap`, and the ALB content roles members self-assign from the reaction role message in `#content-roles`:

```
## 📊 Albion role numbers
### Ranks
@ALB/Archmage           1
@ALB/Magister           3
@ALB/EldritchMager      8
@ALB/Adept             12
@ALB/Graduate          40
@ALB/Disciple          55
@ALB/Registered       120

Members holding **any** Albion rank: **120**

### Content roles
ALB/FactionWarfare          35
ALB/Dungeons                28
ALB/RoadsOfAvalon           22
ALB/AvalonianDungeons       19
ALB/HellgatesDepths         14
ALB/BlackZones              12
ALB/Mist                     9
ALB/Arena                    7
ALB/HardcoreExpeditions      6
ALB/Tracking                 4
ALB/HOAlert                  3

Registered members in the server: **118**
```

Both tables are rendered inside code blocks so the numbers copy-paste cleanly into a spreadsheet.

## How content roles are found

They aren't configured anywhere — they're added and retired in the Discord UI as the guild's interests change — so they're found by name search on the server: any role whose name starts with `ALB/` that isn't one of the rank role IDs from the role map. A leading `@` is tolerated, since the config names carry one and Discord's role names don't. New content roles are therefore picked up with no code or config change.

## Design calls

- **Content counts are cross-referenced against the Albion registrations.** These roles are self-assignable by anyone in the server, so only members who hold the role *and* have a registration row for the configured Albion guild are counted. The report also shows the registered headcount as the denominator.
- **Rank counts are left unfiltered**, since those are the numbers being read off the Discord UI today and filtering them would make the two stop matching.
- **No sum of the per-rank counts.** The `keep: true` ranks (Archmage, Graduate, Registered) stay on a member after promotion, so adding the counts up would double count people. A de-duplicated headcount of anyone holding any rank is reported instead.
- **Roles are fetched before members.** discord.js derives `member.roles.cache` from the guild's role cache, and `getAllRolesFromGuild` clears that cache before re-fetching, so counting first would silently return zeroes.
- **Content roles are ordered most popular first**, which is more useful than alphabetical for a "what do people actually play" report.
- **Ephemeral reply, no channel restriction.** It's read-only, so it can be run from anywhere without spamming a channel. The report is chunked across follow-ups if the guild ever grows enough content roles to outgrow Discord's 2000 character message limit (it's ~1000 characters today).
- **Bots are excluded** throughout, and the footer says so, so the numbers are explainable if they ever differ from what the Discord UI shows.

## Changes

- `src/albion/services/albion.rank.counts.service.ts` — counting and formatting
- `src/albion/commands/rank-counts.command.ts` — the slash command
- Colocated specs for both (27 tests), wired up in `albion.module.ts`

## Testing

`pnpm lint`, `pnpm build` and the full Jest suite all pass locally (49 suites, 646 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018carNDGGNVee4SU9khXvji