### PR TITLE
ci: Stop prose choosing the release, and ship the stranded merge

### DIFF
--- a/.claude/memory/commit-messages-drive-version-bump.md
+++ b/.claude/memory/commit-messages-drive-version-bump.md
@@ -1,17 +1,40 @@
 ---
 name: commit-messages-drive-version-bump
-description: "Commit messages on main decide the release version bump via substring match — the word \"feat\" anywhere forces a minor bump"
-metadata: 
+description: "The release bump is chosen by substring-matching the commit message; the trigger words are now explicit markers, not prose"
+metadata:
   node_type: memory
   type: project
   originSessionId: ca733b42-5e99-422a-9fda-a6e80f064fc3
-  modified: 2026-08-02T22:04:33.897Z
+  modified: 2026-08-02T22:08:39.823Z
 ---
 
-Every push to main runs `.github/workflows/release.yml`, where `phips28/gh-action-bump-version` picks the bump type by **substring-matching the commit message**, not by parsing the conventional-commit type. Defaults: `minor-wording: feat,minor`, `major-wording: BREAKING CHANGE,major`, otherwise patch.
+Every push to main runs `.github/workflows/release.yml`, where `phips28/gh-action-bump-version` picks
+the bump type by **substring-matching the commit message**, subject *and* body, rather than parsing
+the conventional-commit type. Its defaults are `minor-wording: feat,minor` and
+`major-wording: BREAKING CHANGE,major`, which means ordinary prose decides the release.
 
-**Why:** the match is a plain substring test over the whole message, subject *and* body. Prose like "Features", "minor tweak", or a body sentence containing "major" silently bumps the version harder than intended — and the bump is pushed and tagged before anyone sees it.
+**Why that mattered:** the words hide inside longer ones. "majority" contains *major*; "features"
+and "defeat" contain *feat*. Worse than over-bumping, a spurious version bump of the largest size
+**breaks the deploy outright**: tags `3.0.0` and `3.0.1` have existed since April 2025 (the project
+briefly ran a 3.x line, then went back to 2.x), so the action computes `3.0.0`, `git tag` fails with
+"tag already exists", the release job dies, and **Build & Publish container and Trigger deployment
+are both skipped**. The PR shows merged and green while the change never leaves the repository, and
+nothing in the failure points at the commit message. This is not hypothetical: it stranded a merge on
+2026-08-02, and a check across the preceding history showed a pure bugfix PR had already been
+released as a minor version for the same reason.
 
-**A major bump does not just over-bump, it breaks the deploy.** Tags `3.0.0` and `3.0.1` already exist from April 2025, and the version later went back down to 2.x. So the action computes `3.0.0`, `git tag` fails with "tag already exists", the release job dies, and **Build & Publish container and Trigger deployment are both skipped** — the merge lands on main and never ships. On 2026-08-02 the word *majority* in a commit body did exactly this, and the change sat undeployed until the next push.
+**Now configured explicitly**, in `release.yml` and identically in `build-and-test-main.yml` (which
+runs the same action in dry-run to label the SonarCloud scan — they must agree or Sonar reports a
+version the tag never becomes):
 
-**How to apply:** when writing a commit destined for main, keep `feat`/`minor`/`major`/`BREAKING CHANGE` out of the message entirely unless that bump is genuinely wanted. Watch for them hiding inside longer words — "features", "majority", "de**feat**ed", "refactor**major**ly". For an intentional minor bump, use a real `feat:` type. If a deploy has already failed this way, the fix is the next push: nothing was tagged, so a following commit with a clean message bumps normally and carries the stranded change out with it. Related: [[albion-registration-critical-pillar]].
+- `major-wording: BUMP-MAJOR` — a marker that cannot appear by accident
+- `minor-wording: feat:,feat(` — the conventional-commit prefix, not the bare word
+- `rc-wording: BUMP-RC`
+- `default: patch`
+
+**How to apply:** a `feat:` or `feat(scope):` subject still gives a minor bump, which is the existing
+convention and worth keeping. Everything else is a patch. For a deliberate large bump, put
+`BUMP-MAJOR` in the message — and first deal with the stale `3.0.0`/`3.0.1` tags, which will collide
+with it. If a deploy ever fails this way again, nothing was tagged, so the next push with a clean
+message bumps normally and carries the stranded change out with it.
+Related: [[albion-registration-critical-pillar]].

