### PR TITLE
fix(albion): Stop the ballot countdown queueing behind Discord's edit limit

### DIFF
--- a/src/albion/services/albion.ballot.text.ts
+++ b/src/albion/services/albion.ballot.text.ts
@@ -23,10 +23,13 @@ export const majorityScore = (electorateSize: number): number => electorateSize 
 // looks visibly unsettled rather than silently wrong while the burst finishes
 export const RECALCULATING = 'recalculating';
 
-// How often the countdown is repainted. Every tick is a message edit, so a burst costs one edit
-// per second of the debounce. Concurrent ballots share Discord's edit budget and discord.js
-// queues rather than failing, so the worst case is a countdown that lags, not a lost update.
+// How often the countdown is checked. Cheap - a tick only edits when it crosses a mark below.
 export const RECALCULATING_TICK_MS = 1000;
+
+// Seconds-remaining marks that actually cost an edit. A per-second countdown queued behind
+// Discord's edit limit and the whole burst visibly lagged, so the countdown shows the full
+// debounce, one step, then the recount rewrites it.
+export const COUNTDOWN_MARKS = [2];
 
 // The one definition of the score line, shared with the ballot builder. Kept together with the
 // regex in the vote service, which has to match whatever this writes.

--- a/src/albion/services/albion.rank.up.service.spec.ts
+++ b/src/albion/services/albion.rank.up.service.spec.ts
@@ -708,7 +708,7 @@ describe('AlbionRankUpService', () => {
       const content = lastSentContent();
 
       expect(content).toContain('Eligible voters: 6');
-      expect(content).toContain('Passes at a score of **3.5** — a majority of 6 (6 ÷ 2 + 0.5)');
+      expect(content).toContain('Passes at a score of **3.5** — a majority of 6 (6 ÷ 2 = 3) + 0.5');
       expect(content).toContain('## 📊 Current score: 0 / 3.5');
     });
 
@@ -727,7 +727,7 @@ describe('AlbionRankUpService', () => {
 
       const content = lastSentContent();
       expect(content).toContain('Eligible voters: 7');
-      expect(content).toContain('Passes at a score of **4** — a majority of 7 (7 ÷ 2 + 0.5)');
+      expect(content).toContain('Passes at a score of **4** — a majority of 7 (7 ÷ 2 = 3.5) + 0.5');
       expect(content).toContain('## 📊 Current score: 0 / 4');
     });
 

--- a/src/albion/services/albion.rank.up.service.ts
+++ b/src/albion/services/albion.rank.up.service.ts
@@ -413,7 +413,7 @@ Please react with the following:
 Scoring: 👍 = 1 point · 🤷 = 0.5 points · 👎 = 0 points
 
 Eligible voters: ${electorateSize}
-Passes at a score of **${requiredScore}** — a majority of ${electorateSize} (${electorateSize} ÷ 2 + 0.5)
+Passes at a score of **${requiredScore}** — a majority of ${electorateSize} (${electorateSize} ÷ 2 = ${electorateSize / 2}) + 0.5
 Voting closes ${discordTime(expiresAt, 'R')}
 
 -# Every outcome, a veto included, is held for ${HOLD_HOURS} hour${HOLD_HOURS === 1 ? '' : 's'} before it locks in. Lift a veto inside that window and the vote carries on.

