### PR TITLE
fix(albion): Make the live score a heading so it stands out

### DIFF
--- a/src/albion/services/albion.rank.up.service.spec.ts
+++ b/src/albion/services/albion.rank.up.service.spec.ts
@@ -655,7 +655,7 @@ describe('AlbionRankUpService', () => {
       const content = lastSentContent();
       expect(content).toContain('Eligible voters: 7');
       expect(content).toContain('Passes at a score of 4');
-      expect(content).toContain('Current score: **0** / 4');
+      expect(content).toContain('## 📊 Current score: 0 / 4');
     });
 
     it('keeps the wording leadership already use', async () => {

--- a/src/albion/services/albion.rank.up.service.ts
+++ b/src/albion/services/albion.rank.up.service.ts
@@ -12,7 +12,7 @@ import { AlbionUtilities } from '../utilities/albion.utilities';
 import { DiscordService } from '../../discord/discord.service';
 import { MemberActivityRollupService } from '../../general/services/member.activity.rollup.service';
 import { LeadershipPing } from '../../config/albion.app.config';
-import { AlbionRankUpVoteService, VOTE_REACTIONS } from './albion.rank.up.vote.service';
+import { AlbionRankUpVoteService, scoreHeading, VOTE_REACTIONS } from './albion.rank.up.vote.service';
 import { discordTime } from '../../helpers';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -367,7 +367,7 @@ Eligible voters: ${electorateSize}
 Passes at a score of ${requiredScore}
 Voting closes ${discordTime(expiresAt, 'R')}
 
-Current score: **0** / ${requiredScore}
+${scoreHeading(0, requiredScore)}
 
 ${stats}`;
   }

--- a/src/albion/services/albion.rank.up.vote.service.spec.ts
+++ b/src/albion/services/albion.rank.up.vote.service.spec.ts
@@ -6,6 +6,7 @@ import { Collection } from 'discord.js';
 import {
   AlbionRankUpVoteService,
   PROVISIONAL_HOLD_MS,
+  scoreHeading,
   UNPOSTED_GRACE_MS,
   VOTE_APPROVE,
   VOTE_DISAPPROVE,
@@ -49,7 +50,7 @@ describe('AlbionRankUpVoteService', () => {
   });
 
   // Builds a message whose reactions resolve to the given voters
-  const makeMessage = (reactions: Record<string, string[]>, content = 'Current score: **0** / 4') => {
+  const makeMessage = (reactions: Record<string, string[]>, content = '## 📊 Current score: 0 / 4') => {
     const cache = new Collection<string, any>();
 
     for (const [emoji, userIds] of Object.entries(reactions)) {
@@ -311,7 +312,7 @@ describe('AlbionRankUpVoteService', () => {
 
       const line = service.scoreLine(vote);
 
-      expect(line).toContain('Current score: **4** / 4');
+      expect(line).toContain('## 📊 Current score: 4 / 4');
       expect(line).toContain('locked in');
       expect(line).toContain('pass');
       expect(line).toContain('window to change it');
@@ -320,7 +321,7 @@ describe('AlbionRankUpVoteService', () => {
     it('shows only the score when nothing is being held', () => {
       const line = service.scoreLine(makeVote({ score: 2 }));
 
-      expect(line).toBe('Current score: **2** / 4');
+      expect(line).toBe('## 📊 Current score: 2 / 4');
       expect(line).not.toContain('locked in');
     });
   });
@@ -359,6 +360,37 @@ describe('AlbionRankUpVoteService', () => {
       for (const call of execute.mock.calls) {
         expect(call[2]).toBe('run');
       }
+    });
+  });
+
+  describe('the live score line', () => {
+    // The regex that rewrites it has to match what the ballot builder wrote. If they drift, the
+    // score silently stops updating and nothing errors.
+    it('rewrites the heading the ballot builder produces', async () => {
+      const message = makeMessage({ [VOTE_APPROVE]: ['e1', 'e2'] }, scoreHeading(0, 4));
+      discordService.getTextChannel = jest.fn().mockResolvedValue({
+        id: 'chan-1', send: channelSend, messages: { fetch: jest.fn().mockResolvedValue(message) },
+      });
+
+      await service.evaluate(makeVote());
+
+      expect(messageEdit).toHaveBeenCalledWith(scoreHeading(2, 4));
+    });
+
+    // A ballot posted before the heading existed must keep updating across the deploy
+    it('still rewrites a ballot posted without the heading', async () => {
+      const message = makeMessage({ [VOTE_APPROVE]: ['e1', 'e2'] }, 'Current score: **0** / 4');
+      discordService.getTextChannel = jest.fn().mockResolvedValue({
+        id: 'chan-1', send: channelSend, messages: { fetch: jest.fn().mockResolvedValue(message) },
+      });
+
+      await service.evaluate(makeVote());
+
+      expect(messageEdit).toHaveBeenCalledWith(scoreHeading(2, 4));
+    });
+
+    it('is a heading so it stands out from the ballot body', () => {
+      expect(scoreHeading(2, 4).startsWith('## ')).toBe(true);
     });
   });
 
@@ -417,7 +449,7 @@ describe('AlbionRankUpVoteService', () => {
     const passed = () => makeVote({ status: AlbionRankUpVoteStatus.PASSED, toRank: '@ALB/Adept' });
     const releaseCall = () => execute.mock.calls.find((c: any[]) => c[0].includes('announced_at = null'));
 
-    const withBallot = (content = 'Current score: **4** / 4') => {
+    const withBallot = (content = '## 📊 Current score: 4 / 4') => {
       discordService.getTextChannel = jest.fn().mockResolvedValue({
         id: 'chan-1',
         send: channelSend,
@@ -454,7 +486,7 @@ describe('AlbionRankUpVoteService', () => {
 
     // A retried announcement must not stack a second outcome header on the ballot
     it('does not re-prepend a header the ballot already carries', async () => {
-      withBallot('# ✅ PASSED — score 4 / 4\n\nCurrent score: **4** / 4');
+      withBallot('# ✅ PASSED — score 4 / 4\n\n## 📊 Current score: 4 / 4');
 
       await service.announce(passed());
 

--- a/src/albion/services/albion.rank.up.vote.service.ts
+++ b/src/albion/services/albion.rank.up.vote.service.ts
@@ -34,9 +34,15 @@ const DISCORD_UNKNOWN_MESSAGE = 10008;
 // which has already had the full voting period.
 export const PROVISIONAL_HOLD_MS = 60 * 60 * 1000;
 
-// The live score line plus any hold notice beneath it, rewritten in place on every recount.
-// Both are matched together so a stale hold notice can't survive the replacement.
-const SCORE_LINE = /^Current score:.*(?:\n⏳.*)?$/m;
+// The one definition of the score line, shared with the ballot builder. Kept together with the
+// regex below, which has to match whatever this writes.
+export const scoreHeading = (score: number, requiredScore: number): string =>
+  `## 📊 Current score: ${score} / ${requiredScore}`;
+
+// The live score line plus any hold notice beneath it, rewritten in place on every recount. Both
+// are matched together so a stale hold notice can't survive the replacement. Deliberately loose
+// about the heading so ballots posted before it was added keep updating.
+const SCORE_LINE = /^.*Current score:.*(?:\n⏳.*)?$/m;
 
 // Discord rate limits message edits, and a busy ballot recounts on every reaction
 const SCORE_EDIT_THROTTLE_MS = 5000;
@@ -237,7 +243,7 @@ export class AlbionRankUpVoteService {
   }
 
   scoreLine(vote: AlbionRankUpVoteEntity): string {
-    const base = `Current score: **${vote.score}** / ${vote.requiredScore}`;
+    const base = scoreHeading(vote.score, vote.requiredScore);
 
     if (!vote.provisionalStatus || !vote.provisionalSince) {
       return base;


### PR DESCRIPTION
> [!NOTE]
> **No manual steps.** Nothing to set, migrate or restart beyond the normal deploy.

The live score was a plain line in the middle of the ballot, sitting between the scoring rules and
the activity block and reading like more of the same. It is the one number leadership is actually
scanning for, so it is now a heading:

**Before**
```
Eligible voters: 7
Passes at a score of 4
Voting closes in 5 days

Current score: **0** / 4
```

**After**
```
Eligible voters: 7
Passes at a score of 4
Voting closes in 5 days

## 📊 Current score: 0 / 4
```

And mid-vote, while an early result is on its cooling-off hold:

```
## 📊 Current score: 4 / 4
⏳ This vote will be locked in and **pass** in an hour — this is your window to change it.
```

## The part worth reviewing

The ballot builder writes that line and the vote service rewrites it in place on every recount, by
regex, against whatever the builder wrote. Those two had been separate string literals in separate
services — if they ever drifted, the score would silently stop updating with nothing to error on.

Both now render through a single exported `scoreHeading()`, and there is a test asserting the
recount rewrites exactly what the builder produces, so drift fails the build rather than the ballot.

## Ballots already live

The matching regex is deliberately loose about the heading, so **a ballot posted before this deploy
keeps updating** and picks up the heading on its next recount. There is a test for that too — worth
having, since one is open right now.

## Validation

- `pnpm lint` clean, **631 tests across 47 suites passing**.
- Rendered the full ballot to check how it actually reads, rather than only asserting on substrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qt1VkMfrJd8ArmWZnw3iHa
