### PR TITLE
feat(general): Add /activity, reporting one member's activity and game time

### DIFF
--- a/src/albion/services/albion.rank.up.service.spec.ts
+++ b/src/albion/services/albion.rank.up.service.spec.ts
@@ -865,6 +865,11 @@ describe('AlbionRankUpService', () => {
     });
 
     it('does not let the recent window claim more days than have been tracked', async () => {
+      // Frozen: tracking starting exactly three days ago rounds up to four the moment any
+      // time passes between the mock being set and the service reading the clock
+      const frozen = Date.now();
+      const clock = jest.spyOn(Date, 'now').mockReturnValue(frozen);
+
       rollupService.getRollup.mockResolvedValue([
         { messagesSent: 5, reactionsAdded: 0, voiceMinutes: 0, date: daysAgo(1) },
       ]);
@@ -873,6 +878,8 @@ describe('AlbionRankUpService', () => {
       await service.handleRankUpRequest(member);
 
       expect(lastSentContent()).toContain('📈 Activity last 14 days: **1** of **3** days');
+
+      clock.mockRestore();
     });
 
     // The stats are server wide, and reading them as Albion-only would undercount everyone

--- a/src/albion/services/albion.rank.up.service.ts
+++ b/src/albion/services/albion.rank.up.service.ts
@@ -19,7 +19,7 @@ import {
   UNPOSTED_GRACE_MS,
   VOTE_REACTIONS,
 } from './albion.ballot.text';
-import { discordTime } from '../../helpers';
+import { activityBand, discordTime, friendlyDuration } from '../../helpers';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DENIAL_NOTICE_THROTTLE_HOURS = 24;
@@ -514,21 +514,11 @@ ${stats}`;
   }
 
   activityBand(activeDays: number, trackedDays: number): string {
-    if (trackedDays <= 0) {
-      return '🔴 Low';
-    }
-
-    const ratio = activeDays / trackedDays;
-
-    if (ratio >= 0.75) return '🟢 Very active';
-    if (ratio >= 0.5) return '🟡 Active';
-    if (ratio >= 0.25) return '🟠 Occasional';
-    return '🔴 Low';
+    return activityBand(activeDays, trackedDays);
   }
 
   friendlyDuration(minutes: number): string {
-    const hours = Math.floor(minutes / 60);
-    return `${hours}h ${minutes % 60}m`;
+    return friendlyDuration(minutes);
   }
 
   friendlyRank(roleName: string): string {

--- a/src/general/commands/activity.command.spec.ts
+++ b/src/general/commands/activity.command.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Test } from '@nestjs/testing';
+import { MessageFlags } from 'discord.js';
 import { TestBootstrapper } from '../../test.bootstrapper';
 import { ActivityCommand } from './activity.command';
 import { MemberActivityReportService } from '../services/member.activity.report.service';
@@ -34,12 +35,11 @@ describe('ActivityCommand', () => {
     dto = { member: mockDiscordUser.user };
   });
 
-  it('replies publicly with the summary and follows up with the games', async () => {
+  it('replies with the summary and follows up with the games', async () => {
     const result = await command.onActivityCommand(dto, mockInteraction);
 
-    expect(mockInteraction[0].deferReply).toHaveBeenCalledWith();
     expect(mockInteraction[0].editReply).toHaveBeenCalledWith('the summary');
-    expect(mockInteraction[0].followUp).toHaveBeenCalledWith('the games');
+    expect(mockInteraction[0].followUp).toHaveBeenCalledWith(expect.objectContaining({ content: 'the games' }));
     expect(result).toBe('the summary');
   });
 
@@ -48,8 +48,34 @@ describe('ActivityCommand', () => {
 
     await command.onActivityCommand(dto, mockInteraction);
 
-    expect(mockInteraction[0].followUp).toHaveBeenNthCalledWith(1, 'two');
-    expect(mockInteraction[0].followUp).toHaveBeenNthCalledWith(2, 'three');
+    expect(mockInteraction[0].followUp).toHaveBeenNthCalledWith(1, expect.objectContaining({ content: 'two' }));
+    expect(mockInteraction[0].followUp).toHaveBeenNthCalledWith(2, expect.objectContaining({ content: 'three' }));
+  });
+
+  describe('visibility', () => {
+    // A follow-up does not inherit the reply's privacy, so both have to carry the flag
+    it('keeps the whole report private when show-in-channel is not set', async () => {
+      await command.onActivityCommand(dto, mockInteraction);
+
+      expect(mockInteraction[0].deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+      expect(mockInteraction[0].followUp).toHaveBeenCalledWith({
+        content: 'the games',
+        flags: MessageFlags.Ephemeral,
+      });
+    });
+
+    it('posts the whole report to the channel when show-in-channel is true', async () => {
+      await command.onActivityCommand({ ...dto, showInChannel: true }, mockInteraction);
+
+      expect(mockInteraction[0].deferReply).toHaveBeenCalledWith({});
+      expect(mockInteraction[0].followUp).toHaveBeenCalledWith({ content: 'the games' });
+    });
+
+    it('stays private when the option is explicitly false', async () => {
+      await command.onActivityCommand({ ...dto, showInChannel: false }, mockInteraction);
+
+      expect(mockInteraction[0].deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    });
   });
 
   it('passes the resolved guild member to the report', async () => {

--- a/src/general/commands/activity.command.spec.ts
+++ b/src/general/commands/activity.command.spec.ts
@@ -1,0 +1,80 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Test } from '@nestjs/testing';
+import { TestBootstrapper } from '../../test.bootstrapper';
+import { ActivityCommand } from './activity.command';
+import { MemberActivityReportService } from '../services/member.activity.report.service';
+
+describe('ActivityCommand', () => {
+  let command: ActivityCommand;
+  let reportService: MemberActivityReportService;
+  let mockInteraction: any;
+  let mockDiscordUser: any;
+  let dto: any;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        ActivityCommand,
+        {
+          provide: MemberActivityReportService,
+          useValue: {
+            buildReport: jest.fn().mockResolvedValue(['the summary', 'the games']),
+          },
+        },
+      ],
+    }).compile();
+
+    command = moduleRef.get<ActivityCommand>(ActivityCommand);
+    reportService = moduleRef.get<MemberActivityReportService>(MemberActivityReportService);
+
+    mockDiscordUser = TestBootstrapper.getMockDiscordUser();
+    mockInteraction = TestBootstrapper.getMockDiscordInteraction('123456789', mockDiscordUser);
+    mockInteraction[0].deferred = true;
+    mockInteraction[0].followUp = jest.fn();
+    dto = { member: mockDiscordUser.user };
+  });
+
+  it('replies publicly with the summary and follows up with the games', async () => {
+    const result = await command.onActivityCommand(dto, mockInteraction);
+
+    expect(mockInteraction[0].deferReply).toHaveBeenCalledWith();
+    expect(mockInteraction[0].editReply).toHaveBeenCalledWith('the summary');
+    expect(mockInteraction[0].followUp).toHaveBeenCalledWith('the games');
+    expect(result).toBe('the summary');
+  });
+
+  it('sends every message the report produced', async () => {
+    (reportService.buildReport as jest.Mock).mockResolvedValue(['one', 'two', 'three']);
+
+    await command.onActivityCommand(dto, mockInteraction);
+
+    expect(mockInteraction[0].followUp).toHaveBeenNthCalledWith(1, 'two');
+    expect(mockInteraction[0].followUp).toHaveBeenNthCalledWith(2, 'three');
+  });
+
+  it('passes the resolved guild member to the report', async () => {
+    const member = { displayName: 'Mock Member' };
+    mockInteraction[0].guild.members.fetch = jest.fn().mockResolvedValue(member);
+
+    await command.onActivityCommand(dto, mockInteraction);
+
+    expect(reportService.buildReport).toHaveBeenCalledWith(dto.member, member);
+  });
+
+  it('still reports on a member who has left the server', async () => {
+    mockInteraction[0].guild.members.fetch = jest.fn().mockRejectedValue(new Error('Unknown Member'));
+
+    await command.onActivityCommand(dto, mockInteraction);
+
+    expect(reportService.buildReport).toHaveBeenCalledWith(dto.member, null);
+  });
+
+  it('surfaces a report failure instead of leaving the interaction hanging', async () => {
+    (reportService.buildReport as jest.Mock).mockRejectedValue(new Error('database is on fire'));
+
+    const result = await command.onActivityCommand(dto, mockInteraction);
+
+    expect(result).toContain('⛔️ **ERROR:**');
+    expect(result).toContain('database is on fire');
+  });
+});

--- a/src/general/commands/activity.command.ts
+++ b/src/general/commands/activity.command.ts
@@ -26,7 +26,11 @@ export class ActivityCommand {
     // Private unless asked for, so running one on someone doesn't put it in front of the channel
     // by accident. necord ignores DTO field initialisers, so an omitted option arrives as null.
     const showInChannel = dto.showInChannel ?? false;
-    const privately = showInChannel ? {} : { flags: MessageFlags.Ephemeral };
+    // Typed, not inferred: a ternary through a const widens the flag to MessageFlags, and both
+    // call sites want the narrower Ephemeral-only union
+    const privately: { flags?: MessageFlags.Ephemeral } = showInChannel
+      ? {}
+      : { flags: MessageFlags.Ephemeral };
 
     // Deferred because the report hits the database several times, which blows Discord's 3s window
     await interaction.deferReply(privately);

--- a/src/general/commands/activity.command.ts
+++ b/src/general/commands/activity.command.ts
@@ -1,6 +1,6 @@
 import { Context, Options, SlashCommand, SlashCommandContext } from 'necord';
 import { Injectable, Logger } from '@nestjs/common';
-import { GuildMember } from 'discord.js';
+import { GuildMember, MessageFlags } from 'discord.js';
 import { ActivityDto } from '../dto/activity.dto';
 import { MemberActivityReportService } from '../services/member.activity.report.service';
 import { replyTo } from '../../discord/discord.hacks';
@@ -23,9 +23,13 @@ export class ActivityCommand {
   ): Promise<string> {
     this.logger.log(`Received Activity Command for ${dto.member.id}`);
 
-    // Deliberately public - the whole point is that the report is visible to the channel.
-    // Deferred because the report hits the database several times, which blows Discord's 3s window.
-    await interaction.deferReply();
+    // Private unless asked for, so running one on someone doesn't put it in front of the channel
+    // by accident. necord ignores DTO field initialisers, so an omitted option arrives as null.
+    const showInChannel = dto.showInChannel ?? false;
+    const privately = showInChannel ? {} : { flags: MessageFlags.Ephemeral };
+
+    // Deferred because the report hits the database several times, which blows Discord's 3s window
+    await interaction.deferReply(privately);
 
     // A leaver still has an activity record worth reading, so a missing member is not an error
     let member: GuildMember | null = null;
@@ -43,9 +47,10 @@ export class ActivityCommand {
       await replyTo(interaction, summary);
 
       // Each message carries its own 2000 character budget, so the game list can't cost
-      // the summary its place. Sent in order rather than in parallel.
+      // the summary its place. Sent in order rather than in parallel. A follow-up does not
+      // inherit the reply's privacy, so the flag has to be repeated or the games go public.
       for (const message of rest) {
-        await interaction.followUp(message);
+        await interaction.followUp({ content: message, ...privately });
       }
 
       return summary;

--- a/src/general/commands/activity.command.ts
+++ b/src/general/commands/activity.command.ts
@@ -1,0 +1,58 @@
+import { Context, Options, SlashCommand, SlashCommandContext } from 'necord';
+import { Injectable, Logger } from '@nestjs/common';
+import { GuildMember } from 'discord.js';
+import { ActivityDto } from '../dto/activity.dto';
+import { MemberActivityReportService } from '../services/member.activity.report.service';
+import { replyTo } from '../../discord/discord.hacks';
+
+@Injectable()
+export class ActivityCommand {
+  private readonly logger = new Logger(ActivityCommand.name);
+
+  constructor(
+    private readonly memberActivityReportService: MemberActivityReportService,
+  ) {}
+
+  @SlashCommand({
+    name: 'activity',
+    description: 'Show a member\'s activity record and game activity summary.',
+  })
+  async onActivityCommand(
+    @Options() dto: ActivityDto,
+    @Context() [interaction]: SlashCommandContext,
+  ): Promise<string> {
+    this.logger.log(`Received Activity Command for ${dto.member.id}`);
+
+    // Deliberately public - the whole point is that the report is visible to the channel.
+    // Deferred because the report hits the database several times, which blows Discord's 3s window.
+    await interaction.deferReply();
+
+    // A leaver still has an activity record worth reading, so a missing member is not an error
+    let member: GuildMember | null = null;
+
+    try {
+      member = await interaction.guild?.members.fetch(dto.member.id) ?? null;
+    }
+    catch {
+      this.logger.log(`${dto.member.id} is not a member of the guild, reporting without server context`);
+    }
+
+    try {
+      const [summary, ...rest] = await this.memberActivityReportService.buildReport(dto.member, member);
+
+      await replyTo(interaction, summary);
+
+      // Each message carries its own 2000 character budget, so the game list can't cost
+      // the summary its place. Sent in order rather than in parallel.
+      for (const message of rest) {
+        await interaction.followUp(message);
+      }
+
+      return summary;
+    }
+    catch (err) {
+      this.logger.error(err.message);
+      return replyTo(interaction, `⛔️ **ERROR:** Could not build the activity report. Err: ${err.message}`);
+    }
+  }
+}

--- a/src/general/dto/activity.dto.ts
+++ b/src/general/dto/activity.dto.ts
@@ -1,4 +1,4 @@
-import { UserOption } from 'necord';
+import { BooleanOption, UserOption } from 'necord';
 import { User } from 'discord.js';
 
 export class ActivityDto {
@@ -8,4 +8,13 @@ export class ActivityDto {
     required: true,
   })
   member: User;
+
+  @BooleanOption({
+    name: 'show-in-channel',
+    description:
+      'Post the report in this channel for everyone to see. Leave unset and only you will see it.',
+    required: false,
+  })
+  // Defaulted at the use site — necord ignores field initialisers on option DTOs.
+  showInChannel: boolean;
 }

--- a/src/general/dto/activity.dto.ts
+++ b/src/general/dto/activity.dto.ts
@@ -1,0 +1,11 @@
+import { UserOption } from 'necord';
+import { User } from 'discord.js';
+
+export class ActivityDto {
+  @UserOption({
+    name: 'member',
+    description: 'Discord member to report on.',
+    required: true,
+  })
+  member: User;
+}

--- a/src/general/general.module.ts
+++ b/src/general/general.module.ts
@@ -18,7 +18,9 @@ import { RoleMetricsService } from './services/role.metrics.service';
 import { RecRolePingService } from './services/rec.role.ping.service';
 import { HealthcheckService } from './services/healthcheck.service';
 import { MemberActivityRollupService } from './services/member.activity.rollup.service';
+import { MemberActivityReportService } from './services/member.activity.report.service';
 import { MemberPresenceCronService } from './services/member.presence.cron.service';
+import { ActivityCommand } from './commands/activity.command';
 
 @Module({
   imports: [
@@ -32,11 +34,13 @@ import { MemberPresenceCronService } from './services/member.presence.cron.servi
     DiscordService,
     HealthcheckService,
     JoinerLeaverService,
+    MemberActivityReportService,
     MemberActivityRollupService,
     RecRolePingService,
     RoleMetricsService,
 
     // Commands
+    ActivityCommand,
     ActivityReportCommand,
     HelloThereCommand,
     PingCommand,

--- a/src/general/services/member.activity.report.service.spec.ts
+++ b/src/general/services/member.activity.report.service.spec.ts
@@ -1,0 +1,222 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@mikro-orm/nestjs';
+import { MemberActivityReportService } from './member.activity.report.service';
+import { MemberActivityRollupService } from './member.activity.rollup.service';
+import { ActivityEntity } from '../../database/entities/activity.entity';
+import { utcMidnight } from '../../helpers';
+
+describe('MemberActivityReportService', () => {
+  let service: MemberActivityReportService;
+  let activityRepository: any;
+  let rollupService: any;
+
+  const daysAgo = (days: number) => new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+  const mockUser = { id: '1234567890', username: 'mockuser' } as any;
+  const mockMember = (joinedAt: Date | null = daysAgo(200)) => ({
+    displayName: 'Mock Member',
+    joinedAt,
+  }) as any;
+
+  const rollupRow = (date: Date, messagesSent = 0, reactionsAdded = 0, voiceMinutes = 0) => ({
+    date,
+    messagesSent,
+    reactionsAdded,
+    voiceMinutes,
+  }) as any;
+
+  beforeEach(async () => {
+    activityRepository = { findOne: jest.fn().mockResolvedValue(null) };
+    rollupService = {
+      getTrackingStartDate: jest.fn().mockResolvedValue(daysAgo(100)),
+      getRollup: jest.fn().mockResolvedValue([]),
+      getGameTotals: jest.fn().mockResolvedValue([]),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MemberActivityReportService,
+        { provide: getRepositoryToken(ActivityEntity), useValue: activityRepository },
+        { provide: MemberActivityRollupService, useValue: rollupService },
+      ],
+    }).compile();
+
+    service = module.get<MemberActivityReportService>(MemberActivityReportService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('windowStart', () => {
+    it('measures from tracking start when the member predates it', () => {
+      const trackingStart = utcMidnight(daysAgo(100));
+
+      expect(service.windowStart(trackingStart, daysAgo(300))).toEqual(trackingStart);
+    });
+
+    it('measures from the join date when the member joined after tracking began', () => {
+      const joinedAt = daysAgo(10);
+
+      expect(service.windowStart(utcMidnight(daysAgo(100)), joinedAt)).toEqual(utcMidnight(joinedAt));
+    });
+
+    it('falls back to today when nothing has ever been tracked', () => {
+      expect(service.windowStart(null, null)).toEqual(utcMidnight());
+    });
+  });
+
+  describe('buildReport', () => {
+    it('returns the summary and the games as separate messages', async () => {
+      const [summary, games] = await service.buildReport(mockUser, mockMember());
+
+      expect(summary).toContain('### Engagement');
+      expect(summary).not.toContain('### 🎮 Game Activity');
+      expect(games).toContain('### 🎮 Game Activity');
+    });
+
+    it('reports the member name, mention and join date', async () => {
+      const [summary] = await service.buildReport(mockUser, mockMember(daysAgo(5)));
+
+      expect(summary).toContain('# 📊 Activity Report: Mock Member');
+      expect(summary).toContain('<@1234567890>');
+      expect(summary).toContain('Joined the server:');
+      expect(summary).toContain('**5** days ago');
+    });
+
+    it('falls back to the username when the member has left the server', async () => {
+      const [summary] = await service.buildReport(mockUser, null);
+
+      expect(summary).toContain('# 📊 Activity Report: mockuser');
+      expect(summary).toContain('Not currently a member of this server.');
+    });
+
+    it('shows the last activity timestamp when one is recorded', async () => {
+      const lastActivity = daysAgo(2);
+      activityRepository.findOne.mockResolvedValue({ lastActivity } as ActivityEntity);
+
+      const [summary] = await service.buildReport(mockUser, mockMember());
+
+      expect(summary).toContain(`<t:${Math.floor(lastActivity.getTime() / 1000)}:R>`);
+    });
+
+    it('says so plainly when nothing has ever been seen from them', async () => {
+      const [summary] = await service.buildReport(mockUser, mockMember());
+
+      expect(summary).toContain('Last seen: **never recorded**');
+    });
+
+    // The live record is deleted on guildMemberRemove, so a leaver has rollups but no record
+    it('falls back to the last active rollup day when the live record has been deleted', async () => {
+      const lastActive = daysAgo(3);
+      rollupService.getRollup.mockResolvedValue([
+        rollupRow(daysAgo(9), 4),
+        rollupRow(lastActive, 1),
+        rollupRow(daysAgo(1), 0, 0, 0),
+      ]);
+
+      const [summary] = await service.buildReport(mockUser, null);
+
+      expect(summary).toContain(`on or around <t:${Math.floor(lastActive.getTime() / 1000)}:D>`);
+      expect(summary).not.toContain('never recorded');
+    });
+
+    it('totals the engagement counters and bands the active days', async () => {
+      rollupService.getTrackingStartDate.mockResolvedValue(utcMidnight(daysAgo(4)));
+      rollupService.getRollup.mockResolvedValue([
+        rollupRow(daysAgo(3), 10, 2, 30),
+        rollupRow(daysAgo(2), 5, 1, 90),
+        rollupRow(daysAgo(1), 0, 0, 0),
+      ]);
+
+      const [summary] = await service.buildReport(mockUser, mockMember(daysAgo(300)));
+
+      expect(summary).toContain('💬 Messages: **15**');
+      expect(summary).toContain('⭐ Reactions: **3**');
+      expect(summary).toContain('🎙️ Voice: **2h 0m**');
+      // Five, not four - the day in progress counts, same as the rank up ballot
+      expect(summary).toContain('📊 Active days all time: **2** of **5** days (40%) — 🟠 Occasional');
+    });
+
+    it('flags an empty window rather than rendering zeroes', async () => {
+      const [summary] = await service.buildReport(mockUser, mockMember());
+
+      expect(summary).toContain('📭 **Nothing recorded in this window.**');
+      expect(summary).not.toContain('💬 Messages:');
+    });
+
+    it('lists games in order with their share of the total', async () => {
+      rollupService.getGameTotals.mockResolvedValue([
+        { gameName: 'Albion Online', minutes: 180 },
+        { gameName: 'Foxhole', minutes: 60 },
+      ]);
+
+      const [, games] = await service.buildReport(mockUser, mockMember());
+
+      expect(games).toContain('Total tracked game time: **4h 0m** across **2** games');
+      expect(games).toContain('**Albion Online** — 3h 0m (75%)');
+      expect(games).toContain('**Foxhole** — 1h 0m (25%)');
+    });
+
+    it('counts the tail without naming it when a member plays more than ten games', async () => {
+      rollupService.getGameTotals.mockResolvedValue(
+        Array.from({ length: 13 }, (_, index) => ({ gameName: `Game ${index}`, minutes: 10 * (13 - index) })),
+      );
+
+      const [, games] = await service.buildReport(mockUser, mockMember());
+
+      expect(games).toContain('**Game 0** — 2h 10m');
+      expect(games).toContain('**Game 9**');
+      expect(games).not.toContain('**Game 10**');
+      expect(games).toContain('…and **3** others totalling 1h 0m');
+    });
+
+    it('keeps both messages inside Discord\'s limit when game names are at their maximum length', async () => {
+      rollupService.getGameTotals.mockResolvedValue(
+        Array.from({ length: 12 }, () => ({ gameName: 'g'.repeat(128), minutes: 60 })),
+      );
+      rollupService.getRollup.mockResolvedValue([rollupRow(daysAgo(1), 10, 2, 30)]);
+
+      const [summary, games] = await service.buildReport(mockUser, mockMember());
+
+      expect(summary.length).toBeLessThanOrEqual(2000);
+      expect(games.length).toBeLessThanOrEqual(2000);
+      // Trimmed rather than dropped - the full count still appears in the total line
+      expect(games).toContain('across **12** games');
+    });
+
+    it('notes when no game activity has been recorded', async () => {
+      const [, games] = await service.buildReport(mockUser, mockMember());
+
+      expect(games).toContain('📭 **No game activity recorded.**');
+    });
+
+    it('says tracking is empty when nothing has been recorded for anyone', async () => {
+      rollupService.getTrackingStartDate.mockResolvedValue(null);
+
+      const [summary] = await service.buildReport(mockUser, mockMember());
+
+      expect(summary).toContain('Activity tracking has not recorded anything yet, for anyone.');
+    });
+
+    it('attributes the window to the join date when the member joined after tracking began', async () => {
+      const [summary] = await service.buildReport(mockUser, mockMember(daysAgo(10)));
+
+      expect(summary).toContain('since they joined the server');
+    });
+
+    it('attributes the window to tracking start when the member predates it', async () => {
+      const [summary] = await service.buildReport(mockUser, mockMember(daysAgo(300)));
+
+      expect(summary).toContain('since tracking began');
+    });
+
+    it('queries both rollups from the same window start', async () => {
+      await service.buildReport(mockUser, mockMember(daysAgo(10)));
+
+      const since = rollupService.getRollup.mock.calls[0][1];
+      expect(rollupService.getGameTotals).toHaveBeenCalledWith('1234567890', since);
+    });
+  });
+});

--- a/src/general/services/member.activity.report.service.ts
+++ b/src/general/services/member.activity.report.service.ts
@@ -1,0 +1,201 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { EntityRepository } from '@mikro-orm/core';
+import { GuildMember, User } from 'discord.js';
+import { ActivityEntity } from '../../database/entities/activity.entity';
+import { GameTotal, MemberActivityRollupService } from './member.activity.rollup.service';
+import { MemberDailyActivityEntity } from '../../database/entities/member.daily.activity.entity';
+import { activityBand, discordTime, friendlyDuration, utcMidnight } from '../../helpers';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const RECENT_WINDOW_DAYS = 14;
+const MAX_GAMES_LISTED = 10;
+// Discord rejects a message over 2000 characters outright, and game names run to 128 each
+const REPORT_CHAR_BUDGET = 1900;
+
+const GAME_FOOTNOTE = [
+  '-# Game time is sampled from Discord presence — it only counts when the member has Discord open with game activity sharing enabled, so a low figure may reflect settings rather than inactivity.',
+];
+
+const isActiveDay = (row: MemberDailyActivityEntity): boolean =>
+  row.messagesSent > 0 || row.reactionsAdded > 0 || row.voiceMinutes > 0;
+
+@Injectable()
+export class MemberActivityReportService {
+  private readonly logger = new Logger(MemberActivityReportService.name);
+
+  constructor(
+    @InjectRepository(ActivityEntity) private readonly activityRepository: EntityRepository<ActivityEntity>,
+    private readonly rollupService: MemberActivityRollupService,
+  ) {}
+
+  // Two messages, not one: the summary and the game list each have their own 2000 character
+  // budget, so a member with a long game list can't cost them their activity figures.
+  async buildReport(user: User, member: GuildMember | null): Promise<string[]> {
+    const discordId = user.id;
+    this.logger.log(`Building activity report for ${discordId}`);
+
+    const record = await this.activityRepository.findOne({ discordId });
+    const trackingStart = await this.rollupService.getTrackingStartDate();
+    const joinedAt = member?.joinedAt ?? null;
+
+    // Figures are only meaningful from the later of "tracking existed" and "they were here".
+    // Measuring from tracking start alone would score a recent joiner against days they missed.
+    const since = this.windowStart(trackingStart, joinedAt);
+
+    const rollup = await this.rollupService.getRollup(discordId, since);
+    const gameTotals = await this.rollupService.getGameTotals(discordId, since);
+    const trackedDays = Math.max(1, Math.ceil((Date.now() - since.getTime()) / DAY_MS));
+
+    const summary = [
+      `# 📊 Activity Report: ${member?.displayName ?? user.username}`,
+      `<@${discordId}>`,
+      '',
+      ...this.overviewLines(record, rollup, member),
+      '',
+      ...this.engagementLines(rollup, trackedDays),
+      '',
+      ...this.summaryFootnotes(trackingStart, since, trackedDays, joinedAt),
+    ].join('\n');
+
+    return [summary, this.gamesMessage(gameTotals)];
+  }
+
+  // Trims the list until it fits rather than letting Discord reject the message. Names run to
+  // 128 characters each, so ten of them is well over the limit on its own.
+  private gamesMessage(gameTotals: GameTotal[]): string {
+    for (let listed = MAX_GAMES_LISTED; listed > 0; listed--) {
+      const message = this.gameLines(gameTotals, listed).join('\n');
+
+      if (message.length <= REPORT_CHAR_BUDGET) {
+        return message;
+      }
+    }
+
+    return this.gameLines(gameTotals, 0).join('\n');
+  }
+
+  windowStart(trackingStart: Date | null, joinedAt: Date | null): Date {
+    const anchor = trackingStart ?? utcMidnight();
+    return joinedAt && joinedAt > anchor ? utcMidnight(joinedAt) : anchor;
+  }
+
+  private overviewLines(
+    record: ActivityEntity | null,
+    rollup: MemberDailyActivityEntity[],
+    member: GuildMember | null,
+  ): string[] {
+    const lines = ['### Overview'];
+
+    if (member?.joinedAt) {
+      const joinedDays = Math.floor((Date.now() - member.joinedAt.getTime()) / DAY_MS);
+      lines.push(`- 📅 Joined the server: ${discordTime(member.joinedAt, 'D')} — **${joinedDays}** day${joinedDays === 1 ? '' : 's'} ago`);
+    }
+    else {
+      lines.push('- 📅 Not currently a member of this server.');
+    }
+
+    lines.push(this.lastSeenLine(record, rollup));
+
+    return lines;
+  }
+
+  // The live record is deleted on guildMemberRemove, so a leaver with plenty of rollup history
+  // has no record at all. Saying "never recorded" there would contradict the figures below it.
+  private lastSeenLine(record: ActivityEntity | null, rollup: MemberDailyActivityEntity[]): string {
+    if (record) {
+      return `- 👀 Last seen: ${discordTime(record.lastActivity, 'R')} (${discordTime(record.lastActivity, 'f')})`;
+    }
+
+    const lastActiveDay = rollup
+      .filter(isActiveDay)
+      .reduce<Date | null>((latest, row) => !latest || row.date > latest ? row.date : latest, null);
+
+    if (lastActiveDay) {
+      return `- 👀 Last seen: on or around ${discordTime(lastActiveDay, 'D')} — there is no live record for them, which is normal once a member has left the server.`;
+    }
+
+    return '- 👀 Last seen: **never recorded** — no messages, reactions or voice have been seen from them.';
+  }
+
+  private engagementLines(rollup: MemberDailyActivityEntity[], trackedDays: number): string[] {
+    const lines = ['### Engagement'];
+
+    if (rollup.length === 0) {
+      lines.push('📭 **Nothing recorded in this window.** They may have been quiet, or simply predate what has been tracked.');
+      return lines;
+    }
+
+    const messages = rollup.reduce((total, row) => total + row.messagesSent, 0);
+    const reactions = rollup.reduce((total, row) => total + row.reactionsAdded, 0);
+    const voiceMinutes = rollup.reduce((total, row) => total + row.voiceMinutes, 0);
+
+    const activeDays = rollup.filter(isActiveDay).length;
+
+    // Filtered from the rows already fetched rather than queried again
+    const recentFrom = Date.now() - RECENT_WINDOW_DAYS * DAY_MS;
+    const recentActiveDays = rollup.filter((row) => row.date.getTime() >= recentFrom && isActiveDay(row)).length;
+
+    lines.push(
+      `- 💬 Messages: **${messages}** (${(messages / trackedDays).toFixed(1)}/day)`,
+      `- ⭐ Reactions: **${reactions}**`,
+      `- 🎙️ Voice: **${friendlyDuration(voiceMinutes)}**`,
+      this.activityLine('📊 Active days all time', activeDays, trackedDays),
+      this.activityLine(`📈 Active days last ${RECENT_WINDOW_DAYS}`, recentActiveDays, Math.min(RECENT_WINDOW_DAYS, trackedDays)),
+    );
+
+    return lines;
+  }
+
+  private gameLines(gameTotals: GameTotal[], maxListed: number): string[] {
+    const lines = ['### 🎮 Game Activity'];
+
+    if (gameTotals.length === 0) {
+      lines.push('📭 **No game activity recorded.**', ...GAME_FOOTNOTE);
+      return lines;
+    }
+
+    const totalMinutes = gameTotals.reduce((total, game) => total + game.minutes, 0);
+    const listed = gameTotals.slice(0, maxListed);
+    const share = (minutes: number) => totalMinutes > 0 ? ` (${((minutes / totalMinutes) * 100).toFixed(0)}%)` : '';
+
+    lines.push(`- 🕹️ Total tracked game time: **${friendlyDuration(totalMinutes)}** across **${gameTotals.length}** game${gameTotals.length === 1 ? '' : 's'}`);
+    lines.push(...listed.map((game) => `  - **${game.gameName}** — ${friendlyDuration(game.minutes)}${share(game.minutes)}`));
+
+    const remaining = gameTotals.slice(maxListed);
+
+    // Counted, never named - the tail exists to keep the message inside Discord's limit,
+    // and listing the names is the thing that broke the limit in the first place.
+    if (remaining.length > 0 && listed.length > 0) {
+      const remainingMinutes = remaining.reduce((total, game) => total + game.minutes, 0);
+      lines.push(`  - …and **${remaining.length}** other${remaining.length === 1 ? '' : 's'} totalling ${friendlyDuration(remainingMinutes)}`);
+    }
+
+    lines.push(...GAME_FOOTNOTE);
+
+    return lines;
+  }
+
+  private summaryFootnotes(trackingStart: Date | null, since: Date, trackedDays: number, joinedAt: Date | null): string[] {
+    const lines: string[] = [];
+
+    if (!trackingStart) {
+      lines.push('-# Activity tracking has not recorded anything yet, for anyone.');
+    }
+    else {
+      const anchor = joinedAt && since.getTime() > trackingStart.getTime() ? 'they joined the server' : 'tracking began';
+      lines.push(`-# Figures cover the ${trackedDays} day${trackedDays === 1 ? '' : 's'} since ${anchor} (${discordTime(since, 'D')}).`);
+    }
+
+    lines.push('-# Messages, reactions and voice are counted across all channels, not filtered to one game section.');
+
+    return lines;
+  }
+
+  activityLine(label: string, activeDays: number, trackedDays: number): string {
+    const days = Math.max(1, trackedDays);
+    const percent = ((activeDays / days) * 100).toFixed(0);
+
+    return `- ${label}: **${activeDays}** of **${days}** days (${percent}%) — ${activityBand(activeDays, days)}`;
+  }
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -17,6 +17,25 @@ export const utcMidnight = (date: Date = new Date()): Date => {
 export const discordTime = (date: Date, format: 'f' | 'F' | 'D' | 'R' = 'f'): string =>
   `<t:${Math.floor(date.getTime() / 1000)}:${format}>`;
 
+export const friendlyDuration = (minutes: number): string => {
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+};
+
+// Shared by the rank up ballot and /activity so the same ratio always reads the same way
+export const activityBand = (activeDays: number, trackedDays: number): string => {
+  if (trackedDays <= 0) {
+    return '🔴 Low';
+  }
+
+  const ratio = activeDays / trackedDays;
+
+  if (ratio >= 0.75) return '🟢 Very active';
+  if (ratio >= 0.5) return '🟡 Active';
+  if (ratio >= 0.25) return '🟠 Occasional';
+  return '🔴 Low';
+};
+
 export const generateDateInPast = (daysAgo: number): Date => {
   const now = new Date();
   // Subtract daysAgo (which may be fractional) in milliseconds


### PR DESCRIPTION
## Manual steps before merging

**None.** No new environment variables, secrets, migrations or config. The command registers itself through necord like every other slash command, and it reads tables that already exist and are already being populated.

## What this adds

`/activity <member> [show-in-channel]` — takes a single Discord member and reports their activity.

**Private by default.** Unset, only the person who ran it sees the report. Pass `show-in-channel: true` to post it to the channel for everyone. The option is worded for people who have never heard the word "ephemeral". Running a report on someone can't put it in front of the channel by accident.

Two messages rather than one:

1. **Summary** — join date, last seen, messages, reactions, voice time, and active-day ratios over the tracked window, banded the same way the rank up ballot bands them.
2. **Game activity** — total tracked game time and a top ten by minutes, each with its share of the total.

The window starts at the later of "tracking began" and "they joined", so a recent joiner isn't scored against days they weren't here. Empty states are handled separately rather than rendering a wall of zeroes, which would read as a damning report when it usually just means the member predates tracking.

## Why two messages

Discord activity names run to 128 characters each. Ten of them, plus the summary and the footnotes, is a valid worst case comfortably past the 2000 character limit — at which point the send fails and the member gets a generic error instead of a report. Splitting gives each half its own budget, games past the tenth are counted but never named, and the list trims further if it still doesn't fit.

A follow-up doesn't inherit the privacy of the reply it follows, so the flag is repeated on it — otherwise the game list would go public on its own.

## Leavers

`ActivityEntity` is deleted on `guildMemberRemove`, but the daily rollups are kept. Reading last-seen only from that record meant a leaver was reported as never having been seen, printed directly above figures showing hundreds of messages. The last-seen line now falls back to the most recent active day in the rollups and says why there's no live record.

## Shared helpers

`friendlyDuration` and `activityBand` move into `helpers.ts` so the ballot and this report band the same ratio the same way. `AlbionRankUpService` keeps both methods and delegates, so nothing downstream changes.

## Unrelated fix carried here

One existing rank up ballot test mocks tracking as starting *exactly* three days ago, then asserts on a window the service computes with `Math.ceil` against a freshly read clock. Any elapsed time at all rounds it up to four days and fails the assertion. It's a latent race on `main` that only surfaces under a slower suite, which the new tests here made likelier — so the clock is now frozen for that test. No production code changed for it.

## Validation

`pnpm lint`, `pnpm build` and the full suite pass — 729 tests, 51 suites, with 28 new tests across the command and the report service. The rank up spec was run repeatedly to confirm the race is settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)