--- a/src/albion/services/albion.rank.up.vote.service.spec.ts
+++ b/src/albion/services/albion.rank.up.vote.service.spec.ts
@@ -8,6 +8,7 @@ import {
   majorityScore,
   PROVISIONAL_HOLD_MS,
   REACTION_DEBOUNCE_MS,
+  COUNTDOWN_MARKS,
   RECALCULATING_TICK_MS,
   scoreHeading,
   VOTE_APPROVE,
@@ -576,20 +577,30 @@ describe('AlbionRankUpVoteService', () => {
       expect(editedLines()[0]).toContain('2.5 / 4');
     });
 
-    it('counts down once a second', async () => {
+    // A per-second countdown queued behind Discord's edit limit and lagged the whole burst
+    it('spends one edit per countdown mark, not one per second', async () => {
       withBallot();
       await service.scheduleRecount(makeVote({ score: 2.5 }));
 
-      await jest.advanceTimersByTimeAsync(RECALCULATING_TICK_MS * 3);
+      await jest.advanceTimersByTimeAsync(REACTION_DEBOUNCE_MS - RECALCULATING_TICK_MS);
 
       const seconds = editedLines()
         .map((line: string) => line.match(/(\d+)s\)/)?.[1])
         .filter(Boolean)
         .map(Number);
 
-      expect(seconds.length).toBeGreaterThanOrEqual(3);
-      expect(seconds).toEqual([...seconds].sort((a, b) => b - a)); // strictly falling
-      expect(seconds[0]).toBe(REACTION_DEBOUNCE_MS / 1000);
+      expect(seconds).toEqual([REACTION_DEBOUNCE_MS / 1000, ...COUNTDOWN_MARKS]);
+    });
+
+    // Jitter must not drop a mark: a tick running late steps over it rather than landing on it
+    it('paints a mark the ticker stepped over', async () => {
+      withBallot();
+      await service.scheduleRecount(makeVote({ score: 2.5 }));
+
+      jest.setSystemTime(Date.now() + REACTION_DEBOUNCE_MS - 1500);
+      await jest.advanceTimersByTimeAsync(RECALCULATING_TICK_MS);
+
+      expect(editedLines().at(-1)).toContain(`${Math.max(...COUNTDOWN_MARKS)}s)`);
     });
 
     it('recounts when the countdown runs out, and stops painting', async () => {

--- a/src/albion/services/albion.rank.up.vote.service.ts
+++ b/src/albion/services/albion.rank.up.vote.service.ts
@@ -15,6 +15,7 @@ import { resolvePartialReaction } from '../../discord/discord.hacks';
 import { discordTime } from '../../helpers';
 import { AlbionRankUpService } from './albion.rank.up.service';
 import {
+  COUNTDOWN_MARKS,
   PROVISIONAL_HOLD_MS,
   RECALCULATING_TICK_MS,
   scoreHeading,
@@ -26,6 +27,7 @@ import {
 
 // Re-exported so callers have one place to import ballot vocabulary from
 export {
+  COUNTDOWN_MARKS,
   majorityScore,
   UNPOSTED_GRACE_MS,
   PROVISIONAL_HOLD_MS,
@@ -63,6 +65,7 @@ export const REACTION_DEBOUNCE_MS = 5 * 1000;
 interface PendingRecount {
   deadline: number;
   timer: NodeJS.Timeout;
+  painted: Set<number>; // Marks already shown, so a mark costs one edit however often we tick
   message?: Message;
 }
 
@@ -138,18 +141,19 @@ export class AlbionRankUpVoteService {
 
     if (pending) {
       pending.deadline = deadline;
-      await this.paintCountdown(vote, pending);
+      pending.painted.clear(); // The clock restarted, so the marks are due again
+      await this.paintCountdown(vote, pending, REACTION_DEBOUNCE_MS / 1000);
       return;
     }
 
     const timer = setInterval(() => void this.tick(vote), RECALCULATING_TICK_MS);
     timer.unref?.(); // Must not hold the process open on shutdown
 
-    const started: PendingRecount = { deadline, timer };
+    const started: PendingRecount = { deadline, timer, painted: new Set() };
     this.pendingRecounts.set(vote.id, started);
 
     // Painted immediately rather than waiting a tick, so the ballot reacts at once
-    await this.paintCountdown(vote, started);
+    await this.paintCountdown(vote, started, REACTION_DEBOUNCE_MS / 1000);
   }
 
   private async tick(vote: AlbionRankUpVoteEntity): Promise<void> {
@@ -166,16 +170,25 @@ export class AlbionRankUpVoteService {
       return;
     }
 
-    await this.paintCountdown(vote, pending);
+    // Crossed rather than equalled: a tick that runs late must still paint the mark it stepped
+    // over, or timer jitter silently drops it and the countdown appears to stall.
+    const secondsLeft = (pending.deadline - Date.now()) / 1000;
+    const due = COUNTDOWN_MARKS.find(mark => secondsLeft <= mark && !pending.painted.has(mark));
+
+    if (due === undefined) {
+      return;
+    }
+
+    pending.painted.add(due);
+    await this.paintCountdown(vote, pending, due);
   }
 
   // Repaints the score line with the time left. The ballot is fetched once per burst and reused,
-  // so a countdown costs one fetch and a handful of edits rather than a fetch per tick.
-  private async paintCountdown(vote: AlbionRankUpVoteEntity, pending: PendingRecount): Promise<void> {
+  // so a countdown costs one fetch and one edit per mark rather than a fetch per tick.
+  private async paintCountdown(vote: AlbionRankUpVoteEntity, pending: PendingRecount, secondsLeft: number): Promise<void> {
     try {
       pending.message ??= await this.fetchBallot(vote);
 
-      const secondsLeft = (pending.deadline - Date.now()) / 1000;
       const updated = pending.message.content.replace(SCORE_LINE, this.scoreLine(vote, secondsLeft));
 
       if (updated !== pending.message.content) {


### PR DESCRIPTION
## Manual steps

**None.** No environment variables, secrets, migrations or server changes. Deploys clean on its own.

## The countdown

Painting every second meant five edits per burst. They queued behind Discord's edit limit and the whole debounce visibly lagged — the thing the debounce exists to avoid.

The ticker still runs once a second, but that is now just a clock: it only spends an edit when it crosses a mark.

```
5s  →  2s  →  (the recount rewrites the line)
```

Two edits per burst instead of five.

Marks are **crossed, not equalled** — a tick that runs late steps over 2s rather than landing on it, and matching on equality would drop the paint to timer jitter and leave the countdown looking stalled. Each mark is remembered per burst, so it costs one edit however often the ticker fires; a new reaction clears the marks, so the restarted clock shows the full debounce again.

`COUNTDOWN_MARKS` sits with the other ballot constants, so the cadence is one line to change if two edits still queue.

## The majority line

```
Passes at a score of **4** — a majority of 7 (7 ÷ 2 = 3.5) + 0.5
```

## Validation

`pnpm lint` and `pnpm build` clean; 671 tests across 47 suites passing. New coverage: one edit per mark rather than one per second, and a mark the ticker stepped over still gets painted.