### PR TITLE
fix(discord): Clear stale global slash commands that necord never prunes

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -15,5 +15,6 @@
 - [Queue status flips collide with history](queue-status-unique-key-collides-with-history.md) — the unique key is on (guild, member, status), so an old succeeded row blocks the new one
 - [execute() needs 'run' for affectedRows](mikro-orm-execute-needs-run-mode.md) — the default returns rows, so every conditional-update election silently reads as lost
 - [A claimed row can strand](claimed-row-before-side-effect-can-strand.md) — anything fallible between the claim and the side effect locks the member behind a ballot nobody saw
+- [necord never prunes global commands](necord-never-prunes-global-commands.md) — guild-scoping means that scope is never written, so stale globals show as duplicate slash commands forever
 
 Note: this memory lives in the repo at `.claude/memory/` (wired via `autoMemoryDirectory` in `.claude/settings.json`) so it's shared via git across machines and collaborators. See README "Claude Code memory".

--- a/.claude/memory/necord-never-prunes-global-commands.md
+++ b/.claude/memory/necord-never-prunes-global-commands.md
@@ -1,0 +1,29 @@
+---
+name: necord-never-prunes-global-commands
+description: "necord skips the global command scope entirely when every command is guild-scoped, so stale global registrations survive every redeploy"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 32bc8f0f-2d66-4a8c-b99c-c9b4012b8549
+  modified: 2026-08-03T20:23:47.759Z
+---
+
+necord's `registerGlobalCommands()` returns early when there are no global commands to write,
+*before* it calls `application.commands.set()`. Because `development: [guildId]` in
+`app.module.ts` stamps every command with a guild, this app never has a global command — so
+necord never writes that scope and never prunes it. Anything registered globally by an earlier
+deploy stays on Discord forever and shows up as a **duplicate slash command** in the picker,
+since Discord merges the global and guild sets.
+
+**Why:** this fails silently and looks like a code bug. The command is declared once in source,
+the guild bulk-overwrite works correctly, and no amount of redeploying changes anything, because
+the stale copy lives in a scope the bot no longer writes to. Only some commands duplicate — the
+global set is a frozen snapshot of whichever commands existed when it was last written.
+
+**How to apply:** `GlobalCommandCleanupService` (`src/discord/`) now clears that scope on
+`clientReady`, guarded on necord's own `development` option being a non-empty array. If that
+option is ever removed, necord starts owning the global scope and the cleanup must not run.
+Note it only prunes the global scope — guild commands registered in *other* guilds are
+deliberately left alone. Also beware `development: [undefined]`: necord throws part way through
+registration and silently leaves the previous command set in place, which is the likely origin
+of the stale globals, so the module factory now refuses to start without the guild id.

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,21 +15,32 @@ import { ScheduleModule } from '@nestjs/schedule';
     DatabaseModule,
     NecordModule.forRootAsync({
       imports: [ConfigModule],
-      useFactory: (configService: ConfigService) => ({
-        token: configService.get('TOKEN'),
-        intents: [
-          GatewayIntentBits.Guilds,
-          GatewayIntentBits.GuildMembers,
-          GatewayIntentBits.GuildMessages,
-          GatewayIntentBits.GuildMessageReactions,
-          GatewayIntentBits.GuildPresences,
-          GatewayIntentBits.GuildVoiceStates,
-        ],
-        partials: [Partials.Message, Partials.Channel, Partials.Reaction],
-        // Scopes every command to the DIG guild. necord bulk-overwrites that guild's command set
-        // on startup, which is what prunes stale commands now `removeCommandsBefore` is gone.
-        development: [configService.get('discord.guildId')],
-      }),
+      useFactory: (configService: ConfigService) => {
+        const guildId = configService.get('discord.guildId');
+
+        // An undefined guild id makes necord throw part way through registration, silently
+        // leaving whatever command set was registered previously in place.
+        if (!guildId) {
+          throw new Error('GUILD_ID_WITH_COMMANDS is not set, so commands cannot be scoped to the guild. Refusing to start.');
+        }
+
+        return {
+          token: configService.get('TOKEN'),
+          intents: [
+            GatewayIntentBits.Guilds,
+            GatewayIntentBits.GuildMembers,
+            GatewayIntentBits.GuildMessages,
+            GatewayIntentBits.GuildMessageReactions,
+            GatewayIntentBits.GuildPresences,
+            GatewayIntentBits.GuildVoiceStates,
+          ],
+          partials: [Partials.Message, Partials.Channel, Partials.Reaction],
+          // Scopes every command to the DIG guild. necord bulk-overwrites that guild's command set
+          // on startup, which is what prunes stale commands now `removeCommandsBefore` is gone.
+          // It never touches the global scope though — GlobalCommandCleanupService does that.
+          development: [guildId],
+        };
+      },
       inject: [ConfigService],
     }),
     GeneralModule,

