### PR TITLE
feat(albion): Re-render the ballot on every reaction, and widen the metrics

### DIFF
--- a/src/albion/services/albion.ballot.text.ts
+++ b/src/albion/services/albion.ballot.text.ts
@@ -1,0 +1,45 @@
+// Pure ballot vocabulary, owned by neither service. Both the publisher and the vote runner need
+// these, and the vote runner asks the publisher to re-render a ballot - keeping the shared values
+// here is what stops that becoming a circular import.
+
+export const VOTE_APPROVE = '👍';
+export const VOTE_SHRUG = '🤷';
+export const VOTE_DISAPPROVE = '👎';
+export const VOTE_VETO = '⛔';
+
+export const VOTE_REACTIONS = [VOTE_APPROVE, VOTE_SHRUG, VOTE_DISAPPROVE, VOTE_VETO];
+
+// An early result is held this long before it is committed, so an elector who changes their mind
+// flips the outcome rather than arriving after it was announced. Does not apply to a timeout,
+// which has already had the full voting period.
+export const PROVISIONAL_HOLD_MS = 60 * 60 * 1000;
+
+// A majority is strictly more than half. Shrugs are worth 0.5, so half a point is a real
+// increment and an even electorate needs half plus 0.5 rather than a whole extra vote:
+// 6 voters pass at 3.5, not 4. Odd counts are unchanged - 7 still passes at 4.
+export const majorityScore = (electorateSize: number): number => electorateSize / 2 + 0.5;
+
+// Shown from the moment a change is detected, counting down, so a number that is about to move
+// looks visibly unsettled rather than silently wrong while the burst finishes
+export const RECALCULATING = 'recalculating';
+
+// How often the countdown is repainted. Every tick is a message edit, so a burst costs one edit
+// per second of the debounce. Concurrent ballots share Discord's edit budget and discord.js
+// queues rather than failing, so the worst case is a countdown that lags, not a lost update.
+export const RECALCULATING_TICK_MS = 1000;
+
+// The one definition of the score line, shared with the ballot builder. Kept together with the
+// regex in the vote service, which has to match whatever this writes.
+export const scoreHeading = (score: number, requiredScore: number, secondsLeft?: number): string => {
+  const countdown = secondsLeft === undefined
+    ? ''
+    : ` *(${RECALCULATING}… ${Math.max(0, Math.ceil(secondsLeft))}s)*`;
+
+  return `## 📊 Current score: ${score} / ${requiredScore}${countdown}`;
+};
+
+// How long a claimed but unposted ballot is left alone before it is treated as dead. A send can
+// stall far longer than it looks - discord.js queues behind rate limits - so this is a long way
+// past a normal post rather than a tight bound. It is not the only guard: trackBallot() writes the
+// message ID conditionally, so a publish that loses this race takes its own orphan back down.
+export const UNPOSTED_GRACE_MS = 5 * 60 * 1000;

--- a/src/albion/services/albion.rank.up.service.spec.ts
+++ b/src/albion/services/albion.rank.up.service.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { getRepositoryToken } from '@mikro-orm/nestjs';
 import { UniqueConstraintViolationException } from '@mikro-orm/core';