--- a/.claude/memory/commit-messages-drive-version-bump.md
+++ b/.claude/memory/commit-messages-drive-version-bump.md
@@ -5,11 +5,13 @@ metadata:
   node_type: memory
   type: project
   originSessionId: ca733b42-5e99-422a-9fda-a6e80f064fc3
-  modified: 2026-07-26T23:00:54.909Z
+  modified: 2026-08-02T22:04:33.897Z
 ---
 
 Every push to main runs `.github/workflows/release.yml`, where `phips28/gh-action-bump-version` picks the bump type by **substring-matching the commit message**, not by parsing the conventional-commit type. Defaults: `minor-wording: feat,minor`, `major-wording: BREAKING CHANGE,major`, otherwise patch.
 
 **Why:** the match is a plain substring test over the whole message, subject *and* body. Prose like "Features", "minor tweak", or a body sentence containing "major" silently bumps the version harder than intended — and the bump is pushed and tagged before anyone sees it.
 
-**How to apply:** when writing a commit destined for main, keep `feat`/`minor`/`major`/`BREAKING CHANGE` out of the message entirely unless that bump is genuinely wanted. Watch for them hiding inside longer words ("features", "refactor**major**ly"). For an intentional minor bump, use a real `feat:` type. Related: [[albion-registration-critical-pillar]].
+**A major bump does not just over-bump, it breaks the deploy.** Tags `3.0.0` and `3.0.1` already exist from April 2025, and the version later went back down to 2.x. So the action computes `3.0.0`, `git tag` fails with "tag already exists", the release job dies, and **Build & Publish container and Trigger deployment are both skipped** — the merge lands on main and never ships. On 2026-08-02 the word *majority* in a commit body did exactly this, and the change sat undeployed until the next push.
+
+**How to apply:** when writing a commit destined for main, keep `feat`/`minor`/`major`/`BREAKING CHANGE` out of the message entirely unless that bump is genuinely wanted. Watch for them hiding inside longer words — "features", "majority", "de**feat**ed", "refactor**major**ly". For an intentional minor bump, use a real `feat:` type. If a deploy has already failed this way, the fix is the next push: nothing was tagged, so a following commit with a clean message bumps normally and carries the stranded change out with it. Related: [[albion-registration-critical-pillar]].

--- a/.github/workflows/build-and-test-main.yml
+++ b/.github/workflows/build-and-test-main.yml
@@ -76,6 +76,11 @@ jobs:
           skip-commit: 'true'
           skip-tag: 'true'
           skip-push:  'true'
+          # Must match release.yml exactly, or Sonar labels a version the tag never becomes
+          major-wording: 'BUMP-MAJOR'
+          minor-wording: 'feat:,feat('
+          rc-wording: 'BUMP-RC'
+          default: patch
 
       - name: SonarCloud Scan with version attached
         uses: SonarSource/sonarqube-scan-action@v8.2.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           target-branch: main
+          # The action substring-matches the whole commit message, body included, against these
+          # words - so prose drives the release. "majority" read as major and tried to tag 3.0.0,
+          # which has existed since April 2025, failing the job and skipping the deploy entirely.
+          # Explicit markers instead, and a conventional-commit prefix rather than bare "feat".
+          major-wording: 'BUMP-MAJOR'
+          minor-wording: 'feat:,feat('
+          rc-wording: 'BUMP-RC'
+          default: patch
 
       # GitHub's own generated notes only list merged pull requests, so anything pushed straight to
       # main left the release body as nothing but a compare link. This rolls up every conventional