--- a/src/discord/discord.module.ts
+++ b/src/discord/discord.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 
 import { ConfigModule } from '../config/config.module';
 import { DiscordService } from './discord.service';
+import { GlobalCommandCleanupService } from './global.command.cleanup.service';
 
 @Module({
   imports: [ConfigModule],
-  providers: [DiscordService],
+  providers: [DiscordService, GlobalCommandCleanupService],
   exports: [DiscordService],
 })
 export class DiscordModule {}

--- a/src/discord/global.command.cleanup.service.spec.ts
+++ b/src/discord/global.command.cleanup.service.spec.ts
@@ -1,0 +1,106 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Client, Collection } from 'discord.js';
+import { Logger } from '@nestjs/common';
+import { NECORD_MODULE_OPTIONS, NecordModuleOptions } from 'necord';
+import { GlobalCommandCleanupService } from './global.command.cleanup.service';
+
+describe('GlobalCommandCleanupService', () => {
+  let service: GlobalCommandCleanupService;
+  let necordOptions: NecordModuleOptions;
+  let fetch: jest.Mock;
+  let set: jest.Mock;
+  let warn: jest.SpyInstance;
+  let error: jest.SpyInstance;
+
+  const globalCommands = (...names: string[]) => {
+    const collection = new Collection<string, { name: string }>();
+    names.forEach((name, index) => collection.set(String(index), { name }));
+    return collection;
+  };
+
+  beforeEach(async () => {
+    fetch = jest.fn().mockResolvedValue(globalCommands());
+    set = jest.fn().mockResolvedValue(undefined);
+    necordOptions = { token: 'token', intents: [], development: ['1234'] };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GlobalCommandCleanupService,
+        {
+          provide: Client,
+          useValue: { application: { commands: { fetch, set } } },
+        },
+        {
+          provide: NECORD_MODULE_OPTIONS,
+          useValue: necordOptions,
+        },
+      ],
+    }).compile();
+
+    service = module.get<GlobalCommandCleanupService>(GlobalCommandCleanupService);
+
+    warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+    error = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('is defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('clears the global scope when stale commands are present', async () => {
+    fetch.mockResolvedValue(globalCommands('albion-register', 'ping'));
+
+    await service.onClientReady();
+
+    expect(set).toHaveBeenCalledWith([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('albion-register, ping'));
+  });
+
+  it('does nothing when the global scope is already empty', async () => {
+    await service.onClientReady();
+
+    expect(set).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when necord is not scoping commands to a guild', async () => {
+    necordOptions.development = false;
+
+    await service.onClientReady();
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when necord is given an empty guild list', async () => {
+    necordOptions.development = [];
+
+    await service.onClientReady();
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it('logs rather than throwing when the fetch fails', async () => {
+    fetch.mockRejectedValue(new Error('Missing Access'));
+
+    await expect(service.onClientReady()).resolves.toBeUndefined();
+
+    expect(set).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('Missing Access'), expect.any(Error));
+  });
+
+  it('logs rather than throwing when the overwrite fails', async () => {
+    fetch.mockResolvedValue(globalCommands('albion-register'));
+    set.mockRejectedValue(new Error('Rate limited'));
+
+    await expect(service.onClientReady()).resolves.toBeUndefined();
+
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('Rate limited'), expect.any(Error));
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/discord/global.command.cleanup.service.ts
+++ b/src/discord/global.command.cleanup.service.ts
@@ -1,0 +1,46 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Client } from 'discord.js';
+import { NECORD_MODULE_OPTIONS, NecordModuleOptions, Once } from 'necord';
+
+@Injectable()
+export class GlobalCommandCleanupService {
+  private readonly logger = new Logger(GlobalCommandCleanupService.name);
+
+  constructor(
+    private readonly discordClient: Client,
+    @Inject(NECORD_MODULE_OPTIONS) private readonly necordOptions: NecordModuleOptions,
+  ) {}
+
+  // necord skips the global command scope entirely when every command is guild-scoped, so a
+  // global registration left by an older deploy survives forever and shows up as a duplicate.
+  @Once('clientReady')
+  async onClientReady(): Promise<void> {
+    if (!this.isGuildScoped()) {
+      return;
+    }
+
+    try {
+      const globalCommands = await this.discordClient.application.commands.fetch({});
+
+      if (globalCommands.size === 0) {
+        return;
+      }
+
+      const names = globalCommands.map((command) => command.name).join(', ');
+      await this.discordClient.application.commands.set([]);
+
+      this.logger.warn(`Removed ${globalCommands.size} stale global command(s): ${names}. Discord can take up to an hour to stop offering them.`);
+    }
+    catch (err) {
+      this.logger.error(`Failed to clear stale global commands, so duplicate commands may still be visible! Err: ${err.message}`, err);
+    }
+  }
+
+  // Only safe while necord is stamping every command with a guild; without it necord owns the
+  // global scope and wiping it would delete commands it had just registered.
+  private isGuildScoped(): boolean {
+    const development = this.necordOptions.development;
+
+    return Array.isArray(development) && development.length > 0;
+  }
+}


### PR DESCRIPTION
## No manual steps

Nothing to set, run or migrate. `GUILD_ID_WITH_COMMANDS` is already set wherever this deploys — the new fail-fast only makes an existing silent failure loud.

## The problem

Two `/albion-register` entries show in the picker on the DIG server, both belonging to this bot. The command is declared exactly once in source. They are the same command registered at two different scopes — guild and global — and Discord merges both scopes into the picker.

## Why no redeploy could fix it

necord's `registerGlobalCommands()` returns early before it writes anything:

```js
const rawCommands = commands.flatMap(command => command.toJSON());
if (rawCommands.length === 0) {
    return;                    // never reaches application.commands.set()
}
```

`development: [guildId]` stamps every command with a guild, so the global list is always empty, so that scope is never written and never pruned. Whatever was last registered globally — most likely by a deploy from the `@discord-nestjs` era where `forGuild` resolved to `undefined` — has been sitting there ever since. The guild bulk-overwrite prunes the guild scope only, which is why tinkering with the command definitions changed nothing.

That also explains why only *some* commands duplicate: the global set is a frozen snapshot of whichever commands existed when it was last written.

## The fix

`GlobalCommandCleanupService` clears the global scope on `clientReady`, guarded on necord's own `development` option being a non-empty array — if that option is ever removed, necord starts owning the global scope and wiping it would delete what it had just registered. Failures log at error level saying duplicates may still be visible, so a green deploy can't quietly hide an unfixed problem.

Also refuses to start when `GUILD_ID_WITH_COMMANDS` is unset. `development: [undefined]` currently makes necord throw part way through registration and silently leave the previous command set in place — the likely origin of this whole mess.

Scope note: this prunes the global scope only. Guild commands registered in guilds other than DIG are deliberately left alone; the bot is DIG-only now and that was a conscious call rather than an oversight.

## Validation

- `pnpm build`, `pnpm lint` clean
- `pnpm test` — 737 passed, 52 suites
- New spec covers: clears on a non-empty global scope, no-ops on an empty one, no-ops when `development` is `false` or `[]`, and logs rather than throwing when either API call fails
- The startup log is the confirmation this was the cause: watch for `Removed N stale global command(s): ...` naming them on first boot. Discord can take up to an hour to stop offering a deleted global command, so the picker will lag that line.

This plan went through an adversarial Codex review before being built; it caught that an earlier version of the guard could never evaluate false, which is why the guard reads necord's options rather than its command list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)