### PR TITLE
fix(general): Send the /activity game list as its own message

### DIFF
--- a/src/general/commands/activity.command.spec.ts
+++ b/src/general/commands/activity.command.spec.ts
@@ -32,10 +32,11 @@ describe('ActivityCommand', () => {
     mockInteraction = TestBootstrapper.getMockDiscordInteraction('123456789', mockDiscordUser);
     mockInteraction[0].deferred = true;
     mockInteraction[0].followUp = jest.fn();
+    mockInteraction[0].channel.isSendable = jest.fn().mockReturnValue(true);
     dto = { member: mockDiscordUser.user };
   });
 
-  it('replies with the summary and follows up with the games', async () => {
+  it('replies with the summary and sends the games after it', async () => {
     const result = await command.onActivityCommand(dto, mockInteraction);
 
     expect(mockInteraction[0].editReply).toHaveBeenCalledWith('the summary');
@@ -64,10 +65,22 @@ describe('ActivityCommand', () => {
       });
     });
 
-    it('posts the whole report to the channel when show-in-channel is true', async () => {
+    // Standalone, so the games don't hang off the reply as a chained message
+    it('sends the games as their own message when show-in-channel is true', async () => {
       await command.onActivityCommand({ ...dto, showInChannel: true }, mockInteraction);
 
       expect(mockInteraction[0].deferReply).toHaveBeenCalledWith({});
+      expect(mockInteraction[0].channel.send).toHaveBeenCalledWith('the games');
+      expect(mockInteraction[0].followUp).not.toHaveBeenCalled();
+    });
+
+    // Only a follow-up can stay private, so a private report cannot use a plain send
+    it('falls back to a follow-up when the channel cannot be sent to', async () => {
+      mockInteraction[0].channel.isSendable.mockReturnValue(false);
+
+      await command.onActivityCommand({ ...dto, showInChannel: true }, mockInteraction);
+
+      expect(mockInteraction[0].channel.send).not.toHaveBeenCalled();
       expect(mockInteraction[0].followUp).toHaveBeenCalledWith({ content: 'the games' });
     });
 

--- a/src/general/commands/activity.command.ts
+++ b/src/general/commands/activity.command.ts
@@ -50,10 +50,17 @@ export class ActivityCommand {
 
       await replyTo(interaction, summary);
 
-      // Each message carries its own 2000 character budget, so the game list can't cost
-      // the summary its place. Sent in order rather than in parallel. A follow-up does not
-      // inherit the reply's privacy, so the flag has to be repeated or the games go public.
+      // Each message carries its own 2000 character budget, so the game list can't cost the
+      // summary its place. Sent in order rather than in parallel.
       for (const message of rest) {
+        // Posted as its own message rather than chained onto the reply. A private report has
+        // no such option - only a follow-up can stay private, and it needs the flag repeated
+        // because it does not inherit the reply's.
+        if (showInChannel && interaction.channel?.isSendable()) {
+          await interaction.channel.send(message);
+          continue;
+        }
+
         await interaction.followUp({ content: message, ...privately });
       }
 


### PR DESCRIPTION
## Manual steps before merging

**None.** Behaviour-only change to how the second message of an existing command is sent.

## What changed

A public `/activity` report posted the game list with `interaction.followUp`, which Discord renders chained onto the reply. It's now sent straight to the channel with `channel.send`, so it reads as its own message.

## The private case can't do this

A private report (the default, no `show-in-channel`) still uses `followUp`. Only a follow-up can carry the ephemeral flag — a plain channel send would put the game list in front of everyone while the summary stayed private, which is the exact opposite of what the option is for. Same fallback if the channel isn't sendable.

So the behaviour is:

| `show-in-channel` | Summary | Games |
| --- | --- | --- |
| unset / false | private reply | private follow-up |
| true | public reply | standalone channel message |

## Validation

`pnpm build`, `pnpm lint` and the full suite pass — 737 tests, 52 suites. Two new tests: the games go out as a standalone send when public, and the follow-up fallback holds when the channel isn't sendable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)