### PR TITLE
fix(albion): Settle the ballot before tallying, and rework how it reads

### DIFF
--- a/src/albion/services/albion.rank.up.service.spec.ts
+++ b/src/albion/services/albion.rank.up.service.spec.ts
@@ -649,12 +649,36 @@ describe('AlbionRankUpService', () => {
   });
 
   describe('the ballot', () => {
+    // An even electorate is where the majority rule bites: 6 passes at 3.5, not 4
+    it('sets the bar at a true majority for an even electorate', async () => {
+      albionUtilities.getElectors.mockResolvedValue(
+        ['e1', 'e2', 'e3', 'e4', 'e5', 'e6'].map((id) => ({ id })),
+      );
+
+      await service.handleRankUpRequest(member);
+      const content = lastSentContent();
+
+      expect(content).toContain('Eligible voters: 6');
+      expect(content).toContain('Passes at a score of **3.5** — a majority of 6 (6 ÷ 2 + 0.5)');
+      expect(content).toContain('## 📊 Current score: 0 / 3.5');
+    });
+
+    it('freezes the majority on the row, not just the message', async () => {
+      albionUtilities.getElectors.mockResolvedValue(
+        ['e1', 'e2', 'e3', 'e4', 'e5', 'e6'].map((id) => ({ id })),
+      );
+
+      await service.handleRankUpRequest(member);
+
+      expect(votePersist.mock.calls[0][0].requiredScore).toBe(3.5);
+    });
+
     it('states the electorate, threshold and starting score', async () => {
       await service.handleRankUpRequest(member);
 
       const content = lastSentContent();
       expect(content).toContain('Eligible voters: 7');
-      expect(content).toContain('Passes at a score of 4');
+      expect(content).toContain('Passes at a score of **4** — a majority of 7 (7 ÷ 2 + 0.5)');
       expect(content).toContain('## 📊 Current score: 0 / 4');
     });
 
@@ -716,16 +740,26 @@ describe('AlbionRankUpService', () => {
       rollupService.getGameTotals.mockResolvedValue([]);
 
       await service.handleRankUpRequest(member);
+      const content = lastSentContent();
 
-      expect(lastSentContent()).toContain('**Character:** Testy');
+      expect(content).toContain('Guildmember **Testy** (<@candidate>)');
+      expect(content).toContain('📅 Registered:');
     });
 
-    it('shows the top three other games and omits the line when there are none', async () => {
+    // The character is the thing leadership recognises, so it leads rather than sitting in stats
+    it('names the character and the member on the opening line', async () => {
+      await service.handleRankUpRequest(member);
+      const content = lastSentContent();
+
+      expect(content).toContain('Guildmember **Testy** (<@candidate>) wants to be ranked up');
+      expect(content).not.toContain('**Character:**');
+    });
+
+    // The vote is about Albion. Listing what else someone plays invites judging them on it.
+    it('reports Albion only, never the other games recorded', async () => {
       rollupService.getGameTotals.mockResolvedValue([
         { gameName: 'Albion Online', minutes: 600 },
         { gameName: 'Foxhole', minutes: 300 },
-        { gameName: 'Deep Rock', minutes: 120 },
-        { gameName: 'Factorio', minutes: 60 },
         { gameName: 'Noita', minutes: 30 },
       ]);
 
@@ -733,14 +767,42 @@ describe('AlbionRankUpService', () => {
       const content = lastSentContent();
 
       expect(content).toContain('Albion Online: 10h 0m');
-      expect(content).toContain('Foxhole 5h');
+      expect(content).not.toContain('Foxhole');
       expect(content).not.toContain('Noita');
+      expect(content).not.toContain('Other games');
     });
 
-    it('omits the other games line entirely when there are none', async () => {
-      await service.handleRankUpRequest(member);
+    it('heads the block Metrics and bullets the dates with the rest', async () => {
+      rollupService.getRollup.mockResolvedValue([{ messagesSent: 5, reactionsAdded: 2, voiceMinutes: 60 }]);
 
-      expect(lastSentContent()).not.toContain('Other games');
+      await service.handleRankUpRequest(member);
+      const content = lastSentContent();
+
+      expect(content).toContain('### Metrics');
+      expect(content).toMatch(/- 📅 Registered:.*30\*\* days ago/);
+    });
+
+    // The stats are server wide, and reading them as Albion-only would undercount everyone
+    it('marks the server wide counters against their footnote', async () => {
+      rollupService.getRollup.mockResolvedValue([{ messagesSent: 5, reactionsAdded: 2, voiceMinutes: 60 }]);
+
+      await service.handleRankUpRequest(member);
+      const content = lastSentContent();
+
+      expect(content).toMatch(/🎙️ Voice:.*²/);
+      expect(content).toMatch(/💬 Messages:.*²/);
+      expect(content).toMatch(/⭐ Reactions:.*²/);
+      expect(content).toContain('² Monitored across the entire DIG server, not filtered by Albion section.');
+    });
+
+    it('marks the game figures against the presence footnote', async () => {
+      rollupService.getGameTotals.mockResolvedValue([{ gameName: 'Albion Online', minutes: 120 }]);
+
+      await service.handleRankUpRequest(member);
+      const content = lastSentContent();
+
+      expect(content).toMatch(/⚔️.*¹/);
+      expect(content).toContain('¹ Game time is sampled from Discord presence');
     });
 
     it('carries both the tracking and presence caveats', async () => {

--- a/src/albion/services/albion.rank.up.service.ts
+++ b/src/albion/services/albion.rank.up.service.ts
@@ -12,7 +12,13 @@ import { AlbionUtilities } from '../utilities/albion.utilities';
 import { DiscordService } from '../../discord/discord.service';
 import { MemberActivityRollupService } from '../../general/services/member.activity.rollup.service';
 import { LeadershipPing } from '../../config/albion.app.config';
-import { AlbionRankUpVoteService, scoreHeading, VOTE_REACTIONS } from './albion.rank.up.vote.service';
+import {
+  AlbionRankUpVoteService,
+  majorityScore,
+  PROVISIONAL_HOLD_MS,
+  scoreHeading,
+  VOTE_REACTIONS,
+} from './albion.rank.up.vote.service';
 import { discordTime } from '../../helpers';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -30,8 +36,10 @@ const LOCKOUT_STATUSES = [
   AlbionRankUpVoteStatus.VETOED,
 ];
 const VOTE_DURATION_DAYS = 5;
+
+// Stated on the ballot, so it is read from the hold itself rather than written down twice
+const HOLD_HOURS = Math.round(PROVISIONAL_HOLD_MS / (60 * 60 * 1000));
 const MAX_CHARACTER_NAME = 32;
-const MAX_GAME_NAME = 48;
 
 export enum RankUpRefusal {
   NOT_REGISTERED = 'NOT_REGISTERED',
@@ -179,14 +187,14 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
   ): Promise<RankUpOutcome> {
     const electors = await this.albionUtilities.getElectors(member.guild);
 
-    // floor(0/2)+1 is 1, which would post a ballot any single reaction could pass.
+    // An empty electorate would set the bar at half a point, which a single shrug clears.
     // That's a configuration fault, not a vote.
     if (electors.length === 0) {
       this.logger.error('Refusing to open a rank up ballot: no electors found in the guild');
       return await this.refuse(member, registration, tier, RankUpRefusal.NO_ELECTORATE);
     }
 
-    const requiredScore = Math.floor(electors.length / 2) + 1;
+    const requiredScore = majorityScore(electors.length);
     const expiresAt = new Date(Date.now() + VOTE_DURATION_DAYS * DAY_MS);
     const characterName = registration.characterName.slice(0, MAX_CHARACTER_NAME);
 
@@ -353,7 +361,7 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
 
     return `${ping.mention}
 
-Guildmember <@${member.id}> wants to be ranked up from **${this.friendlyRank(tier.from)}** to **${this.friendlyRank(tier.to)}**.
+Guildmember **${registration.characterName.slice(0, MAX_CHARACTER_NAME)}** (<@${member.id}>) wants to be ranked up from **${this.friendlyRank(tier.from)}** to **${this.friendlyRank(tier.to)}**.
 Please react with the following:
 
 👍 - to approve the rank up
@@ -361,11 +369,13 @@ Please react with the following:
 👎 - to disapprove the rank up
 ⛔ - to put a veto on the rank up (this action needs justification with proof)
 
-👍 = 1 point · 🤷 = 0.5 points · 👎 = 0 points · ⛔ ends the vote immediately
+👍 = 1 point · 🤷 = 0.5 points · 👎 = 0 points · ⛔ closes the vote whatever the score
 
 Eligible voters: ${electorateSize}
-Passes at a score of ${requiredScore}
+Passes at a score of **${requiredScore}** — a majority of ${electorateSize} (${electorateSize} ÷ 2 + 0.5)
 Voting closes ${discordTime(expiresAt, 'R')}
+
+-# Every outcome, a veto included, is held for ${HOLD_HOURS} hour${HOLD_HOURS === 1 ? '' : 's'} before it locks in. Lift a veto inside that window and the vote carries on.
 
 ${scoreHeading(0, requiredScore)}
 
@@ -395,21 +405,18 @@ ${stats}`;
     const registeredDays = Math.floor((Date.now() - registration.createdAt.getTime()) / DAY_MS);
 
     const albionName = this.config.get('albion.gameActivityName');
+    // Only Albion is reported. Other games are still recorded, but they are not what this
+    // vote is about and listing them invites judging people on what else they play.
     const albionMinutes = gameTotals.find((game) => game.gameName === albionName)?.minutes ?? 0;
-    const otherGames = gameTotals
-      .filter((game) => game.gameName !== albionName)
-      .slice(0, 3)
-      .map((game) => `${game.gameName.slice(0, MAX_GAME_NAME)} ${Math.round(game.minutes / 60)}h`);
 
     const lines = [
-      '### Activity',
-      `**Character:** ${registration.characterName}`,
-      `**Registered:** ${discordTime(registration.createdAt, 'D')} — ${registeredDays} days ago`,
+      '### Metrics',
+      `- 📅 Registered: ${discordTime(registration.createdAt, 'D')} — **${registeredDays}** days ago`,
     ];
 
     if (tier.to === '@ALB/Adept' && registration.graduateSince) {
       const graduateDays = Math.floor((Date.now() - registration.graduateSince.getTime()) / DAY_MS);
-      lines.push(`**Graduate since:** ${discordTime(registration.graduateSince, 'D')} — ${graduateDays} days ago`);
+      lines.push(`- 🎓 Graduate since: ${discordTime(registration.graduateSince, 'D')} — **${graduateDays}** days ago`);
     }
 
     // No rows at all is not the same as a member who did nothing. Rendering zeroes and a red band
@@ -423,17 +430,13 @@ ${stats}`;
     }
     else {
       lines.push(gameTotals.length > 0
-        ? `- ⚔️ **${albionName}: ${this.friendlyDuration(albionMinutes)}**`
-        : '- ⚔️ No game activity recorded');
-
-      if (otherGames.length > 0) {
-        lines.push(`- 🎮 Other games: ${otherGames.join(', ')}`);
-      }
+        ? `- ⚔️ **${albionName}: ${this.friendlyDuration(albionMinutes)}** ¹`
+        : '- ⚔️ No game activity recorded ¹');
 
       lines.push(
-        `- 🎙️ Voice: **${this.friendlyDuration(voiceMinutes)}**`,
-        `- 💬 Messages: **${messages}** (${(messages / trackedDays).toFixed(1)}/day)`,
-        `- ⭐ Reactions: **${reactions}**`,
+        `- 🎙️ Voice: **${this.friendlyDuration(voiceMinutes)}** ²`,
+        `- 💬 Messages: **${messages}** (${(messages / trackedDays).toFixed(1)}/day) ²`,
+        `- ⭐ Reactions: **${reactions}** ²`,
         `- 📊 Active on **${activeDays}** of **${trackedDays}** days (${((activeDays / trackedDays) * 100).toFixed(0)}%) — ${this.activityBand(activeDays, trackedDays)}`,
       );
     }
@@ -445,7 +448,10 @@ ${stats}`;
       lines.push('\n-# Activity tracking has not recorded anything yet, for anyone.');
     }
 
-    lines.push('-# Game time is sampled from Discord presence — it only counts when the member has Discord open with game activity sharing enabled, so a low figure may reflect settings rather than inactivity.');
+    lines.push(
+      '-# ¹ Game time is sampled from Discord presence — it only counts when the member has Discord open with game activity sharing enabled, so a low figure may reflect settings rather than inactivity.',
+      '-# ² Monitored across the entire DIG server, not filtered by Albion section.',
+    );
 
     return lines.join('\n');
   }

--- a/src/albion/services/albion.rank.up.vote.cron.service.spec.ts
+++ b/src/albion/services/albion.rank.up.vote.cron.service.spec.ts
@@ -2,7 +2,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@mikro-orm/nestjs';
 import { AlbionRankUpVoteCronService } from './albion.rank.up.vote.cron.service';
-import { AlbionRankUpVoteService, PROVISIONAL_HOLD_MS } from './albion.rank.up.vote.service';
+import { AlbionRankUpVoteService } from './albion.rank.up.vote.service';
 import {
   AlbionRankUpVoteEntity,
   AlbionRankUpVoteStatus,
@@ -34,6 +34,7 @@ describe('AlbionRankUpVoteCronService', () => {
 
     voteService = {
       reclaimUnposted: jest.fn().mockResolvedValue(0),
+      resyncPending: jest.fn().mockResolvedValue(undefined),
       evaluate: jest.fn().mockResolvedValue(undefined),
       resolve: jest.fn().mockResolvedValue(true),
       announce: jest.fn().mockResolvedValue(undefined),
@@ -69,29 +70,6 @@ describe('AlbionRankUpVoteCronService', () => {
       await service.reconcileUnannounced();
 
       expect(voteService.announce).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('commitElapsedHolds', () => {
-    it('re-evaluates a hold whose window has passed', async () => {
-      const vote = makeVote({
-        provisionalStatus: AlbionRankUpVoteStatus.PASSED,
-        provisionalSince: new Date(Date.now() - PROVISIONAL_HOLD_MS - 1000),
-      });
-      voteRepository.find.mockResolvedValueOnce([vote]);
-
-      await service.commitElapsedHolds();
-
-      // Re-tallied rather than trusting the stored result, in case reactions changed
-      expect(voteService.evaluate).toHaveBeenCalledWith(vote);
-    });
-
-    it('queries only holds older than the window', async () => {
-      await service.commitElapsedHolds();
-
-      const query = voteRepository.find.mock.calls[0][0];
-      expect(query.status).toBe(AlbionRankUpVoteStatus.PENDING);
-      expect(query.provisionalSince.$lte).toBeInstanceOf(Date);
     });
   });
 
@@ -162,13 +140,16 @@ describe('AlbionRankUpVoteCronService', () => {
         order.push('reclaim');
         return 0;
       });
+      voteService.resyncPending.mockImplementation(async () => {
+        order.push('resync');
+      });
       jest.spyOn(service, 'expireOverdue').mockImplementation(async () => {
         order.push('expire');
       });
 
       await service.sweep();
 
-      expect(order).toEqual(['reclaim', 'expire']);
+      expect(order).toEqual(['reclaim', 'resync', 'expire']);
     });
   });
 

--- a/src/albion/services/albion.rank.up.vote.cron.service.ts
+++ b/src/albion/services/albion.rank.up.vote.cron.service.ts
@@ -6,7 +6,7 @@ import {
   AlbionRankUpVoteEntity,
   AlbionRankUpVoteStatus,
 } from '../../database/entities/albion.rank.up.vote.entity';
-import { AlbionRankUpVoteService, PROVISIONAL_HOLD_MS } from './albion.rank.up.vote.service';
+import { AlbionRankUpVoteService } from './albion.rank.up.vote.service';
 
 @Injectable()
 export class AlbionRankUpVoteCronService implements OnApplicationBootstrap {
@@ -43,23 +43,10 @@ export class AlbionRankUpVoteCronService implements OnApplicationBootstrap {
     // First, so a stranded claim is cleared before expireOverdue can time it out
     await this.voteService.reclaimUnposted();
     await this.reconcileUnannounced();
-    await this.commitElapsedHolds();
+    // Re-tallies every open ballot, which also commits any hold whose window has passed. A cron
+    // rather than an in-process timer, so a restart mid-hold doesn't strand the ballot.
+    await this.voteService.resyncPending();
     await this.expireOverdue();
-  }
-
-  // Commits early results whose cooling off window has passed. This is the mechanism rather
-  // than an in-process timer, so a restart mid-hold doesn't strand the ballot.
-  async commitElapsedHolds(): Promise<void> {
-    const held = await this.voteRepository.find({
-      status: AlbionRankUpVoteStatus.PENDING,
-      provisionalSince: { $lte: new Date(Date.now() - PROVISIONAL_HOLD_MS) },
-    });
-
-    for (const vote of held) {
-      // Re-tally rather than trusting the stored result, in case reactions changed while
-      // the bot was down and the hold silently became wrong
-      await this.voteService.evaluate(vote);
-    }
   }
 
   // The crash-in-between case: resolved in the database, never posted to Discord

--- a/src/albion/services/albion.rank.up.vote.service.spec.ts
+++ b/src/albion/services/albion.rank.up.vote.service.spec.ts
@@ -5,7 +5,9 @@ import { getRepositoryToken } from '@mikro-orm/nestjs';
 import { Collection } from 'discord.js';
 import {
   AlbionRankUpVoteService,
+  majorityScore,
   PROVISIONAL_HOLD_MS,
+  REACTION_DEBOUNCE_MS,
   scoreHeading,
   UNPOSTED_GRACE_MS,
   VOTE_APPROVE,
@@ -363,6 +365,192 @@ describe('AlbionRankUpVoteService', () => {
     });
   });
 
+  describe('majorityScore', () => {
+    // Strictly more than half. An even electorate needs half plus 0.5, not a whole extra vote.
+    it.each([
+      [1, 1],
+      [2, 1.5],
+      [4, 2.5],
+      [5, 3],
+      [6, 3.5],
+      [7, 4],
+      [8, 4.5],
+    ])('%i voters pass at %d', (electors, expected) => {
+      expect(majorityScore(electors)).toBe(expected);
+    });
+
+    it('is always more than half the electorate', () => {
+      for (let n = 1; n <= 20; n++) {
+        expect(majorityScore(n)).toBeGreaterThan(n / 2);
+      }
+    });
+  });
+
+  describe('debouncing a burst of reactions', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    it('recounts once the burst has settled', async () => {
+      const vote = makeVote();
+      voteRepository.findOne.mockResolvedValue(vote);
+      const evaluate = jest.spyOn(service, 'evaluate').mockResolvedValue(undefined);
+
+      await service.scheduleRecount(vote);
+      expect(evaluate).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(REACTION_DEBOUNCE_MS);
+
+      expect(evaluate).toHaveBeenCalledTimes(1);
+    });
+
+    // The whole point: five electors reacting together produce one tally, not five racing ones
+    it('collapses rapid changes into a single recount', async () => {
+      const vote = makeVote();
+      voteRepository.findOne.mockResolvedValue(vote);
+      const evaluate = jest.spyOn(service, 'evaluate').mockResolvedValue(undefined);
+
+      for (let i = 0; i < 5; i++) {
+        await service.scheduleRecount(vote);
+        await jest.advanceTimersByTimeAsync(REACTION_DEBOUNCE_MS / 2);
+      }
+
+      expect(evaluate).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(REACTION_DEBOUNCE_MS);
+
+      expect(evaluate).toHaveBeenCalledTimes(1);
+    });
+
+    it('debounces each ballot separately', async () => {
+      voteRepository.findOne.mockImplementation(async ({ id }: any) => makeVote({ id }));
+      const evaluate = jest.spyOn(service, 'evaluate').mockResolvedValue(undefined);
+
+      await service.scheduleRecount(makeVote({ id: 1 }));
+      await service.scheduleRecount(makeVote({ id: 2 }));
+      await jest.advanceTimersByTimeAsync(REACTION_DEBOUNCE_MS);
+
+      expect(evaluate).toHaveBeenCalledTimes(2);
+    });
+
+    // The wait is long enough for the vote to have been resolved by the cron underneath it
+    it('does nothing when the vote resolved while it waited', async () => {
+      voteRepository.findOne.mockResolvedValue(null);
+      const evaluate = jest.spyOn(service, 'evaluate');
+
+      await service.scheduleRecount(makeVote({ id: 1 }));
+      await jest.advanceTimersByTimeAsync(REACTION_DEBOUNCE_MS);
+
+      expect(evaluate).not.toHaveBeenCalled();
+    });
+
+    it('only ever looks at ballots that are still pending', async () => {
+      voteRepository.findOne.mockResolvedValue(null);
+
+      await service.recount(1);
+
+      expect(voteRepository.findOne).toHaveBeenCalledWith({
+        id: 1,
+        status: AlbionRankUpVoteStatus.PENDING,
+      });
+    });
+
+    it('does not let a failed recount escape', async () => {
+      voteRepository.findOne.mockRejectedValue(new Error('db down'));
+
+      await expect(service.recount(1)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('flagging the score as recalculating', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    const withBallotContent = (content: string) => {
+      const message = makeMessage({}, content);
+      discordService.getTextChannel = jest.fn().mockResolvedValue({
+        id: 'chan-1', send: channelSend, messages: { fetch: jest.fn().mockResolvedValue(message) },
+      });
+      return message;
+    };
+
+    // The number is about to move, so it should look unsettled rather than quietly wrong
+    it('marks the score the moment a change is detected', async () => {
+      withBallotContent(scoreHeading(2.5, 4));
+
+      await service.scheduleRecount(makeVote({ score: 2.5 }));
+
+      expect(messageEdit).toHaveBeenCalledWith(scoreHeading(2.5, 4, true));
+    });
+
+    it('keeps the last known score visible while it recalculates', async () => {
+      withBallotContent(scoreHeading(2.5, 4));
+
+      await service.scheduleRecount(makeVote({ score: 2.5 }));
+
+      expect(messageEdit.mock.calls[0][0]).toContain('2.5 / 4');
+    });
+
+    it('marks it once for a whole burst, not once per reaction', async () => {
+      const message = withBallotContent(scoreHeading(2.5, 4));
+      messageEdit.mockImplementation(async (content: string) => {
+        message.content = content;
+        return message;
+      });
+
+      for (let i = 0; i < 4; i++) {
+        await service.scheduleRecount(makeVote({ score: 2.5 }));
+      }
+
+      expect(messageEdit).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears the marker when the recount lands', async () => {
+      withBallotContent(scoreHeading(2.5, 4, true));
+      const vote = makeVote({ score: 2.5 });
+      voteRepository.findOne.mockResolvedValue(vote);
+
+      await service.recount(vote.id);
+
+      expect(messageEdit).toHaveBeenCalledWith(expect.not.stringContaining('recalculating'));
+    });
+
+    it('does not let a failed marker edit stop the recount being scheduled', async () => {
+      discordService.getTextChannel = jest.fn().mockRejectedValue(new Error('discord down'));
+      const vote = makeVote();
+      voteRepository.findOne.mockResolvedValue(vote);
+      const evaluate = jest.spyOn(service, 'evaluate').mockResolvedValue(undefined);
+
+      await service.scheduleRecount(vote);
+      await jest.advanceTimersByTimeAsync(REACTION_DEBOUNCE_MS);
+
+      expect(evaluate).toHaveBeenCalled();
+    });
+  });
+
+  describe('resyncPending', () => {
+    // The debounce timer is in process, so a restart loses any recount it was holding
+    it('re-evaluates every open ballot that was posted', async () => {
+      const votes = [makeVote({ id: 1 }), makeVote({ id: 2 })];
+      voteRepository.find.mockResolvedValue(votes);
+      const evaluate = jest.spyOn(service, 'evaluate').mockResolvedValue(undefined);
+
+      await service.resyncPending();
+
+      expect(evaluate).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips ballots that were never posted', async () => {
+      voteRepository.find.mockResolvedValue([]);
+
+      await service.resyncPending();
+
+      expect(voteRepository.find).toHaveBeenCalledWith({
+        status: AlbionRankUpVoteStatus.PENDING,
+        messageId: { $ne: null },
+      });
+    });
+  });
+
   describe('the live score line', () => {
     // The regex that rewrites it has to match what the ballot builder wrote. If they drift, the
     // score silently stops updating and nothing errors.
@@ -662,42 +850,52 @@ describe('AlbionRankUpVoteService', () => {
 
     const userReacting = (id: string, bot = false) => ({ partial: false, id, bot } as any);
 
-    it('evaluates the vote a tracked ballot belongs to', async () => {
+    it('schedules a recount for the ballot the reaction belongs to', async () => {
       const vote = makeVote();
       voteRepository.findOne.mockResolvedValue(vote);
+      const schedule = jest.spyOn(service, 'scheduleRecount').mockImplementation(() => undefined);
+
+      await service.onReactionAdd([reactionOn('msg-1'), userReacting('e1')] as never);
+
+      expect(schedule).toHaveBeenCalledWith(vote);
+    });
+
+    // Tallying on each event lands a count taken mid-change; the burst has to settle first
+    it('does not recount straight away', async () => {
+      voteRepository.findOne.mockResolvedValue(makeVote());
       const evaluate = jest.spyOn(service, 'evaluate').mockResolvedValue(undefined);
 
       await service.onReactionAdd([reactionOn('msg-1'), userReacting('e1')] as never);
 
-      expect(evaluate).toHaveBeenCalledWith(vote);
+      expect(evaluate).not.toHaveBeenCalled();
     });
 
     it('ignores reactions on messages that are not ballots', async () => {
       voteRepository.findOne.mockResolvedValue(null);
-      const evaluate = jest.spyOn(service, 'evaluate');
+      const schedule = jest.spyOn(service, 'scheduleRecount');
 
       await service.onReactionAdd([reactionOn('some-other-message'), userReacting('e1')] as never);
 
-      expect(evaluate).not.toHaveBeenCalled();
+      expect(schedule).not.toHaveBeenCalled();
     });
 
     it('ignores the bot reacting to itself', async () => {
-      const evaluate = jest.spyOn(service, 'evaluate');
+      const schedule = jest.spyOn(service, 'scheduleRecount');
 
       await service.onReactionAdd([reactionOn('msg-1'), userReacting('bot', true)] as never);
 
       expect(voteRepository.findOne).not.toHaveBeenCalled();
-      expect(evaluate).not.toHaveBeenCalled();
+      expect(schedule).not.toHaveBeenCalled();
     });
 
     it('re-evaluates when a reaction is removed', async () => {
       const vote = makeVote();
       voteRepository.findOne.mockResolvedValue(vote);
-      const evaluate = jest.spyOn(service, 'evaluate').mockResolvedValue(undefined);
+      const schedule = jest.spyOn(service, 'scheduleRecount').mockImplementation(() => undefined);
 
       await service.onReactionRemove([reactionOn('msg-1'), userReacting('e1')] as never);
 
-      expect(evaluate).toHaveBeenCalledWith(vote);
+      expect(schedule).toHaveBeenCalledWith(vote);
     });
 
     it('does not let a scoring failure escape into the gateway handler', async () => {

--- a/src/albion/services/albion.rank.up.vote.service.ts
+++ b/src/albion/services/albion.rank.up.vote.service.ts
@@ -34,10 +34,19 @@ const DISCORD_UNKNOWN_MESSAGE = 10008;
 // which has already had the full voting period.
 export const PROVISIONAL_HOLD_MS = 60 * 60 * 1000;
 
+// A majority is strictly more than half. Shrugs are worth 0.5, so half a point is a real
+// increment and an even electorate needs half plus 0.5 rather than a whole extra vote:
+// 6 voters pass at 3.5, not 4. Odd counts are unchanged - 7 still passes at 4.
+export const majorityScore = (electorateSize: number): number => electorateSize / 2 + 0.5;
+
+// Shown the moment a change is detected, so a number that is about to move looks visibly
+// unsettled rather than silently wrong while the burst finishes
+export const RECALCULATING = '*(recalculating…)*';
+
 // The one definition of the score line, shared with the ballot builder. Kept together with the
 // regex below, which has to match whatever this writes.
-export const scoreHeading = (score: number, requiredScore: number): string =>
-  `## 📊 Current score: ${score} / ${requiredScore}`;
+export const scoreHeading = (score: number, requiredScore: number, recalculating = false): string =>
+  `## 📊 Current score: ${score} / ${requiredScore}${recalculating ? ` ${RECALCULATING}` : ''}`;
 
 // The live score line plus any hold notice beneath it, rewritten in place on every recount. Both
 // are matched together so a stale hold notice can't survive the replacement. Deliberately loose
@@ -46,6 +55,11 @@ const SCORE_LINE = /^.*Current score:.*(?:\n⏳.*)?$/m;
 
 // Discord rate limits message edits, and a busy ballot recounts on every reaction
 const SCORE_EDIT_THROTTLE_MS = 5000;
+
+// Reactions arrive in bursts: changing your mind fires a remove and an add, and electors tend to
+// vote together. Recounting on each event races Discord's own state and lands a tally taken
+// mid-change. Waiting for the burst to settle means one recount against a settled ballot.
+export const REACTION_DEBOUNCE_MS = 10 * 1000;
 
 // How long a claimed but unposted ballot is left alone before it is treated as dead. A send can
 // stall far longer than it looks - discord.js queues behind rate limits - so this is a long way
@@ -69,6 +83,7 @@ export interface GrantOutcome {
 export class AlbionRankUpVoteService {
   private readonly logger = new Logger(AlbionRankUpVoteService.name);
   private readonly lastScoreEdit = new Map<number, number>();
+  private readonly pendingRecounts = new Map<number, NodeJS.Timeout>();
 
   constructor(
     private readonly config: ConfigService,
@@ -107,10 +122,67 @@ export class AlbionRankUpVoteService {
         return;
       }
 
-      await this.evaluate(vote);
+      await this.scheduleRecount(vote);
     }
     catch (err) {
       this.logger.error(`Error handling rank up vote reaction: ${err.message}`);
+    }
+  }
+
+  // Each new reaction pushes the recount back, so a burst produces one tally once it settles.
+  // The timer is in process and lost on restart; resyncPending() in the sweep is the backstop.
+  async scheduleRecount(vote: AlbionRankUpVoteEntity): Promise<void> {
+    clearTimeout(this.pendingRecounts.get(vote.id));
+
+    const timer = setTimeout(() => {
+      this.pendingRecounts.delete(vote.id);
+      void this.recount(vote.id);
+    }, REACTION_DEBOUNCE_MS);
+
+    timer.unref?.(); // Must not hold the process open on shutdown
+    this.pendingRecounts.set(vote.id, timer);
+
+    await this.markRecalculating(vote);
+  }
+
+  // Flags the score as unsettled straight away. Deliberately outside the edit throttle - it is
+  // the one edit that has to land immediately - but only ever once per burst.
+  private async markRecalculating(vote: AlbionRankUpVoteEntity): Promise<void> {
+    try {
+      const message = await this.fetchBallot(vote);
+
+      if (message.content.includes(RECALCULATING)) {
+        return;
+      }
+
+      const updated = message.content.replace(SCORE_LINE, this.scoreLine(vote, true));
+
+      if (updated !== message.content) {
+        await message.edit(updated);
+      }
+    }
+    catch (err) {
+      // Cosmetic: the recount rewrites the line properly in a few seconds regardless
+      this.logger.warn(`Could not flag ballot ${vote.messageId} as recalculating: ${err.message}`);
+    }
+  }
+
+  async recount(voteId: number): Promise<void> {
+    try {
+      // Re-read rather than reusing the entity - the vote may have resolved while we waited
+      const vote = await this.voteRepository.findOne({
+        id: voteId,
+        status: AlbionRankUpVoteStatus.PENDING,
+      });
+
+      if (!vote) {
+        return;
+      }
+
+      await this.evaluate(vote);
+    }
+    catch (err) {
+      this.logger.error(`Failed the debounced recount for vote ${voteId}: ${err.message}`);
     }
   }
 
@@ -242,8 +314,8 @@ export class AlbionRankUpVoteService {
     return Date.now() - vote.provisionalSince.getTime() >= PROVISIONAL_HOLD_MS;
   }
 
-  scoreLine(vote: AlbionRankUpVoteEntity): string {
-    const base = scoreHeading(vote.score, vote.requiredScore);
+  scoreLine(vote: AlbionRankUpVoteEntity, recalculating = false): string {
+    const base = scoreHeading(vote.score, vote.requiredScore, recalculating);
 
     if (!vote.provisionalStatus || !vote.provisionalSince) {
       return base;
@@ -264,6 +336,8 @@ export class AlbionRankUpVoteService {
   private async refreshScoreLine(vote: AlbionRankUpVoteEntity, message: Message): Promise<void> {
     const lastEdit = this.lastScoreEdit.get(vote.id) ?? 0;
 
+    // Dropped rather than deferred, so a burst of reactions leaves the displayed number behind.
+    // resyncPending() in the sweep is what catches up, within a minute.
     if (Date.now() - lastEdit < SCORE_EDIT_THROTTLE_MS) {
       return;
     }
@@ -286,6 +360,21 @@ export class AlbionRankUpVoteService {
   private async fetchBallot(vote: AlbionRankUpVoteEntity): Promise<Message> {
     const channel = await this.discordService.getTextChannel(vote.channelId) as TextChannel;
     return await channel.messages.fetch(vote.messageId);
+  }
+
+  // Re-tallies every open ballot. Two things leave a displayed score stale with nothing to correct
+  // it: reactions cast while the bot was down are invisible until something recounts, and a
+  // throttled score edit is dropped rather than deferred. Also commits any hold that has elapsed,
+  // since evaluate() does that itself.
+  async resyncPending(): Promise<void> {
+    const open = await this.voteRepository.find({
+      status: AlbionRankUpVoteStatus.PENDING,
+      messageId: { $ne: null },
+    });
+
+    for (const vote of open) {
+      await this.evaluate(vote);
+    }
   }
 
   // A pending row with no messageId is a ballot that was never posted: the insert claimed the


### PR DESCRIPTION
> [!NOTE]
> **No manual steps.** Nothing to set, migrate or restart beyond the normal deploy.

Found while watching a real ballot: the posted score read 3.5 when the reactions on it added up to
2.5, and stayed wrong. It was not the bot's own pre-adds being counted — a test reproducing the
exact reaction set, with the bot forced to count as an elector, still tallies 2.5 and ignores the
bot's own ⛔ — it was the tally being taken mid-change.

## Behaviour

**Reactions now debounce for 10 seconds.** Changing your mind fires a remove then an add, and
electors tend to vote together, so recounting on each event counted a ballot that was still moving.
One recount now runs once the burst settles. The moment a change is detected the score is flagged:

```
## 📊 Current score: 2.5 / 4 *(recalculating…)*
```

so a number that is about to move looks unsettled rather than quietly wrong. That edit deliberately
bypasses the rate-limit throttle, but only fires once per burst.

**`resyncPending()` re-tallies every open ballot in the sweep.** The debounce timer is in process
and lost on a restart. This also closes an older gap: reactions cast while the bot was down were
invisible until someone reacted again or the vote expired, up to five days later. It replaces
`commitElapsedHolds`, which it subsumes entirely.

**The pass mark is a true majority.** `electorate / 2 + 0.5`, rather than `floor(electorate / 2) + 1`.
Shrugs are worth half a point, so half a point is a real increment and an even electorate should
need half plus 0.5 rather than a whole extra vote. Six voters now pass at **3.5**, not 4. Odd counts
are unchanged — seven still passes at 4. The ballot shows the sum.

**Veto** already went through the same one-hour hold as every other outcome, and a veto lifted
inside that window already let the vote carry on. The only thing wrong was the ballot claiming ⛔
"ends the vote immediately". The wording now matches, and the hold is stated explicitly.

## Presentation

- The live score is a `##` heading — it is the one number leadership scans for.
- The character leads the opening line: `Guildmember **Glumroot** (@Glumroot) wants to be…`
- `### Activity` → `### Metrics`, with the dates as bullets alongside everything else.
- Footnote markers: ¹ game time is presence-sampled, ² message, reaction and voice counts are
  server wide rather than Albion only.
- Other games are dropped from the ballot. The rows are still recorded, so a "who plays Albion
  most" report remains possible — they are just not what this vote is about.

## The bit worth reviewing

The ballot builder writes the score line and the vote service rewrites it in place **by regex,
matched against whatever the builder wrote**. Those were separate string literals in separate
services; drift between them would have stopped the score updating with nothing to error on. Both
now render through one exported `scoreHeading()`, with a test asserting the recount rewrites exactly
what the builder produced.

The regex stays deliberately loose about the heading so a ballot posted before this deploy keeps
updating and picks up the heading on its next recount. There is a test for that too.

## Validation

- `pnpm lint` clean, **656 tests across 47 suites passing**.
- The debounce is tested with fake timers: a single burst of five changes produces one recount, each
  ballot debounces separately, and a vote resolved while the timer was pending is left alone.
- The majority formula is tested across electorate sizes 1–20, asserting it is always strictly
  greater than half.
- Rendered the full ballot at each step rather than only asserting on substrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qt1VkMfrJd8ArmWZnw3iHa