--- a/src/albion/services/albion.rank.up.service.spec.ts
+++ b/src/albion/services/albion.rank.up.service.spec.ts
@@ -688,7 +688,23 @@ describe('AlbionRankUpService', () => {
       const content = lastSentContent();
       expect(content).toContain('wants to be ranked up');
       expect(content).toContain('Please react with the following');
-      expect(content).toContain('⛔ - to put a veto on the rank up');
+      expect(content).toContain('- ⛔ to put a veto on the rank up');
+    });
+
+    it('bullets each reaction explainer but keeps the scoring on one line', async () => {
+      await service.handleRankUpRequest(member);
+      const content = lastSentContent();
+
+      for (const line of [
+        '- 👍 to approve the rank up',
+        '- 🤷 to say "I don\'t know the person well enough"',
+        '- 👎 to disapprove the rank up',
+        '- ⛔ to put a veto on the rank up',
+      ]) {
+        expect(content).toContain(line);
+      }
+
+      expect(content).toContain('👍 = 1 point · 🤷 = 0.5 points · 👎 = 0 points · ⛔ closes the vote whatever the score');
     });
 
     it('pings the leadership role and the candidate only', async () => {

--- a/src/albion/services/albion.rank.up.service.ts
+++ b/src/albion/services/albion.rank.up.service.ts
@@ -364,10 +364,10 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
 Guildmember **${registration.characterName.slice(0, MAX_CHARACTER_NAME)}** (<@${member.id}>) wants to be ranked up from **${this.friendlyRank(tier.from)}** to **${this.friendlyRank(tier.to)}**.
 Please react with the following:
 
-👍 - to approve the rank up
-🤷 - to say "I don't know the person well enough"
-👎 - to disapprove the rank up
-⛔ - to put a veto on the rank up (this action needs justification with proof)
+- 👍 to approve the rank up
+- 🤷 to say "I don't know the person well enough"
+- 👎 to disapprove the rank up
+- ⛔ to put a veto on the rank up (this action needs justification with proof)
 
 👍 = 1 point · 🤷 = 0.5 points · 👎 = 0 points · ⛔ closes the vote whatever the score
 


### PR DESCRIPTION
> [!IMPORTANT]
> **No manual steps — but merging this is what ships #757.**
>
> #757 merged cleanly and is on `main`, but **it was never deployed**: its release job failed, so the
> container build and the deployment were both skipped. Nothing is wrong with its code. Merging this
> triggers a clean release that carries it out.

## Why the release keeps trying to jump to 3.0.0

`phips28/gh-action-bump-version` picks the bump size by **substring-matching the entire commit
message**, subject and body, rather than parsing the conventional-commit type. Its defaults are
ordinary English words, so they hide inside longer ones — and a sentence of description silently
decides the release.

```
current 1: 2.34.2 / version: major
newVersion 1: 3.0.0
runInWorkspace | command: git args: [ 'tag', '3.0.0' ]
✖  fatal     fatal: tag '3.0.0' already exists
✖  fatal     Failed to bump version
```

`3.0.0` and `3.0.1` have existed since **April 2025** — the project briefly ran a 3.x line, then went
back to 2.x. So the largest bump is not merely wrong, it is fatal: tagging fails, the release job
exits, and `Build & Publish container` and `Trigger deployment` both come back `skipped`. The PR
reads as merged and green while nothing ships, and nothing in the failure points at the commit
message.

**This is not a one-off.** Replaying both rule sets over the last 25 commits on `main`:

| old | new | commit |
|---|---|---|
| **MAJOR** | patch | `fix(albion): Settle the ballot before tallying…` (#757) |
| **minor** | patch | `fix(albion): Fix six faults in the rank-up ballot` (#753) |
| minor | minor | `feat(albion): Add /albion-force-register…` (#751) |
| minor | minor | `feat(albion): Add /albion-rank-up…` (#750) |
| patch | patch | every `ci:` and `fix:` commit |

#753 was a pure bugfix and shipped as **2.34.0**, a size bump it never asked for. Only the two
mis-sized entries change; every genuine feature commit keeps exactly the bump it has always had.

## The fix

Explicit trigger words in `release.yml`, and identical values in `build-and-test-main.yml` — that one
runs the same action in dry-run to label the SonarCloud scan, and if the two disagree Sonar reports a
version the tag never becomes.

```yaml
major-wording: 'BUMP-MAJOR'      # cannot appear by accident
minor-wording: 'feat:,feat('     # the conventional-commit prefix, not the bare word
rc-wording:    'BUMP-RC'
default: patch
```

A `feat:` or `feat(scope):` subject still gives the same bump it always did — that convention is
worth keeping, it just should not be triggerable from prose.

## The ballot change

The four reaction explainers are list items now, so they read as a set. The scoring summary
underneath deliberately stays on one line.

```
- 👍 to approve the rank up
- 🤷 to say "I don't know the person well enough"
- 👎 to disapprove the rank up
- ⛔ to put a veto on the rank up (this action needs justification with proof)

👍 = 1 point · 🤷 = 0.5 points · 👎 = 0 points · ⛔ closes the vote whatever the score
```

## Worth deciding separately

The stale `3.0.0` / `3.0.1` tags are still there. They no longer break anything, since nothing
reaches for that size by accident now, but a deliberate `BUMP-MAJOR` would still collide with them.
Left alone — deleting published tags is not a call to make inside an unrelated PR.

## Validation

- `pnpm lint` clean, **657 tests across 47 suites passing**.
- Both workflow files parse as valid YAML.
- Both commit messages here were checked against the old *and* new trigger words before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qt1VkMfrJd8ArmWZnw3iHa