+import { UNPOSTED_GRACE_MS } from './albion.ballot.text';
 import { AlbionRankUpService, RankUpRefusal } from './albion.rank.up.service';
 import { AlbionRegistrationsEntity } from '../../database/entities/albion.registrations.entity';
 import {
@@ -12,7 +13,6 @@ import {
 import { AlbionUtilities } from '../utilities/albion.utilities';
 import { DiscordService } from '../../discord/discord.service';
 import { MemberActivityRollupService } from '../../general/services/member.activity.rollup.service';
-import { AlbionRankUpVoteService } from './albion.rank.up.vote.service';
 import { TestBootstrapper } from '../../test.bootstrapper';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -23,7 +23,6 @@ describe('AlbionRankUpService', () => {
   let voteRepository: any;
   let albionUtilities: any;
   let rollupService: any;
-  let voteService: any;
   let votePersist: jest.Mock;
   let voteFlush: jest.Mock;
   let voteExecute: jest.Mock;
@@ -103,8 +102,6 @@ describe('AlbionRankUpService', () => {
       getTrackingStartDate: jest.fn().mockResolvedValue(daysAgo(10)),
     };
 
-    voteService = { reclaimUnposted: jest.fn().mockResolvedValue(0) };
-
     discordService = {
       getTextChannel: jest.fn().mockResolvedValue({
         id: 'judgement-hall',
@@ -120,7 +117,6 @@ describe('AlbionRankUpService', () => {
         { provide: DiscordService, useValue: discordService },
         { provide: AlbionUtilities, useValue: albionUtilities },
         { provide: MemberActivityRollupService, useValue: rollupService },
-        { provide: AlbionRankUpVoteService, useValue: voteService },
         { provide: getRepositoryToken(AlbionRegistrationsEntity), useValue: registrationsRepository },
         { provide: getRepositoryToken(AlbionRankUpVoteEntity), useValue: voteRepository },
       ],
@@ -406,6 +402,57 @@ describe('AlbionRankUpService', () => {
     });
   });
 
+  describe('reclaimUnposted', () => {
+    it('only touches pending rows that never got a message', async () => {
+      await service.reclaimUnposted();
+
+      expect(voteExecute.mock.calls[0][0]).toContain('message_id is null');
+      expect(voteExecute.mock.calls[0][0]).toContain('status = ?');
+      expect(voteExecute.mock.calls[0][1]).toContain(AlbionRankUpVoteStatus.ABANDONED);
+    });
+
+    it('frees the pending key so the member can ask again', async () => {
+      await service.reclaimUnposted();
+
+      expect(voteExecute.mock.calls[0][0]).toContain('pending_key = null');
+    });
+
+    // Otherwise the reconcile sweep would try to post an outcome for a ballot nobody ever saw
+    it('marks the row announced so nothing tries to post an outcome', async () => {
+      await service.reclaimUnposted();
+
+      expect(voteExecute.mock.calls[0][0]).toContain('announced_at = ?');
+    });
+
+    // Only bounds how recent a claim can be and still be reclaimed. It does not prove a
+    // concurrent publish is safe - trackBallot()'s conditional write is what does that.
+    it('only considers claims older than the grace window', async () => {
+      await service.reclaimUnposted();
+
+      const cutoff: Date = voteExecute.mock.calls[0][1].at(-1);
+      expect(Date.now() - cutoff.getTime()).toBeGreaterThanOrEqual(UNPOSTED_GRACE_MS);
+    });
+
+    it('narrows to one member when given a discord ID', async () => {
+      await service.reclaimUnposted('candidate');
+
+      expect(voteExecute.mock.calls[0][0]).toContain('and discord_id = ?');
+      expect(voteExecute.mock.calls[0][1].at(-1)).toBe('candidate');
+    });
+
+    it('reports how many it reclaimed', async () => {
+      voteExecute.mockResolvedValue({ affectedRows: 2 });
+
+      expect(await service.reclaimUnposted()).toBe(2);
+    });
+
+    it('asks for the affected row count', async () => {
+      await service.reclaimUnposted();
+
+      expect(voteExecute.mock.calls[0][2]).toBe('run');
+    });
+  });
+
   describe('denial notice throttle', () => {
     it('claims the throttle by conditional update before sending', async () => {
       registrationsRepository.findOne.mockResolvedValue(makeRegistration({ createdAt: daysAgo(2) }));
@@ -531,19 +578,21 @@ describe('AlbionRankUpService', () => {
     // A claim left behind by an attempt that died before posting is ours to clear, not a
     // reason to lock the member out of a ballot nobody ever saw
     it('reclaims a ballot that was never posted and retries', async () => {
+      const reclaimSpy = jest.spyOn(service, 'reclaimUnposted');
       voteFlush.mockRejectedValueOnce(duplicateKeyError());
-      voteService.reclaimUnposted.mockResolvedValue(1);
+      reclaimSpy.mockResolvedValue(1);
 
       const outcome = await service.handleRankUpRequest(member);
 
-      expect(voteService.reclaimUnposted).toHaveBeenCalledWith('candidate');
+      expect(reclaimSpy).toHaveBeenCalledWith('candidate');
       expect(outcome.ok).toBe(true);
       expect(lastSentContent()).toContain('wants to be ranked up');
     });
 
     it('refuses when there was nothing stranded to reclaim', async () => {
+      const reclaimSpy = jest.spyOn(service, 'reclaimUnposted');
       voteFlush.mockRejectedValue(duplicateKeyError());
-      voteService.reclaimUnposted.mockResolvedValue(0);
+      reclaimSpy.mockResolvedValue(0);
 
       const outcome = await service.handleRankUpRequest(member);
 
@@ -688,7 +737,7 @@ describe('AlbionRankUpService', () => {
       const content = lastSentContent();
       expect(content).toContain('wants to be ranked up');
       expect(content).toContain('Please react with the following');
-      expect(content).toContain('- ⛔ to put a veto on the rank up');
+      expect(content).toContain('- ⛔ veto the rank up (this action needs justification with proof), this will cause the vote to fail within 1 hour.');
     });
 
     it('bullets each reaction explainer but keeps the scoring on one line', async () => {
@@ -699,12 +748,12 @@ describe('AlbionRankUpService', () => {
         '- 👍 to approve the rank up',
         '- 🤷 to say "I don\'t know the person well enough"',
         '- 👎 to disapprove the rank up',
-        '- ⛔ to put a veto on the rank up',
+        '- ⛔ veto the rank up (this action needs justification with proof), this will cause the vote to fail within 1 hour.',
       ]) {
         expect(content).toContain(line);
       }
 
-      expect(content).toContain('👍 = 1 point · 🤷 = 0.5 points · 👎 = 0 points · ⛔ closes the vote whatever the score');
+      expect(content).toContain('Scoring: 👍 = 1 point · 🤷 = 0.5 points · 👎 = 0 points\n');
     });
 
     it('pings the leadership role and the candidate only', async () => {
@@ -728,7 +777,7 @@ describe('AlbionRankUpService', () => {
 
     // "0h 0m" reads as "played none", which is a different claim from "we recorded nothing"
     it('says nothing was recorded rather than showing zero hours', async () => {
-      rollupService.getRollup.mockResolvedValue([{ messagesSent: 3, reactionsAdded: 0, voiceMinutes: 0 }]);
+      rollupService.getRollup.mockResolvedValue([{ messagesSent: 3, reactionsAdded: 0, voiceMinutes: 0, date: daysAgo(1) }]);
       rollupService.getGameTotals.mockResolvedValue([]);
 
       await service.handleRankUpRequest(member);
@@ -747,7 +796,7 @@ describe('AlbionRankUpService', () => {
       const content = lastSentContent();
 
       expect(content).toContain('No activity data recorded for this member');
-      expect(content).not.toContain('🔴 Low');
+      expect(content).not.toContain('Activity all time');
       expect(content).not.toContain('Messages:');
     });
 
@@ -789,7 +838,7 @@ describe('AlbionRankUpService', () => {
     });
 
     it('heads the block Metrics and bullets the dates with the rest', async () => {
-      rollupService.getRollup.mockResolvedValue([{ messagesSent: 5, reactionsAdded: 2, voiceMinutes: 60 }]);
+      rollupService.getRollup.mockResolvedValue([{ messagesSent: 5, reactionsAdded: 2, voiceMinutes: 60, date: daysAgo(1) }]);
 
       await service.handleRankUpRequest(member);
       const content = lastSentContent();
@@ -798,9 +847,37 @@ describe('AlbionRankUpService', () => {
       expect(content).toMatch(/- 📅 Registered:.*30\*\* days ago/);
     });
 
+    // A year-long member absent for a fortnight and a brand new one look identical on a
+    // lifetime average, which is the figure leadership would otherwise vote on
+    it('reports activity all time and over the last two weeks', async () => {
+      rollupService.getRollup.mockResolvedValue([
+        { messagesSent: 5, reactionsAdded: 0, voiceMinutes: 0, date: daysAgo(1) },
+        { messagesSent: 3, reactionsAdded: 0, voiceMinutes: 0, date: daysAgo(40) },
+        { messagesSent: 0, reactionsAdded: 0, voiceMinutes: 0, date: daysAgo(41) },
+      ]);
+      rollupService.getTrackingStartDate.mockResolvedValue(daysAgo(60));
+
+      await service.handleRankUpRequest(member);
+      const content = lastSentContent();
+
+      expect(content).toContain('📊 Activity all time registered: **2** of');
+      expect(content).toContain('📈 Activity last 14 days: **1** of **14** days (7%)');
+    });
+
+    it('does not let the recent window claim more days than have been tracked', async () => {
+      rollupService.getRollup.mockResolvedValue([
+        { messagesSent: 5, reactionsAdded: 0, voiceMinutes: 0, date: daysAgo(1) },
+      ]);
+      rollupService.getTrackingStartDate.mockResolvedValue(daysAgo(3));
+
+      await service.handleRankUpRequest(member);
+
+      expect(lastSentContent()).toContain('📈 Activity last 14 days: **1** of **3** days');
+    });
+
     // The stats are server wide, and reading them as Albion-only would undercount everyone
     it('marks the server wide counters against their footnote', async () => {
-      rollupService.getRollup.mockResolvedValue([{ messagesSent: 5, reactionsAdded: 2, voiceMinutes: 60 }]);
+      rollupService.getRollup.mockResolvedValue([{ messagesSent: 5, reactionsAdded: 2, voiceMinutes: 60, date: daysAgo(1) }]);
 
       await service.handleRankUpRequest(member);
       const content = lastSentContent();

--- a/src/albion/services/albion.rank.up.service.ts
+++ b/src/albion/services/albion.rank.up.service.ts
@@ -13,12 +13,12 @@ import { DiscordService } from '../../discord/discord.service';
 import { MemberActivityRollupService } from '../../general/services/member.activity.rollup.service';
 import { LeadershipPing } from '../../config/albion.app.config';
 import {
-  AlbionRankUpVoteService,
   majorityScore,
   PROVISIONAL_HOLD_MS,
   scoreHeading,
+  UNPOSTED_GRACE_MS,
   VOTE_REACTIONS,
-} from './albion.rank.up.vote.service';
+} from './albion.ballot.text';
 import { discordTime } from '../../helpers';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -36,6 +36,10 @@ const LOCKOUT_STATUSES = [
   AlbionRankUpVoteStatus.VETOED,
 ];
 const VOTE_DURATION_DAYS = 5;
+
+// A second, recent window alongside the all-time one. Someone active for a year but absent for the
+// last fortnight and someone who just arrived read identically on a lifetime average.
+const RECENT_WINDOW_DAYS = 14;
 
 // Stated on the ballot, so it is read from the hold itself rather than written down twice
 const HOLD_HOURS = Math.round(PROVISIONAL_HOLD_MS / (60 * 60 * 1000));
@@ -79,7 +83,6 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
     private readonly discordService: DiscordService,
     private readonly albionUtilities: AlbionUtilities,
     private readonly rollupService: MemberActivityRollupService,
-    private readonly voteService: AlbionRankUpVoteService,
     @InjectRepository(AlbionRegistrationsEntity) private readonly registrationsRepository: EntityRepository<AlbionRegistrationsEntity>,
     @InjectRepository(AlbionRankUpVoteEntity) private readonly voteRepository: EntityRepository<AlbionRankUpVoteEntity>,
   ) {}
@@ -156,7 +159,7 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
       return await this.refuse(member, registration, tier, RankUpRefusal.RECENT_FAILED_VOTE, lockoutUntil);
     }
 
-    return await this.publish(member, registration, tier, anchor);
+    return await this.publish(member, registration, tier);
   }
 
   // Returns when they may ask again, or null if nothing is holding them back
@@ -183,7 +186,6 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
     member: GuildMember,
     registration: AlbionRegistrationsEntity,
     tier: Tier,
-    anchor: Date,
   ): Promise<RankUpOutcome> {
     const electors = await this.albionUtilities.getElectors(member.guild);
 
@@ -198,9 +200,6 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
     const expiresAt = new Date(Date.now() + VOTE_DURATION_DAYS * DAY_MS);
     const characterName = registration.characterName.slice(0, MAX_CHARACTER_NAME);
 
-    // Built before the row is claimed. Anything failing in here afterwards would strand a pending
-    // ballot with no message, locking the member out of a vote nobody could ever see.
-    const content = await this.buildBallot(member, registration, tier, anchor, electors.length, requiredScore, expiresAt);
     const ping: LeadershipPing = this.config.get('albion.leadershipPing');
 
     const newBallot = () => new AlbionRankUpVoteEntity({
@@ -214,6 +213,10 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
       electorateSize: electors.length,
       expiresAt,
     });
+
+    // Rendered before the row is claimed. Anything failing in here afterwards would strand a
+    // pending ballot with no message, locking the member out of a vote nobody could ever see.
+    const content = await this.renderBallot(newBallot(), scoreHeading(0, requiredScore));
 
     // The row goes in before the Discord post. Posting first means a flush failure leaves a
     // public ballot nothing tracks and nothing will ever resolve.
@@ -321,6 +324,40 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
     return (result as { affectedRows?: number })?.affectedRows ?? 0;
   }
 
+  // A pending row with no messageId is a ballot that was never posted: the insert claimed the
+  // member's slot and something failed before the send. Nothing else ever clears it, so the member
+  // stays locked out and is eventually timed out for a vote nobody could see.
+  // announcedAt is stamped alongside resolvedAt so the reconcile sweep doesn't try to post an
+  // outcome for a message that never existed.
+  async reclaimUnposted(discordId?: string): Promise<number> {
+    const connection = this.voteRepository.getEntityManager().getConnection();
+    const now = new Date();
+    const cutoff = new Date(Date.now() - UNPOSTED_GRACE_MS);
+
+    const result = await connection.execute(
+      `update albion_rank_up_vote_entity
+          set status = ?, pending_key = null, resolved_at = ?, announced_at = ?,
+              resolution_note = ?, updated_at = ?
+        where status = ? and message_id is null and created_at <= ?
+          ${discordId ? 'and discord_id = ?' : ''}`,
+      [
+        AlbionRankUpVoteStatus.ABANDONED, now, now,
+        'The ballot was never posted', now,
+        AlbionRankUpVoteStatus.PENDING, cutoff,
+        ...(discordId ? [discordId] : []),
+      ],
+      'run',
+    );
+
+    const reclaimed = this.affectedRows(result);
+
+    if (reclaimed > 0) {
+      this.logger.warn(`Reclaimed ${reclaimed} rank up ballot(s) that were never posted`);
+    }
+
+    return reclaimed;
+  }
+
   // A unique violation can mean a live ballot, or a stranded claim from an attempt that died
   // before it posted. Clearing the latter is the difference between a retry and a lockout.
   private async claimBallot(newBallot: () => AlbionRankUpVoteEntity): Promise<AlbionRankUpVoteEntity> {
@@ -335,7 +372,7 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
         throw err;
       }
 
-      if (await this.voteService.reclaimUnposted(ballot.discordId) === 0) {
+      if (await this.reclaimUnposted(ballot.discordId) === 0) {
         throw err;
       }
 
@@ -347,29 +384,33 @@ export class AlbionRankUpService implements OnApplicationBootstrap {
     }
   }
 
-  private async buildBallot(
-    member: GuildMember,
-    registration: AlbionRegistrationsEntity,
-    tier: Tier,
-    anchor: Date,
-    electorateSize: number,
-    requiredScore: number,
-    expiresAt: Date,
-  ): Promise<string> {
+  // Renders the whole ballot from the row, so a live vote can be re-rendered onto the current
+  // wording rather than being frozen in whatever format it was posted under. Everything it needs
+  // is either on the row or re-read here, which is why it takes no other arguments.
+  async renderBallot(vote: AlbionRankUpVoteEntity, scoreLine: string): Promise<string> {
     const ping: LeadershipPing = this.config.get('albion.leadershipPing');
-    const stats = await this.buildActivityBlock(member.id, anchor, registration, tier);
+    const registration = await this.registrationsRepository.findOne({
+      guildId: this.config.get('albion.guildId'),
+      discordId: vote.discordId,
+    });
+    const { electorateSize, requiredScore, expiresAt } = vote;
+
+    // Deregistered mid vote: the ballot still has to render, just without the history
+    const stats = registration
+      ? await this.buildActivityBlock(vote, registration)
+      : '### Metrics\n📭 **This member is no longer registered with the Albion guild.**';
 
     return `${ping.mention}
 
-Guildmember **${registration.characterName.slice(0, MAX_CHARACTER_NAME)}** (<@${member.id}>) wants to be ranked up from **${this.friendlyRank(tier.from)}** to **${this.friendlyRank(tier.to)}**.
+Guildmember **${vote.characterName}** (<@${vote.discordId}>) wants to be ranked up from **${this.friendlyRank(vote.fromRank)}** to **${this.friendlyRank(vote.toRank)}**.
 Please react with the following:
 
 - 👍 to approve the rank up
 - 🤷 to say "I don't know the person well enough"
 - 👎 to disapprove the rank up
-- ⛔ to put a veto on the rank up (this action needs justification with proof)
+- ⛔ veto the rank up (this action needs justification with proof), this will cause the vote to fail within ${HOLD_HOURS} hour${HOLD_HOURS === 1 ? '' : 's'}.
 
-👍 = 1 point · 🤷 = 0.5 points · 👎 = 0 points · ⛔ closes the vote whatever the score
+Scoring: 👍 = 1 point · 🤷 = 0.5 points · 👎 = 0 points
 
 Eligible voters: ${electorateSize}
 Passes at a score of **${requiredScore}** — a majority of ${electorateSize} (${electorateSize} ÷ 2 + 0.5)
@@ -377,17 +418,20 @@ Voting closes ${discordTime(expiresAt, 'R')}
 
 -# Every outcome, a veto included, is held for ${HOLD_HOURS} hour${HOLD_HOURS === 1 ? '' : 's'} before it locks in. Lift a veto inside that window and the vote carries on.
 
-${scoreHeading(0, requiredScore)}
+${scoreLine}
 
 ${stats}`;
   }
 
   private async buildActivityBlock(
-    discordId: string,
-    anchor: Date,
+    vote: AlbionRankUpVoteEntity,
     registration: AlbionRegistrationsEntity,
-    tier: Tier,
   ): Promise<string> {
+    // The window the figures cover. Tier 2 measures from the graduate date, tier 1 from
+    // registration - the same anchor the eligibility gate used.
+    const anchor = (vote.toRank === '@ALB/Adept' ? registration.graduateSince : registration.createdAt)
+      ?? registration.createdAt;
+    const discordId = vote.discordId;
     const trackingStart = await this.rollupService.getTrackingStartDate();
     const since = trackingStart && trackingStart > anchor ? trackingStart : anchor;
 
@@ -397,9 +441,14 @@ ${stats}`;
     const messages = rollup.reduce((total, row) => total + row.messagesSent, 0);
     const reactions = rollup.reduce((total, row) => total + row.reactionsAdded, 0);
     const voiceMinutes = rollup.reduce((total, row) => total + row.voiceMinutes, 0);
-    const activeDays = rollup.filter(
-      (row) => row.messagesSent > 0 || row.reactionsAdded > 0 || row.voiceMinutes > 0,
-    ).length;
+    const isActive = (row: { messagesSent: number, reactionsAdded: number, voiceMinutes: number }) =>
+      row.messagesSent > 0 || row.reactionsAdded > 0 || row.voiceMinutes > 0;
+
+    const activeDays = rollup.filter(isActive).length;
+
+    // Filtered from the rows already fetched rather than queried again
+    const recentFrom = Date.now() - RECENT_WINDOW_DAYS * DAY_MS;
+    const recentActiveDays = rollup.filter((row) => row.date.getTime() >= recentFrom && isActive(row)).length;
 
     const trackedDays = Math.max(1, Math.ceil((Date.now() - since.getTime()) / DAY_MS));
     const registeredDays = Math.floor((Date.now() - registration.createdAt.getTime()) / DAY_MS);
@@ -414,7 +463,7 @@ ${stats}`;
       `- 📅 Registered: ${discordTime(registration.createdAt, 'D')} — **${registeredDays}** days ago`,
     ];
 
-    if (tier.to === '@ALB/Adept' && registration.graduateSince) {
+    if (vote.toRank === '@ALB/Adept' && registration.graduateSince) {
       const graduateDays = Math.floor((Date.now() - registration.graduateSince.getTime()) / DAY_MS);
       lines.push(`- 🎓 Graduate since: ${discordTime(registration.graduateSince, 'D')} — **${graduateDays}** days ago`);
     }
@@ -437,7 +486,8 @@ ${stats}`;
         `- 🎙️ Voice: **${this.friendlyDuration(voiceMinutes)}** ²`,
         `- 💬 Messages: **${messages}** (${(messages / trackedDays).toFixed(1)}/day) ²`,
         `- ⭐ Reactions: **${reactions}** ²`,
-        `- 📊 Active on **${activeDays}** of **${trackedDays}** days (${((activeDays / trackedDays) * 100).toFixed(0)}%) — ${this.activityBand(activeDays, trackedDays)}`,
+        this.activityLine('📊 Activity all time registered', activeDays, trackedDays),
+        this.activityLine(`📈 Activity last ${RECENT_WINDOW_DAYS} days`, recentActiveDays, Math.min(RECENT_WINDOW_DAYS, trackedDays)),
       );
     }
 
@@ -454,6 +504,13 @@ ${stats}`;
     );
 
     return lines.join('\n');
+  }
+
+  activityLine(label: string, activeDays: number, trackedDays: number): string {
+    const days = Math.max(1, trackedDays);
+    const percent = ((activeDays / days) * 100).toFixed(0);
+
+    return `- ${label}: **${activeDays}** of **${days}** days (${percent}%) — ${this.activityBand(activeDays, days)}`;
   }
 
   activityBand(activeDays: number, trackedDays: number): string {

--- a/src/albion/services/albion.rank.up.vote.cron.service.spec.ts
+++ b/src/albion/services/albion.rank.up.vote.cron.service.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@mikro-orm/nestjs';
 import { AlbionRankUpVoteCronService } from './albion.rank.up.vote.cron.service';
 import { AlbionRankUpVoteService } from './albion.rank.up.vote.service';
+import { AlbionRankUpService } from './albion.rank.up.service';
 import {
   AlbionRankUpVoteEntity,
   AlbionRankUpVoteStatus,
@@ -12,6 +13,7 @@ describe('AlbionRankUpVoteCronService', () => {
   let service: AlbionRankUpVoteCronService;
   let voteRepository: any;
   let voteService: any;
+  let rankUpService: any;
 
   const makeVote = (overrides: any = {}) => ({
     id: 1,
@@ -32,8 +34,9 @@ describe('AlbionRankUpVoteCronService', () => {
       findOne: jest.fn().mockResolvedValue(null),
     };
 
+    rankUpService = { reclaimUnposted: jest.fn().mockResolvedValue(0) };
+
     voteService = {
-      reclaimUnposted: jest.fn().mockResolvedValue(0),
       resyncPending: jest.fn().mockResolvedValue(undefined),
       evaluate: jest.fn().mockResolvedValue(undefined),
       resolve: jest.fn().mockResolvedValue(true),
@@ -44,6 +47,7 @@ describe('AlbionRankUpVoteCronService', () => {
       providers: [
         AlbionRankUpVoteCronService,
         { provide: AlbionRankUpVoteService, useValue: voteService },
+        { provide: AlbionRankUpService, useValue: rankUpService },
         { provide: getRepositoryToken(AlbionRankUpVoteEntity), useValue: voteRepository },
       ],
     }).compile();
@@ -136,7 +140,7 @@ describe('AlbionRankUpVoteCronService', () => {
     // reclaimed - which would also lock the member out for the failed vote period
     it('reclaims unposted ballots before anything else', async () => {
       const order: string[] = [];
-      voteService.reclaimUnposted.mockImplementation(async () => {
+      rankUpService.reclaimUnposted.mockImplementation(async () => {
         order.push('reclaim');
         return 0;
       });

--- a/src/albion/services/albion.rank.up.vote.cron.service.ts
+++ b/src/albion/services/albion.rank.up.vote.cron.service.ts
@@ -7,6 +7,7 @@ import {
   AlbionRankUpVoteStatus,
 } from '../../database/entities/albion.rank.up.vote.entity';
 import { AlbionRankUpVoteService } from './albion.rank.up.vote.service';
+import { AlbionRankUpService } from './albion.rank.up.service';
 
 @Injectable()
 export class AlbionRankUpVoteCronService implements OnApplicationBootstrap {
@@ -14,6 +15,7 @@ export class AlbionRankUpVoteCronService implements OnApplicationBootstrap {
 
   constructor(
     private readonly voteService: AlbionRankUpVoteService,
+    private readonly rankUpService: AlbionRankUpService,
     @InjectRepository(AlbionRankUpVoteEntity) private readonly voteRepository: EntityRepository<AlbionRankUpVoteEntity>,
   ) {}
 
@@ -41,7 +43,7 @@ export class AlbionRankUpVoteCronService implements OnApplicationBootstrap {
 
   async sweep(): Promise<void> {
     // First, so a stranded claim is cleared before expireOverdue can time it out
-    await this.voteService.reclaimUnposted();
+    await this.rankUpService.reclaimUnposted();
     await this.reconcileUnannounced();
     // Re-tallies every open ballot, which also commits any hold whose window has passed. A cron
     // rather than an in-process timer, so a restart mid-hold doesn't strand the ballot.

--- a/src/albion/services/albion.rank.up.vote.service.spec.ts
+++ b/src/albion/services/albion.rank.up.vote.service.spec.ts
@@ -8,8 +8,8 @@ import {
   majorityScore,
   PROVISIONAL_HOLD_MS,
   REACTION_DEBOUNCE_MS,
+  RECALCULATING_TICK_MS,
   scoreHeading,
-  UNPOSTED_GRACE_MS,
   VOTE_APPROVE,
   VOTE_DISAPPROVE,
   VOTE_SHRUG,
@@ -21,11 +21,13 @@ import {
 } from '../../database/entities/albion.rank.up.vote.entity';
 import { AlbionUtilities } from '../utilities/albion.utilities';
 import { DiscordService } from '../../discord/discord.service';
+import { AlbionRankUpService } from './albion.rank.up.service';
 import { TestBootstrapper } from '../../test.bootstrapper';
 
 describe('AlbionRankUpVoteService', () => {
   let service: AlbionRankUpVoteService;
   let voteRepository: any;
+  let rankUpService: any;
   let discordService: any;
   let albionUtilities: any;
   let execute: jest.Mock;
@@ -83,6 +85,7 @@ describe('AlbionRankUpVoteService', () => {
 
   beforeEach(async () => {
     execute = jest.fn().mockResolvedValue({ affectedRows: 1 });
+    rankUpService = { renderBallot: jest.fn().mockResolvedValue('RE-RENDERED BALLOT') };
     channelSend = jest.fn().mockResolvedValue({ id: 'outcome-1' });
     messageEdit = jest.fn().mockResolvedValue(true);
 
@@ -114,6 +117,7 @@ describe('AlbionRankUpVoteService', () => {
         { provide: DiscordService, useValue: discordService },
         { provide: AlbionUtilities, useValue: albionUtilities },
         { provide: getRepositoryToken(AlbionRankUpVoteEntity), useValue: voteRepository },
+        { provide: AlbionRankUpService, useValue: rankUpService },
       ],
     }).compile();
 
@@ -461,60 +465,190 @@ describe('AlbionRankUpVoteService', () => {
     });
   });
 
-  describe('flagging the score as recalculating', () => {
-    beforeEach(() => jest.useFakeTimers());
-    afterEach(() => jest.useRealTimers());
-
-    const withBallotContent = (content: string) => {
-      const message = makeMessage({}, content);
+  describe('re-rendering a live ballot', () => {
+    const withBallot = (content: string) => {
+      const message = makeMessage({ [VOTE_APPROVE]: ['e1', 'e2'] }, content);
       discordService.getTextChannel = jest.fn().mockResolvedValue({
         id: 'chan-1', send: channelSend, messages: { fetch: jest.fn().mockResolvedValue(message) },
       });
       return message;
     };
 
-    // The number is about to move, so it should look unsettled rather than quietly wrong
-    it('marks the score the moment a change is detected', async () => {
-      withBallotContent(scoreHeading(2.5, 4));
+    // A ballot posted under older wording is otherwise frozen in it for its whole five days
+    it('rewrites the whole ballot on a reaction driven recount', async () => {
+      withBallot('OLD FORMAT\nCurrent score: **0** / 4');
+      const vote = makeVote();
+      voteRepository.findOne.mockResolvedValue(vote);
 
-      await service.scheduleRecount(makeVote({ score: 2.5 }));
+      await service.evaluate(vote, true);
 
-      expect(messageEdit).toHaveBeenCalledWith(scoreHeading(2.5, 4, true));
+      expect(rankUpService.renderBallot).toHaveBeenCalledWith(vote, expect.stringContaining('Current score'));
+      expect(messageEdit).toHaveBeenCalledWith('RE-RENDERED BALLOT');
     });
 
-    it('keeps the last known score visible while it recalculates', async () => {
-      withBallotContent(scoreHeading(2.5, 4));
+    // The sweep runs every minute; rewriting every open ballot that often is a lot of edits
+    it('only touches the score line when the sweep drives it', async () => {
+      withBallot(scoreHeading(0, 4));
 
-      await service.scheduleRecount(makeVote({ score: 2.5 }));
+      await service.evaluate(makeVote());
 
-      expect(messageEdit.mock.calls[0][0]).toContain('2.5 / 4');
+      expect(rankUpService.renderBallot).not.toHaveBeenCalled();
+      expect(messageEdit).toHaveBeenCalledWith(scoreHeading(2, 4));
     });
 
-    it('marks it once for a whole burst, not once per reaction', async () => {
-      const message = withBallotContent(scoreHeading(2.5, 4));
-      messageEdit.mockImplementation(async (content: string) => {
-        message.content = content;
+    it('does not edit when the render matches what is already posted', async () => {
+      withBallot('RE-RENDERED BALLOT');
+
+      await service.evaluate(makeVote(), true);
+
+      expect(messageEdit).not.toHaveBeenCalled();
+    });
+
+    // Losing the render must not cost the score update as well
+    it('falls back to the score line when the render fails', async () => {
+      withBallot(scoreHeading(0, 4));
+      rankUpService.renderBallot.mockRejectedValue(new Error('registration lookup failed'));
+
+      await service.evaluate(makeVote(), true);
+
+      expect(messageEdit).toHaveBeenCalledWith(scoreHeading(2, 4));
+    });
+  });
+
+  describe('the hold notice', () => {
+    const held = (status: AlbionRankUpVoteStatus) => service.scoreLine(makeVote({
+      score: 4,
+      provisionalStatus: status,
+      provisionalSince: new Date(),
+    }));
+
+    // Which way the hold is going should read at a glance, not from the verb alone
+    it('marks a pending pass with a tick', () => {
+      expect(held(AlbionRankUpVoteStatus.PASSED)).toContain('**✅ pass**');
+    });
+
+    it('marks a pending veto with the veto emoji', () => {
+      expect(held(AlbionRankUpVoteStatus.VETOED)).toContain(`**${VOTE_VETO} be vetoed**`);
+    });
+
+    it('states the window and when it closes', () => {
+      const line = held(AlbionRankUpVoteStatus.PASSED);
+
+      expect(line).toContain('This vote will be locked in and');
+      expect(line).toContain('this is your window to change it');
+      expect(line).toMatch(/<t:\d+:R>/);
+    });
+
+    it('keeps the score heading above the notice', () => {
+      expect(held(AlbionRankUpVoteStatus.PASSED).split('\n')[0]).toBe(scoreHeading(4, 4));
+    });
+
+    it('says nothing extra when no hold is running', () => {
+      expect(service.scoreLine(makeVote({ score: 2 }))).toBe(scoreHeading(2, 4));
+    });
+  });
+
+  describe('the recalculating countdown', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    const withBallot = (content = scoreHeading(2.5, 4)) => {
+      const message = makeMessage({}, content);
+      messageEdit.mockImplementation(async (updated: string) => {
+        message.content = updated;
         return message;
       });
+      discordService.getTextChannel = jest.fn().mockResolvedValue({
+        id: 'chan-1', send: channelSend, messages: { fetch: jest.fn().mockResolvedValue(message) },
+      });
+      return message;
+    };
 
-      for (let i = 0; i < 4; i++) {
-        await service.scheduleRecount(makeVote({ score: 2.5 }));
-      }
+    const editedLines = () => messageEdit.mock.calls.map((c: any[]) => c[0]);
 
-      expect(messageEdit).toHaveBeenCalledTimes(1);
+    // The number is about to move, so it should look unsettled rather than quietly wrong
+    it('marks the score the moment a change is detected', async () => {
+      withBallot();
+
+      await service.scheduleRecount(makeVote({ score: 2.5 }));
+
+      expect(editedLines()[0]).toContain('recalculating');
+      expect(editedLines()[0]).toContain('2.5 / 4');
+    });
+
+    it('counts down once a second', async () => {
+      withBallot();
+      await service.scheduleRecount(makeVote({ score: 2.5 }));
+
+      await jest.advanceTimersByTimeAsync(RECALCULATING_TICK_MS * 3);
+
+      const seconds = editedLines()
+        .map((line: string) => line.match(/(\d+)s\)/)?.[1])
+        .filter(Boolean)
+        .map(Number);
+
+      expect(seconds.length).toBeGreaterThanOrEqual(3);
+      expect(seconds).toEqual([...seconds].sort((a, b) => b - a)); // strictly falling
+      expect(seconds[0]).toBe(REACTION_DEBOUNCE_MS / 1000);
+    });
+
+    it('recounts when the countdown runs out, and stops painting', async () => {
+      withBallot();
+      const vote = makeVote({ score: 2.5 });
+      voteRepository.findOne.mockResolvedValue(vote);
+      const evaluate = jest.spyOn(service, 'evaluate').mockResolvedValue(undefined);
+
+      await service.scheduleRecount(vote);
+      await jest.advanceTimersByTimeAsync(REACTION_DEBOUNCE_MS);
+      expect(evaluate).toHaveBeenCalledTimes(1);
+
+      const afterRecount = messageEdit.mock.calls.length;
+      await jest.advanceTimersByTimeAsync(RECALCULATING_TICK_MS * 5);
+
+      expect(messageEdit.mock.calls.length).toBe(afterRecount);
+      expect(evaluate).toHaveBeenCalledTimes(1);
+    });
+
+    // A reaction mid countdown extends it rather than starting a second ticker
+    it('restarts the countdown when another reaction lands', async () => {
+      withBallot();
+      const vote = makeVote({ score: 2.5 });
+      voteRepository.findOne.mockResolvedValue(vote);
+      const evaluate = jest.spyOn(service, 'evaluate').mockResolvedValue(undefined);
+
+      await service.scheduleRecount(vote);
+      await jest.advanceTimersByTimeAsync(RECALCULATING_TICK_MS * 3);
+      await service.scheduleRecount(vote);
+      await jest.advanceTimersByTimeAsync(RECALCULATING_TICK_MS * 3);
+
+      expect(evaluate).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(REACTION_DEBOUNCE_MS);
+
+      expect(evaluate).toHaveBeenCalledTimes(1);
+    });
+
+    // One fetch per burst, not one per tick - the countdown must not cost a REST call a second
+    it('fetches the ballot once for the whole countdown', async () => {
+      withBallot();
+      await service.scheduleRecount(makeVote({ score: 2.5 }));
+      await jest.advanceTimersByTimeAsync(RECALCULATING_TICK_MS * 3);
+
+      const channel = await discordService.getTextChannel();
+      expect(channel.messages.fetch).toHaveBeenCalledTimes(1);
     });
 
     it('clears the marker when the recount lands', async () => {
-      withBallotContent(scoreHeading(2.5, 4, true));
+      withBallot(scoreHeading(2.5, 4, 5));
       const vote = makeVote({ score: 2.5 });
       voteRepository.findOne.mockResolvedValue(vote);
 
       await service.recount(vote.id);
 
-      expect(messageEdit).toHaveBeenCalledWith(expect.not.stringContaining('recalculating'));
+      expect(editedLines().at(-1)).not.toContain('recalculating');
     });
 
-    it('does not let a failed marker edit stop the recount being scheduled', async () => {
+    it('does not let a failed repaint stop the recount', async () => {
       discordService.getTextChannel = jest.fn().mockRejectedValue(new Error('discord down'));
       const vote = makeVote();
       voteRepository.findOne.mockResolvedValue(vote);
@@ -579,57 +713,6 @@ describe('AlbionRankUpVoteService', () => {
 
     it('is a heading so it stands out from the ballot body', () => {
       expect(scoreHeading(2, 4).startsWith('## ')).toBe(true);
-    });
-  });
-
-  describe('reclaimUnposted', () => {
-    it('only touches pending rows that never got a message', async () => {
-      await service.reclaimUnposted();
-
-      expect(execute.mock.calls[0][0]).toContain('message_id is null');
-      expect(execute.mock.calls[0][0]).toContain('status = ?');
-      expect(execute.mock.calls[0][1]).toContain(AlbionRankUpVoteStatus.ABANDONED);
-    });
-
-    it('frees the pending key so the member can ask again', async () => {
-      await service.reclaimUnposted();
-
-      expect(execute.mock.calls[0][0]).toContain('pending_key = null');
-    });
-
-    // Otherwise the reconcile sweep would try to post an outcome for a ballot nobody ever saw
-    it('marks the row announced so nothing tries to post an outcome', async () => {
-      await service.reclaimUnposted();
-
-      expect(execute.mock.calls[0][0]).toContain('announced_at = ?');
-    });
-
-    // Only bounds how recent a claim can be and still be reclaimed. It does not prove a
-    // concurrent publish is safe - trackBallot()'s conditional write is what does that.
-    it('only considers claims older than the grace window', async () => {
-      await service.reclaimUnposted();
-
-      const cutoff: Date = execute.mock.calls[0][1].at(-1);
-      expect(Date.now() - cutoff.getTime()).toBeGreaterThanOrEqual(UNPOSTED_GRACE_MS);
-    });
-
-    it('narrows to one member when given a discord ID', async () => {
-      await service.reclaimUnposted('candidate');
-
-      expect(execute.mock.calls[0][0]).toContain('and discord_id = ?');
-      expect(execute.mock.calls[0][1].at(-1)).toBe('candidate');
-    });
-
-    it('reports how many it reclaimed', async () => {
-      execute.mockResolvedValue({ affectedRows: 2 });
-
-      expect(await service.reclaimUnposted()).toBe(2);
-    });
-
-    it('asks for the affected row count', async () => {
-      await service.reclaimUnposted();
-
-      expect(execute.mock.calls[0][2]).toBe('run');
     });
   });
 

--- a/src/albion/services/albion.rank.up.vote.service.ts
+++ b/src/albion/services/albion.rank.up.vote.service.ts
@@ -13,13 +13,31 @@ import { AlbionRoleMapInterface, LeadershipPing } from '../../config/albion.app.
 import { DiscordService } from '../../discord/discord.service';
 import { resolvePartialReaction } from '../../discord/discord.hacks';
 import { discordTime } from '../../helpers';
+import { AlbionRankUpService } from './albion.rank.up.service';
+import {
+  PROVISIONAL_HOLD_MS,
+  RECALCULATING_TICK_MS,
+  scoreHeading,
+  VOTE_APPROVE,
+  VOTE_DISAPPROVE,
+  VOTE_SHRUG,
+  VOTE_VETO,
+} from './albion.ballot.text';
 
-export const VOTE_APPROVE = '👍';
-export const VOTE_SHRUG = '🤷';
-export const VOTE_DISAPPROVE = '👎';
-export const VOTE_VETO = '⛔';
-
-export const VOTE_REACTIONS = [VOTE_APPROVE, VOTE_SHRUG, VOTE_DISAPPROVE, VOTE_VETO];
+// Re-exported so callers have one place to import ballot vocabulary from
+export {
+  majorityScore,
+  UNPOSTED_GRACE_MS,
+  PROVISIONAL_HOLD_MS,
+  RECALCULATING,
+  RECALCULATING_TICK_MS,
+  scoreHeading,
+  VOTE_APPROVE,
+  VOTE_DISAPPROVE,
+  VOTE_REACTIONS,
+  VOTE_SHRUG,
+  VOTE_VETO,
+} from './albion.ballot.text';
 
 const REACTION_SCORES: Record<string, number> = {
   [VOTE_APPROVE]: 1,
@@ -28,25 +46,6 @@ const REACTION_SCORES: Record<string, number> = {
 };
 
 const DISCORD_UNKNOWN_MESSAGE = 10008;
-
-// An early result is held this long before it is committed, so an elector who changes their mind
-// flips the outcome rather than arriving after it was announced. Does not apply to a timeout,
-// which has already had the full voting period.
-export const PROVISIONAL_HOLD_MS = 60 * 60 * 1000;
-
-// A majority is strictly more than half. Shrugs are worth 0.5, so half a point is a real
-// increment and an even electorate needs half plus 0.5 rather than a whole extra vote:
-// 6 voters pass at 3.5, not 4. Odd counts are unchanged - 7 still passes at 4.
-export const majorityScore = (electorateSize: number): number => electorateSize / 2 + 0.5;
-
-// Shown the moment a change is detected, so a number that is about to move looks visibly
-// unsettled rather than silently wrong while the burst finishes
-export const RECALCULATING = '*(recalculating…)*';
-
-// The one definition of the score line, shared with the ballot builder. Kept together with the
-// regex below, which has to match whatever this writes.
-export const scoreHeading = (score: number, requiredScore: number, recalculating = false): string =>
-  `## 📊 Current score: ${score} / ${requiredScore}${recalculating ? ` ${RECALCULATING}` : ''}`;
 
 // The live score line plus any hold notice beneath it, rewritten in place on every recount. Both
 // are matched together so a stale hold notice can't survive the replacement. Deliberately loose
@@ -59,13 +58,13 @@ const SCORE_EDIT_THROTTLE_MS = 5000;
 // Reactions arrive in bursts: changing your mind fires a remove and an add, and electors tend to
 // vote together. Recounting on each event races Discord's own state and lands a tally taken
 // mid-change. Waiting for the burst to settle means one recount against a settled ballot.
-export const REACTION_DEBOUNCE_MS = 10 * 1000;
+export const REACTION_DEBOUNCE_MS = 5 * 1000;
 
-// How long a claimed but unposted ballot is left alone before it is treated as dead. A send can
-// stall far longer than it looks - discord.js queues behind rate limits - so this is a long way
-// past a normal post rather than a tight bound. It is not the only guard: trackBallot() writes the
-// message ID conditionally, so a publish that loses this race takes its own orphan back down.
-export const UNPOSTED_GRACE_MS = 5 * 60 * 1000;
+interface PendingRecount {
+  deadline: number;
+  timer: NodeJS.Timeout;
+  message?: Message;
+}
 
 export interface VoteTally {
   score: number;
@@ -83,13 +82,14 @@ export interface GrantOutcome {
 export class AlbionRankUpVoteService {
   private readonly logger = new Logger(AlbionRankUpVoteService.name);
   private readonly lastScoreEdit = new Map<number, number>();
-  private readonly pendingRecounts = new Map<number, NodeJS.Timeout>();
+  private readonly pendingRecounts = new Map<number, PendingRecount>();
 
   constructor(
     private readonly config: ConfigService,
     private readonly discordService: DiscordService,
     private readonly albionUtilities: AlbionUtilities,
     @InjectRepository(AlbionRankUpVoteEntity) private readonly voteRepository: EntityRepository<AlbionRankUpVoteEntity>,
+    private readonly rankUpService: AlbionRankUpService,
   ) {}
 
   @On('messageReactionAdd')
@@ -129,41 +129,62 @@ export class AlbionRankUpVoteService {
     }
   }
 
-  // Each new reaction pushes the recount back, so a burst produces one tally once it settles.
+  // Each new reaction pushes the deadline back, so a burst produces one tally once it settles.
+  // A reaction arriving mid countdown extends it rather than starting a second one.
   // The timer is in process and lost on restart; resyncPending() in the sweep is the backstop.
   async scheduleRecount(vote: AlbionRankUpVoteEntity): Promise<void> {
-    clearTimeout(this.pendingRecounts.get(vote.id));
+    const deadline = Date.now() + REACTION_DEBOUNCE_MS;
+    const pending = this.pendingRecounts.get(vote.id);
 
-    const timer = setTimeout(() => {
-      this.pendingRecounts.delete(vote.id);
-      void this.recount(vote.id);
-    }, REACTION_DEBOUNCE_MS);
+    if (pending) {
+      pending.deadline = deadline;
+      await this.paintCountdown(vote, pending);
+      return;
+    }
 
+    const timer = setInterval(() => void this.tick(vote), RECALCULATING_TICK_MS);
     timer.unref?.(); // Must not hold the process open on shutdown
-    this.pendingRecounts.set(vote.id, timer);
 
-    await this.markRecalculating(vote);
+    const started: PendingRecount = { deadline, timer };
+    this.pendingRecounts.set(vote.id, started);
+
+    // Painted immediately rather than waiting a tick, so the ballot reacts at once
+    await this.paintCountdown(vote, started);
   }
 
-  // Flags the score as unsettled straight away. Deliberately outside the edit throttle - it is
-  // the one edit that has to land immediately - but only ever once per burst.
-  private async markRecalculating(vote: AlbionRankUpVoteEntity): Promise<void> {
+  private async tick(vote: AlbionRankUpVoteEntity): Promise<void> {
+    const pending = this.pendingRecounts.get(vote.id);
+
+    if (!pending) {
+      return;
+    }
+
+    if (Date.now() >= pending.deadline) {
+      clearInterval(pending.timer);
+      this.pendingRecounts.delete(vote.id);
+      await this.recount(vote.id);
+      return;
+    }
+
+    await this.paintCountdown(vote, pending);
+  }
+
+  // Repaints the score line with the time left. The ballot is fetched once per burst and reused,
+  // so a countdown costs one fetch and a handful of edits rather than a fetch per tick.
+  private async paintCountdown(vote: AlbionRankUpVoteEntity, pending: PendingRecount): Promise<void> {
     try {
-      const message = await this.fetchBallot(vote);
+      pending.message ??= await this.fetchBallot(vote);
 
-      if (message.content.includes(RECALCULATING)) {
-        return;
-      }
+      const secondsLeft = (pending.deadline - Date.now()) / 1000;
+      const updated = pending.message.content.replace(SCORE_LINE, this.scoreLine(vote, secondsLeft));
 
-      const updated = message.content.replace(SCORE_LINE, this.scoreLine(vote, true));
-
-      if (updated !== message.content) {
-        await message.edit(updated);
+      if (updated !== pending.message.content) {
+        pending.message = await pending.message.edit(updated);
       }
     }
     catch (err) {
-      // Cosmetic: the recount rewrites the line properly in a few seconds regardless
-      this.logger.warn(`Could not flag ballot ${vote.messageId} as recalculating: ${err.message}`);
+      // Cosmetic: the recount rewrites the line properly when the countdown ends regardless
+      this.logger.warn(`Could not paint the countdown on ballot ${vote.messageId}: ${err.message}`);
     }
   }
 
@@ -179,7 +200,8 @@ export class AlbionRankUpVoteService {
         return;
       }
 
-      await this.evaluate(vote);
+      // Reaction driven, so this is where a ballot picks up any change to the wording
+      await this.evaluate(vote, true);
     }
     catch (err) {
       this.logger.error(`Failed the debounced recount for vote ${voteId}: ${err.message}`);
@@ -234,7 +256,10 @@ export class AlbionRankUpVoteService {
     };
   }
 
-  async evaluate(vote: AlbionRankUpVoteEntity): Promise<void> {
+  // rerender rewrites the whole ballot rather than just the score line, so a vote posted under an
+  // older wording is brought onto the current one. Reaction-driven only: the sweep runs every
+  // minute and rewriting every open ballot that often would be a lot of edits for nothing.
+  async evaluate(vote: AlbionRankUpVoteEntity, rerender = false): Promise<void> {
     let message: Message;
 
     try {
@@ -262,7 +287,7 @@ export class AlbionRankUpVoteService {
       vote.provisionalSince = null;
       vote.provisionalNote = null;
       await this.voteRepository.getEntityManager().persist(vote).flush();
-      await this.refreshScoreLine(vote, message);
+      await this.repaint(vote, message, rerender);
       return;
     }
 
@@ -280,7 +305,28 @@ export class AlbionRankUpVoteService {
       return;
     }
 
-    await this.refreshScoreLine(vote, message);
+    await this.repaint(vote, message, rerender);
+  }
+
+  private async repaint(vote: AlbionRankUpVoteEntity, message: Message, rerender: boolean): Promise<void> {
+    if (!rerender) {
+      await this.refreshScoreLine(vote, message);
+      return;
+    }
+
+    try {
+      const content = await this.rankUpService.renderBallot(vote, this.scoreLine(vote));
+
+      if (content !== message.content) {
+        this.lastScoreEdit.set(vote.id, Date.now());
+        await message.edit(content);
+      }
+    }
+    catch (err) {
+      // Falling back keeps the score correct even when a full render cannot be produced
+      this.logger.warn(`Could not re-render ballot ${vote.messageId}, updating the score only: ${err.message}`);
+      await this.refreshScoreLine(vote, message);
+    }
   }
 
   determineOutcome(
@@ -314,17 +360,18 @@ export class AlbionRankUpVoteService {
     return Date.now() - vote.provisionalSince.getTime() >= PROVISIONAL_HOLD_MS;
   }
 
-  scoreLine(vote: AlbionRankUpVoteEntity, recalculating = false): string {
-    const base = scoreHeading(vote.score, vote.requiredScore, recalculating);
+  scoreLine(vote: AlbionRankUpVoteEntity, secondsLeft?: number): string {
+    const base = scoreHeading(vote.score, vote.requiredScore, secondsLeft);
 
     if (!vote.provisionalStatus || !vote.provisionalSince) {
       return base;
     }
 
     const locksAt = new Date(vote.provisionalSince.getTime() + PROVISIONAL_HOLD_MS);
+    // Carries the outcome's own emoji, so which way the hold is going reads at a glance
     const verb = {
-      [AlbionRankUpVoteStatus.PASSED]: 'pass',
-      [AlbionRankUpVoteStatus.VETOED]: 'be vetoed',
+      [AlbionRankUpVoteStatus.PASSED]: '✅ pass',
+      [AlbionRankUpVoteStatus.VETOED]: `${VOTE_VETO} be vetoed`,
       [AlbionRankUpVoteStatus.FAILED]: 'fail',
     }[vote.provisionalStatus] ?? 'close';
 
@@ -375,40 +422,6 @@ export class AlbionRankUpVoteService {
     for (const vote of open) {
       await this.evaluate(vote);
     }
-  }
-
-  // A pending row with no messageId is a ballot that was never posted: the insert claimed the
-  // member's slot and something failed before the send. Nothing else ever clears it, so the member
-  // stays locked out and is eventually timed out for a vote nobody could see.
-  // announcedAt is stamped alongside resolvedAt so the reconcile sweep doesn't try to post an
-  // outcome for a message that never existed.
-  async reclaimUnposted(discordId?: string): Promise<number> {
-    const connection = this.voteRepository.getEntityManager().getConnection();
-    const now = new Date();
-    const cutoff = new Date(Date.now() - UNPOSTED_GRACE_MS);
-
-    const result = await connection.execute(
-      `update albion_rank_up_vote_entity
-          set status = ?, pending_key = null, resolved_at = ?, announced_at = ?,
-              resolution_note = ?, updated_at = ?
-        where status = ? and message_id is null and created_at <= ?
-          ${discordId ? 'and discord_id = ?' : ''}`,
-      [
-        AlbionRankUpVoteStatus.ABANDONED, now, now,
-        'The ballot was never posted', now,
-        AlbionRankUpVoteStatus.PENDING, cutoff,
-        ...(discordId ? [discordId] : []),
-      ],
-      'run',
-    );
-
-    const reclaimed = this.affectedRows(result);
-
-    if (reclaimed > 0) {
-      this.logger.warn(`Reclaimed ${reclaimed} rank up ballot(s) that were never posted`);
-    }
-
-    return reclaimed;
   }
 
   // Elects a single winner in the database. Re-reading the row and checking it is still pending


### PR DESCRIPTION
## Manual steps

**None.** No new environment variables, no secrets, no migration, no compose or server changes. Deploys clean on its own.

## What this does

### The ballot re-renders

A ballot posted under older wording kept that wording for its full five days, because only the score line was ever edited. A reaction-driven recount now rebuilds the whole message from the row, so a format change reaches live votes the next time anyone reacts.

Sweep-driven recounts still touch only the score line — rewriting every open ballot once a minute would be a lot of edits for nothing. If the render throws, it falls back to updating the score line, so losing the render never costs the score.

### The refactor that made it possible

The vote runner now asks the publisher to render, which would have been a circular dependency. Broken by pulling the shared vocabulary — `scoreHeading`, `majorityScore`, the vote emoji, the hold duration — into a dependency-free `albion.ballot.text.ts`, and moving `reclaimUnposted()` to the publisher that creates those claims in the first place. The old import paths still resolve, so the existing tests moved with their methods rather than being rewritten.

### Two activity windows

```
- 📊 Activity all time registered: **26** of **60** days (43%) — 🟠 Occasional
- 📈 Activity last 14 days: **6** of **14** days (43%) — 🟠 Occasional
```

The recent window filters rows already fetched rather than issuing a second query, and never claims more days than have actually been tracked — a member with 3 days of history shows "1 of 3", not "1 of 14".

### Wording

- The hold notice carries its outcome's emoji: **✅ pass** / **⛔ be vetoed**
- `- ⛔ veto the rank up (this action needs justification with proof), this will cause the vote to fail within 1 hour.`
- `Scoring: 👍 = 1 point · 🤷 = 0.5 points · 👎 = 0 points`

## Worth knowing

Re-rendering recomputes the activity figures, so a ballot's numbers now move when someone reacts. More accurate, but they are no longer the snapshot they were when the first voter looked — the figures were always going stale over five days, so this seems the right way round.

## Validation

`pnpm lint`, `pnpm build` clean; 670 tests across 47 suites passing. The countdown ticker was verified by trace: `5s→4s→3s→2s`, a second reaction resetting to `5s`, then settling to the recounted score.