### PR TITLE
fix(albion): Replace the ballot countdown on each reaction rather than extending it

### DIFF
--- a/src/albion/services/albion.rank.up.vote.service.spec.ts
+++ b/src/albion/services/albion.rank.up.vote.service.spec.ts
@@ -620,7 +620,7 @@ describe('AlbionRankUpVoteService', () => {
       expect(evaluate).toHaveBeenCalledTimes(1);
     });
 
-    // A reaction mid countdown extends it rather than starting a second ticker
+    // A reaction mid countdown replaces the countdown rather than starting a second ticker
     it('restarts the countdown when another reaction lands', async () => {
       withBallot();
       const vote = makeVote({ score: 2.5 });
@@ -639,6 +639,25 @@ describe('AlbionRankUpVoteService', () => {
       expect(evaluate).toHaveBeenCalledTimes(1);
     });
 
+    // The replaced ticker kept its own phase, so an extended countdown fired late and off-step
+    it('runs the replacement countdown from the reaction that replaced it', async () => {
+      withBallot();
+      const vote = makeVote({ score: 2.5 });
+      voteRepository.findOne.mockResolvedValue(vote);
+      const evaluate = jest.spyOn(service, 'evaluate').mockResolvedValue(undefined);
+
+      await service.scheduleRecount(vote);
+      await jest.advanceTimersByTimeAsync(RECALCULATING_TICK_MS * 3);
+      await service.scheduleRecount(vote);
+
+      // The original deadline has now passed, and must not be what fires
+      await jest.advanceTimersByTimeAsync(RECALCULATING_TICK_MS * 3);
+      expect(evaluate).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(RECALCULATING_TICK_MS * 2);
+      expect(evaluate).toHaveBeenCalledTimes(1);
+    });
+
     // One fetch per burst, not one per tick - the countdown must not cost a REST call a second
     it('fetches the ballot once for the whole countdown', async () => {
       withBallot();
@@ -647,6 +666,48 @@ describe('AlbionRankUpVoteService', () => {
 
       const channel = await discordService.getTextChannel();
       expect(channel.messages.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    // Replacing must not cost a REST call either - the fetched ballot carries across
+    it('reuses the fetched ballot when the countdown is replaced', async () => {
+      withBallot();
+      const vote = makeVote({ score: 2.5 });
+
+      await service.scheduleRecount(vote);
+      await jest.advanceTimersByTimeAsync(RECALCULATING_TICK_MS * 3);
+      await service.scheduleRecount(vote);
+
+      const channel = await discordService.getTextChannel();
+      expect(channel.messages.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    // Otherwise the old paint lands after the new one and the ballot shows the wrong time left
+    it('discards a paint from a countdown that was replaced mid flight', async () => {
+      const message = makeMessage({}, scoreHeading(2.5, 4));
+      messageEdit.mockImplementation(async (updated: string) => {
+        message.content = updated;
+        return message;
+      });
+
+      const waiting: Array<(m: any) => void> = [];
+      const slowFetch = jest.fn().mockImplementation(() => new Promise((resolve) => waiting.push(resolve)));
+      discordService.getTextChannel = jest.fn().mockResolvedValue({
+        id: 'chan-1', send: channelSend, messages: { fetch: slowFetch },
+      });
+
+      const vote = makeVote({ score: 2.5 });
+      const stalled = service.scheduleRecount(vote); // Blocks on its fetch
+      await Promise.resolve();
+      const replacement = service.scheduleRecount(vote); // Replaces it, blocks on its own
+      await Promise.resolve();
+
+      waiting[0](message); // The replaced countdown comes back first
+      await stalled;
+      expect(messageEdit).not.toHaveBeenCalled();
+
+      waiting[1](message);
+      await replacement;
+      expect(messageEdit).toHaveBeenCalledTimes(1);
     });
 
     it('clears the marker when the recount lands', async () => {

--- a/src/albion/services/albion.rank.up.vote.service.ts
+++ b/src/albion/services/albion.rank.up.vote.service.ts
@@ -132,24 +132,27 @@ export class AlbionRankUpVoteService {
     }
   }
 
-  // Each new reaction pushes the deadline back, so a burst produces one tally once it settles.
-  // A reaction arriving mid countdown extends it rather than starting a second one.
+  // A burst produces one tally once it settles: each reaction replaces the countdown outright
+  // rather than pushing the old one's deadline back. The ticker closes over the vote row and
+  // keeps whatever phase it started on, so an extended countdown paints a stale score and fires
+  // late. The fetched ballot carries across, so replacing costs no extra REST call.
   // The timer is in process and lost on restart; resyncPending() in the sweep is the backstop.
   async scheduleRecount(vote: AlbionRankUpVoteEntity): Promise<void> {
-    const deadline = Date.now() + REACTION_DEBOUNCE_MS;
-    const pending = this.pendingRecounts.get(vote.id);
+    const previous = this.pendingRecounts.get(vote.id);
 
-    if (pending) {
-      pending.deadline = deadline;
-      pending.painted.clear(); // The clock restarted, so the marks are due again
-      await this.paintCountdown(vote, pending, REACTION_DEBOUNCE_MS / 1000);
-      return;
+    if (previous) {
+      clearInterval(previous.timer);
     }
 
     const timer = setInterval(() => void this.tick(vote), RECALCULATING_TICK_MS);
     timer.unref?.(); // Must not hold the process open on shutdown
 
-    const started: PendingRecount = { deadline, timer, painted: new Set() };
+    const started: PendingRecount = {
+      deadline: Date.now() + REACTION_DEBOUNCE_MS,
+      timer,
+      painted: new Set(),
+      message: previous?.message,
+    };
     this.pendingRecounts.set(vote.id, started);
 
     // Painted immediately rather than waiting a tick, so the ballot reacts at once
@@ -188,6 +191,12 @@ export class AlbionRankUpVoteService {
   private async paintCountdown(vote: AlbionRankUpVoteEntity, pending: PendingRecount, secondsLeft: number): Promise<void> {
     try {
       pending.message ??= await this.fetchBallot(vote);
+
+      // Discarded if this countdown was replaced while the fetch was in flight - otherwise a
+      // paint from the old one lands after the new one and the ballot shows the wrong time left
+      if (this.pendingRecounts.get(vote.id) !== pending) {
+        return;
+      }
 
       const updated = pending.message.content.replace(SCORE_LINE, this.scoreLine(vote, secondsLeft));
 


### PR DESCRIPTION
## Manual steps

**None.** No environment variables, secrets, migrations or server changes. Deploys clean on its own.

## What was wrong

A reaction landing mid-countdown pushed the existing countdown's deadline back. That looked equivalent to starting a fresh one, and it isn't — two things carry over that shouldn't:

- **The ticker's phase.** The interval keeps firing on the schedule the *first* reaction set, so the replacement countdown is checked off-step: the 2s mark gets painted when it isn't really 2s left, and the recount fires up to a tick after the deadline it advertised.
- **The vote row.** The ticker closes over the entity from the first reaction. Later reactions pass a freshly-read row with the current score, but the countdown keeps painting from the stale one.

## What it does now

Each reaction clears the old timer and starts a fresh countdown outright. The fetched ballot carries across, so replacing costs no extra REST call.

A paint whose countdown was replaced while its fetch was in flight is now discarded — otherwise the old paint lands after the new one and the ballot sits showing the wrong time left until the next mark.

## Validation

`pnpm lint` and `pnpm build` clean; 674 tests across 47 suites passing. New coverage: the replacement countdown runs from the reaction that replaced it rather than the original deadline, a replace reuses the fetched ballot, and a paint from a replaced countdown edits nothing.